### PR TITLE
Avoid unecessary explicit path for binary already in PATH

### DIFF
--- a/docs/nodes/bridge-validator-node.md
+++ b/docs/nodes/bridge-validator-node.md
@@ -91,8 +91,7 @@ make install
 
 To check if the binary was successfully compiled you can run the binary using the `--help` flag:
 ```shell
-cd $HOME/go/bin
-./celestia-appd --help
+celestia-appd --help
 ```
 You should see a similar output:
 ```

--- a/docs/nodes/light-node.md
+++ b/docs/nodes/light-node.md
@@ -160,8 +160,7 @@ make install
 ```
 2. To check if the binary was succesfully compiled you can run the binary using the `--help` flag:
 ```shell
-cd $HOME/go/bin
-./celestia-appd --help
+celestia-appd --help
 ```
 
 3. Create the wallet with any wallet name you want e.g.


### PR DESCRIPTION
The path is already exported to `PATH` in a previous step