### PR TITLE
doc: fix typo

### DIFF
--- a/docs/nodes/bridge-validator-node.md
+++ b/docs/nodes/bridge-validator-node.md
@@ -22,7 +22,7 @@ From an implementation perspective, Bridge Nodes run two separate processes:
 The following hardware minimum requirements are recommended for running the bridge node:
 * Memory: 8 GB RAM
 * CPU: Quad-Core
-* Disk: 250 GB SDD Storage
+* Disk: 250 GB SSD Storage
 * Bandwidth: 1 Gbps for Download/100 Mbps for Upload
 
 ## Setting Up Your Bridge Node


### PR DESCRIPTION
I just noticed during the call recap that the SDD -> SSD typo is still there 😃
