### PR TITLE
Add drawio plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,7 +35,9 @@ const config = {
       }),
     ],
   ],
-
+  plugins: [
+    ['drawio', {}],
+  ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "@docusaurus/preset-classic": "2.0.0-beta.17",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
+    "docusaurus-plugin-drawio": "^0.1.7",
     "prism-react-renderer": "^1.2.1",
+    "raw-loader": "^4.0.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },


### PR DESCRIPTION
Tested locally with an example drawio drawing and it works.

Next steps after merging this is moving the existing diagrams that @0xMako has made into their draw.io equivalent and adding them into the docs. For that, would need @0xMako to share the diagrams with me.