### PR TITLE
"Run A Node" Rearchitecture

### DIFF
--- a/docs/developers/node-api.md
+++ b/docs/developers/node-api.md
@@ -4,7 +4,7 @@ This is the Celestia Node API Docs reference page for being able to make API
 requests to your Celestia Node.
 
 In order to query the API, you will need to setup your node. Resources on
-how to do this can be found in the following [guide](../nodes/bridge-node.md#deploy-the-celestia-node).
+how to do this can be found in the following [guide](../nodes/validator-node.md#deploy-the-celestia-node).
 
 ## Endpoints
 

--- a/docs/developers/node-api.md
+++ b/docs/developers/node-api.md
@@ -4,7 +4,7 @@ This is the Celestia Node API Docs reference page for being able to make API
 requests to your Celestia Node.
 
 In order to query the API, you will need to setup your node. Resources on
-how to do this can be found in the following [guide](https://docs.celestia.org/nodes/bridge-validator-node#deploy-the-celestia-node).
+how to do this can be found in the following [guide](../nodes/bridge-node.md#deploy-the-celestia-node).
 
 ## Endpoints
 

--- a/docs/nodes/bridge-node.md
+++ b/docs/nodes/bridge-node.md
@@ -154,36 +154,11 @@ Use "celestia-appd [command] --help" for more information about a command.
 
 ### Setup the P2P Networks
 
-Now we will setup the P2P Networks by cloning the networks repository:
+For this section of the guide, select the network you want to connect to:
 
-```sh
-cd $HOME
-rm -rf networks
-git clone https://github.com/celestiaorg/networks.git
-```
+- [Devnet-2](../nodes/devnet-2.md#setup-p2p-network)
 
-To initialize the network pick a “node-name” that describes your
-node. The --chain-id parameter we are using here is `devnet-2`. Keep in
-mind that this might change if a new testnet is deployed.
-
-```sh
-celestia-appd init "node-name" --chain-id devnet-2
-```
-
-Copy the `genesis.json` file. For devnet-2 we are using:
-
-```sh
-cp $HOME/networks/devnet-2/genesis.json $HOME/.celestia-app/config
-```
-
-Set seeds and peers:
-
-```sh
-SEEDS="74c0c793db07edd9b9ec17b076cea1a02dca511f@46.101.28.34:26656"
-PEERS="34d4bfec8998a8fac6393a14c5ae151cf6a5762f@194.163.191.41:26656"
-sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/; s/^persistent_peers \
-*=.*/persistent_peers = \"$PEERS\"/" $HOME/.celestia-app/config/config.toml
-```
+After that, you can proceed with the rest of the tutorial.
 
 ### Configure Pruning
 
@@ -221,15 +196,9 @@ this method you can synchronize your Celestia node very quickly by downloading
 a recent snapshot of the blockchain. If you would like to sync from the Genesis,
 then you can skip this part.
 
- ```sh
-cd $HOME
-rm -rf ~/.celestia-app/data; \
-mkdir -p ~/.celestia-app/data; 
-SNAP_NAME=$(curl -s https://snaps.qubelabs.io/celestia/ | \
-egrep -o ">devnet-2.*tar" | tr -d ">"); wget -O - \
-https://snaps.qubelabs.io/celestia/${SNAP_NAME} | tar xf - \
--C ~/.celestia-app/data/
-```
+If you want to use snapshot, determine the network you would like to sync to from the list below:
+
+- [Devnet-2](../nodes/devnet-2.md#quick-sync-with-snapshot)
 
 ### Start the Celestia-App with SystemD
 
@@ -351,33 +320,8 @@ Enter keyring passphrase:
 celesvaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd
 ```
 
-To delegate tokens to the the `celesvaloper` validator, as an example you can run:
-
-```sh
-celestia-appd tx staking delegate \
-celesvaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd 1000000celes \
---from=$VALIDATOR_WALLET --chain-id=devnet-2
-```
-
-If successful, you should see a similar output as:
-
-```sh
-code: 0
-codespace: ""
-data: ""
-gas_used: "0"
-gas_wanted: "0"
-height: "0"
-info: ""
-logs: []
-raw_log: '[]'
-timestamp: ""
-tx: null
-txhash: <tx-hash>
-```
-
-You can check if the TX hash went through using the block explorer by
-inputting the `txhash` ID that was returned.
+Next, select the network you want to use to delegate to a validator:
+- [Devnet-2](../nodes/devnet-2.md#delegate-to-a-validator)
 
 ## Deploy the Celestia Node
 
@@ -448,33 +392,9 @@ celestia bridge init --core.remote tcp://127.0.0.1:26657 --headers.trusted-hash 
 
 ### Configure the Bridge Node
 
-In order for your Celestia Bridge Node to communicate with other Bridge Nodes,
-then you need to add them as `mutual peers` in the `config.toml` file and allow
-the peer exchange. Please navigate to
-`networks/devnet-2/celestia-node/mutual_peers.txt` to find the list of
-mutual peers
+To configure your Bridge Node to connect to your network of choice, select one of the networks you would like to connect to from this list and follow the instructions there before proceeding with the rest of this guide:
 
-For more information on `config.toml`, please navigate to [this link](https://github.com/celestiaorg/networks/blob/master/config-toml.md)
-
-```sh
-nano ~/.celestia-bridge/config.toml
-```
-
-```sh
-...
-[P2P]
-  ...
-  #add multiaddresses of other celestia bridge nodes
-  
-  MutualPeers = [
-    "/ip4/46.101.22.123/tcp/2121/p2p/12D3KooWD5wCBJXKQuDjhXFjTFMrZoysGVLtVht5hMoVbSLCbV22",
-    "/ip4/x.x.x.x/tcp/yyy/p2p/abc"] 
-    # the /ip4/x.x.x.x is only for example.
-    # Don't add it! 
-  PeerExchange = true #change this line to true. By default it's false
-  ...
-...
-```
+- [Devnet-2](../nodes/devnet-2.md#configure-the-bridge-node)
 
 ### Start the Bridge Node with SystemD
 
@@ -530,56 +450,5 @@ Example:
 You should be seeing logs coming through of the bridge node syncing.
 
 You have successfully set up a bridge node that is syncing with the network.
-Read on if you are interested in setting up a Validator node.
 
-## Run a Validator Bridge Node
-
-Optionally, if you want to join the active validator list, you can create your
-own validator on-chain following the instructions below. Keep in mind that
-these steps are necessary ONLY if you want to participate in the consensus.
-
-Pick a MONIKER name of your choice! This is the validator name that will show
-up on public dashboards and explorers. `VALIDATOR_WALLET` must be the same you
-defined previously. Parameter `--min-self-delegation=1000000` defines the
-amount of tokens that are self delegated from your validator wallet.
-
-```sh
-MONIKER="your_moniker"
-VALIDATOR_WALLET="validator"
-
-celestia-appd tx staking create-validator \
- --amount=1000000celes \
- --pubkey=$(celestia-appd tendermint show-validator) \
- --moniker=$MONIKER \
- --chain-id=devnet-2 \
- --commission-rate=0.1 \
- --commission-max-rate=0.2 \
- --commission-max-change-rate=0.01 \
- --min-self-delegation=1000000 \
- --from=$VALIDATOR_WALLET
-```
-
-You will be prompted to confirm the transaction:
-
-```sh
-confirm transaction before signing and broadcasting [y/N]: y
-```
-
-Inputting `y` should provide an output similar to:
-
-```sh
-code: 0
-codespace: ""
-data: ""
-gas_used: "0"
-gas_wanted: "0"
-height: "0"
-info: ""
-logs: []
-raw_log: '[]'
-timestamp: ""
-tx: null
-txhash: <tx-hash>
-```
-
-You should now be able to see your validator from a block explorer like [here](https://celestia.observer/validators)
+If you want to next run a validator node, read the following tutorial [here](link).

--- a/docs/nodes/bridge-node.md
+++ b/docs/nodes/bridge-node.md
@@ -461,4 +461,4 @@ You should be seeing logs coming through of the bridge node syncing.
 
 You have successfully set up a bridge node that is syncing with the network.
 
-If you want to next run a validator node, read the following tutorial [here](link).
+If you want to next run a validator node, read the following tutorial [here](../nodes/validator-node.md).

--- a/docs/nodes/bridge-node.md
+++ b/docs/nodes/bridge-node.md
@@ -1,13 +1,9 @@
-# Setting Up A Celestia Bridge & Validator Node
+# Setting Up A Celestia Bridge Node
 
 This tutorial will go over the steps to setting up your Celestia Bridge node.
 
 Bridge nodes connect the data availability layer and the consensus layer while
 also having the option of becoming a validator.
-
-If you are reading this tutorial in order to setup a validator, follow through
-the sections until you reach the validator setup guide. If you just want to
-run a bridge node, you don’t need to complete the validator step at the end.
 
 ## Overview of Bridge Nodes
 
@@ -460,5 +456,3 @@ Example:
 You should be seeing logs coming through of the bridge node syncing.
 
 You have successfully set up a bridge node that is syncing with the network.
-
-If you want to next run a validator node, read the following tutorial [here](../nodes/validator-node.md).

--- a/docs/nodes/bridge-node.md
+++ b/docs/nodes/bridge-node.md
@@ -156,7 +156,7 @@ Use "celestia-appd [command] --help" for more information about a command.
 
 For this section of the guide, select the network you want to connect to:
 
-- [Devnet-2](../nodes/devnet-2.md#setup-p2p-network)
+* [Devnet-2](../nodes/devnet-2.md#setup-p2p-network)
 
 After that, you can proceed with the rest of the tutorial.
 
@@ -196,9 +196,10 @@ this method you can synchronize your Celestia node very quickly by downloading
 a recent snapshot of the blockchain. If you would like to sync from the Genesis,
 then you can skip this part.
 
-If you want to use snapshot, determine the network you would like to sync to from the list below:
+If you want to use snapshot, determine the network you would like to sync
+to from the list below:
 
-- [Devnet-2](../nodes/devnet-2.md#quick-sync-with-snapshot)
+* [Devnet-2](../nodes/devnet-2.md#quick-sync-with-snapshot)
 
 ### Start the Celestia-App with SystemD
 
@@ -321,7 +322,8 @@ celesvaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd
 ```
 
 Next, select the network you want to use to delegate to a validator:
-- [Devnet-2](../nodes/devnet-2.md#delegate-to-a-validator)
+
+* [Devnet-2](../nodes/devnet-2.md#delegate-to-a-validator)
 
 ## Deploy the Celestia Node
 
@@ -392,9 +394,11 @@ celestia bridge init --core.remote tcp://127.0.0.1:26657 --headers.trusted-hash 
 
 ### Configure the Bridge Node
 
-To configure your Bridge Node to connect to your network of choice, select one of the networks you would like to connect to from this list and follow the instructions there before proceeding with the rest of this guide:
+To configure your Bridge Node to connect to your network of choice,
+select one of the networks you would like to connect to from this list and
+follow the instructions there before proceeding with the rest of this guide:
 
-- [Devnet-2](../nodes/devnet-2.md#configure-the-bridge-node)
+* [Devnet-2](../nodes/devnet-2.md#configure-the-bridge-node)
 
 ### Start the Bridge Node with SystemD
 

--- a/docs/nodes/bridge-node.md
+++ b/docs/nodes/bridge-node.md
@@ -108,13 +108,18 @@ Output should be the version installed:
 go version go1.17.2 linux/amd64
 ```
 
-## Deploying The Celestia App
+## Optional: Deploying The Celestia App
 
 This section describes part 1 of Celestia Bridge Node setup: running a Celestia
 App daemon with an internal Celestia Core node.
 
 > Note: Make sure you have at least 100+ Gb of free space to safely install+run
-  the Bridge Node.  
+  the Bridge Node.
+
+Completing this step allows you to connect your Bridge Node to a Celestia App
+instance running. Otherwise, you can connect directly to an existing Celestia
+App endpoint remotely and skip over to the
+[Deploy the Celestia Node](#deploy-the-celestia-node) section.
 
 ### Install Celestia App
 
@@ -269,60 +274,6 @@ curl -s localhost:26657/status | jq .result | jq .sync_info
 
 Make sure that you have `"catching_up": false`, otherwise leave it running
 until it is in sync.
-
-### Wallet
-
-#### Create a Wallet
-
-You can pick whatever wallet name you want. For our example we used
-“validator” as the wallet name:
-
-```sh
-celestia-appd keys add validator
-```
-
-Save the mnemonic output as this is the only way to recover your validator
-wallet in case you lose it!
-
-#### Fund a Wallet
-
-For the public celestia address, you can fund the previously created wallet via
-Discord by sending this message to #faucet channel:
-
-```text
-!faucet celes1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
-
-Wait to see if you get a confirmation that the tokens have been successfully
-sent. To check if tokens have arrived successfully to the destination wallet
-run the command below replacing the public address with your own:
-
-```sh
-celestia-appd q bank balances celes1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
-
-### Delegate Stake to a Validator
-
-If you want to delegate more stake to any validator, including your own you
-will need the `celesvaloper` address of the validator in question. You can
-either check it using the block explorer mentioned above or you can run the
-command below to get the `celesvaloper` of your local validator wallet in
-case you want to delegate more to it:
-
-```sh
-celestia-appd keys show $VALIDATOR_WALLET --bech val -a
-```
-
-After entering the wallet passphrase you should see a similar output:
-
-```sh
-Enter keyring passphrase:
-celesvaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd
-```
-
-Next, select the network you want to use to delegate to a validator:
-
-* [Devnet-2](../nodes/devnet-2.md#delegate-to-a-validator)
 
 ## Deploy the Celestia Node
 

--- a/docs/nodes/bridge-node.md
+++ b/docs/nodes/bridge-node.md
@@ -130,7 +130,10 @@ cd $HOME
 rm -rf celestia-app
 git clone https://github.com/celestiaorg/celestia-app.git
 cd celestia-app/
-git checkout tags/v0.1.0 -b v0.1.0
+APP_VERSION=$(curl -s \
+  https://api.github.com/repos/celestiaorg/celestia-app/releases/latest \
+  | jq -r ".tag_name")
+git checkout tags/$APP_VERSION -b $APP_VERSION
 make install
 ```
 
@@ -339,7 +342,10 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.2.0 -b v0.2.0
+APP_VERSION=$(curl -s \
+  https://api.github.com/repos/celestiaorg/celestia-node/releases/latest \
+  | jq -r ".tag_name")
+git checkout tags/$APP_VERSION -b $APP_VERSION
 make install
 ```
 

--- a/docs/nodes/config-toml.md
+++ b/docs/nodes/config-toml.md
@@ -1,0 +1,42 @@
+# Config.toml breakdown
+
+- [Config.toml breakdown](#configtoml-breakdown)
+  - [Pre-Requisites](#pre-requisites)
+  - [Understanding config.toml](#understanding-configtoml)
+    - [[Core]](#core)
+    - [[P2P]](#p2p)
+      - [Bootstrap](#bootstrap)
+      - [Mutual Peers](#mutual-peers)
+    - [[Services]](#services)
+      - [TrustedHash and TrustedPeer](#trustedhash-and-trustedpeer)
+
+## Pre-Requisites
+Please, make sure that you have installed and initialized celestia node
+
+## Understanding config.toml
+After initialization, for any type of node, you will find a `config.toml` in the following path (default location):
+- `~/.celestia-bridge/config.toml` for bridge node
+- `~/.celestia-light/config.toml` for light node 
+
+Let's break down some of the most used sections.
+### [Core]
+This section is needed for the Celestia Bridge Node. By default, `Remote = false`. Still for devnet, we are going to use the remote core option and this can also be set
+by the command line flag `--core.remote`.
+
+### [P2P]
+#### Bootstrap
+Bootstrappers help new nodes to find peers faster in the network. 
+By default, the `Bootstrapper = false` and the `BootstrapPeers` is empty. If you want your node to be a bootstrapper, then activate `Bootstrapper = true`.
+BootstrapPeers are already provided by default during initialisation. If you want to add your own manually, you need to provide the multiaddresses of the peers. 
+
+#### Mutual Peers
+The purpose of this config is to set up a bidirectional communication. This is usually the case for Celestia Bridge Nodes. In addition, you need to change the field 
+`PeerExchange` from false to true.
+
+### [Services]
+#### TrustedHash and TrustedPeer
+`TrustedHash` is needed to properly initialize a Celestia Bridge Node with an already-running `Remote` Celestia Core node. Celestia Light Node will take a genesis hash as the trusted one, if no hash is manually provided during initialization phase.
+
+`TrustedPeers` is the array of Bridge Nodes' peers that Celestia Light Node trusts. By default, bootstrap peers becomes trusted peers for Celestia Light Nodes if a user is not setting the trusted peer params 
+in config file.
+Any Celestia Bridge Node can be a trusted peer for the Light one. However, the Light node by design can not be a trusted peer for another Light Node.

--- a/docs/nodes/config-toml.md
+++ b/docs/nodes/config-toml.md
@@ -11,32 +11,56 @@
       - [TrustedHash and TrustedPeer](#trustedhash-and-trustedpeer)
 
 ## Pre-Requisites
+
 Please, make sure that you have installed and initialized celestia node
 
 ## Understanding config.toml
-After initialization, for any type of node, you will find a `config.toml` in the following path (default location):
-- `~/.celestia-bridge/config.toml` for bridge node
-- `~/.celestia-light/config.toml` for light node 
+
+After initialization, for any type of node, you will find a
+`config.toml` in the following path (default location):
+
+- `$HOME/.celestia-bridge/config.toml` for bridge node
+- `$HOME/.celestia-light/config.toml` for light node
 
 Let's break down some of the most used sections.
+
 ### [Core]
-This section is needed for the Celestia Bridge Node. By default, `Remote = false`. Still for devnet, we are going to use the remote core option and this can also be set
+
+This section is needed for the Celestia Bridge Node.
+By default, `Remote = false`. Still for devnet, we are going
+to use the remote core option and this can also be set
 by the command line flag `--core.remote`.
 
 ### [P2P]
+
 #### Bootstrap
-Bootstrappers help new nodes to find peers faster in the network. 
-By default, the `Bootstrapper = false` and the `BootstrapPeers` is empty. If you want your node to be a bootstrapper, then activate `Bootstrapper = true`.
-BootstrapPeers are already provided by default during initialisation. If you want to add your own manually, you need to provide the multiaddresses of the peers. 
+
+Bootstrappers help new nodes to find peers faster in the network.
+By default, the `Bootstrapper = false` and the `BootstrapPeers` is empty.
+If you want your node to be a bootstrapper, then activate `Bootstrapper = true`.
+`BootstrapPeers` are already provided by default during initialisation.
+If you want to add your own manually, you need to provide the
+multiaddresses of the peers.
 
 #### Mutual Peers
-The purpose of this config is to set up a bidirectional communication. This is usually the case for Celestia Bridge Nodes. In addition, you need to change the field 
-`PeerExchange` from false to true.
+
+The purpose of this config is to set up a bidirectional communication.
+This is usually the case for Celestia Bridge Nodes. In addition, you
+need to change the field `PeerExchange` from false to true.
 
 ### [Services]
-#### TrustedHash and TrustedPeer
-`TrustedHash` is needed to properly initialize a Celestia Bridge Node with an already-running `Remote` Celestia Core node. Celestia Light Node will take a genesis hash as the trusted one, if no hash is manually provided during initialization phase.
 
-`TrustedPeers` is the array of Bridge Nodes' peers that Celestia Light Node trusts. By default, bootstrap peers becomes trusted peers for Celestia Light Nodes if a user is not setting the trusted peer params 
+#### TrustedHash and TrustedPeer
+
+`TrustedHash` is needed to properly initialize a Celestia Bridge
+Node with an already-running `Remote` Celestia Core node. Celestia
+Light Node will take a genesis hash as the trusted one, if no hash
+is manually provided during initialization phase.
+
+`TrustedPeers` is the array of Bridge Nodes' peers that Celestia
+Light Node trusts. By default, bootstrap peers becomes trusted peers
+for Celestia Light Nodes if a user is not setting the trusted peer params
 in config file.
-Any Celestia Bridge Node can be a trusted peer for the Light one. However, the Light node by design can not be a trusted peer for another Light Node.
+
+Any Celestia Bridge Node can be a trusted peer for the Light one. However,
+the Light node by design can not be a trusted peer for another Light Node.

--- a/docs/nodes/devnet-2.md
+++ b/docs/nodes/devnet-2.md
@@ -58,7 +58,8 @@ You can return back to where you left off in the Bridge Node guide [here](../nod
 
 ## Quick-Sync With Snapshot
 
-Run the following command to quick-sync from a snapshot for `devnet-2`:
+Run the following command to quick-sync from a snapshot for 
+`devnet-2` (Note: this is a 100 GB download):
 
 ```sh
 cd $HOME

--- a/docs/nodes/devnet-2.md
+++ b/docs/nodes/devnet-2.md
@@ -58,7 +58,7 @@ You can return back to where you left off in the Bridge Node guide [here](../nod
 
 ## Quick-Sync With Snapshot
 
-Run the following command to quick-sync from a snapshot for 
+Run the following command to quick-sync from a snapshot for
 `devnet-2` (Note: this is a 100 GB download):
 
 ```sh

--- a/docs/nodes/devnet-2.md
+++ b/docs/nodes/devnet-2.md
@@ -54,7 +54,7 @@ sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/; s/^persistent_peers \
 *=.*/persistent_peers = \"$PEERS\"/" $HOME/.celestia-app/config/config.toml
 ```
 
-You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#configure-pruning)
+You can return back to where you left off in the Bridge Node guide [here](../nodes/validator-node.md#configure-pruning)
 
 ## Quick-Sync With Snapshot
 
@@ -70,7 +70,7 @@ https://snaps.qubelabs.io/celestia/${SNAP_NAME} | tar xf - \
 -C ~/.celestia-app/data/
 ```
 
-You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#start-the-celestia-app-with-systemd)
+You can return back to where you left off in the Bridge Node guide [here](../nodes/validator-node.md#start-the-celestia-app-with-systemd)
 
 ## Delegate to a Validator
 
@@ -102,7 +102,7 @@ txhash: <tx-hash>
 You can check if the TX hash went through using the block explorer by
 inputting the `txhash` ID that was returned.
 
-You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#deploy-the-celestia-node)
+You can return back to where you left off in the Bridge Node guide [here](../nodes/validator-node.md#deploy-the-celestia-node)
 
 ## Configure The Bridge Node
 
@@ -134,7 +134,7 @@ nano ~/.celestia-bridge/config.toml
 ...
 ```
 
-You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#start-the-bridge-node-with-systemd)
+You can return back to where you left off in the Bridge Node guide [here](../nodes/validator-node.md#start-the-bridge-node-with-systemd)
 
 ## Connect Validator
 

--- a/docs/nodes/devnet-2.md
+++ b/docs/nodes/devnet-2.md
@@ -1,20 +1,25 @@
 # DevNet-2
 
-This guide contains the relevant sections for how to connect to Devnet, depending on the type of node you are running.
+This guide contains the relevant sections for how to connect to Devnet,
+depending on the type of node you are running. Devnet-2 is a milestone
+in Celestia, allowing everyone to test out core functionalities on the
+network. You can read more on the announcement [here](https://blog.celestia.org/celestia-launches-devnet/)
 
-Devnet-2 is a milestone in Celestia, allowing everyone to test out core functionalities on the network. You can read more on the announcement [here](https://blog.celestia.org/celestia-launches-devnet/)
+Your best approach to participating is to first determine which node
+you would like to run. Each node guides will link to the relevant network
+in order to show you how to connect to them.
 
-Your best approach to participating is to first determine which node you would like to run. Each node guides will link to the relevant network in order to show you how to connect to them.
+You have a list of options on the type of nodes you can run in order to
+participate in Devnet-2:
 
-You have a list of options on the type of nodes you can run in order to participate in Devnet-2:
+* [Bridge Node](../nodes/bridge-node)
+* [Validator Node](../nodes/validator-node)
+* [Light Node](../nodes/light-node)
 
-- [Bridge Node](../nodes/bridge-node)
-- [Validator Node](../nodes/validator-node)
-- [Light Node](../nodes/light-node)
-
-Select the type of node you would like to run and follow the instructions on each respective page.
-
-Whenever you are asked to select the type of network you want to connect to in those guides, select `Devnet-2` in order to refer to the correct instructions on this page on how to connect to Devnet-2.
+Select the type of node you would like to run and follow the instructions
+on each respective page. Whenever you are asked to select the type of network
+you want to connect to in those guides, select `Devnet-2` in order to refer
+to the correct instructions on this page on how to connect to Devnet-2.
 
 ## Setup P2P Network
 
@@ -65,7 +70,6 @@ https://snaps.qubelabs.io/celestia/${SNAP_NAME} | tar xf - \
 -C ~/.celestia-app/data/
 ```
 
-
 You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#start-the-celestia-app-with-systemd)
 
 ## Delegate to a Validator
@@ -97,7 +101,6 @@ txhash: <tx-hash>
 
 You can check if the TX hash went through using the block explorer by
 inputting the `txhash` ID that was returned.
-
 
 You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#deploy-the-celestia-node)
 
@@ -135,7 +138,8 @@ You can return back to where you left off in the Bridge Node guide [here](../nod
 
 ## Connect Validator
 
-Continuing the Validator tutorial, here are the steps to connect your validator to Devnet:
+Continuing the Validator tutorial, here are the steps to connect your
+validator to Devnet:
 
 ```sh
 MONIKER="your_moniker"

--- a/docs/nodes/devnet-2.md
+++ b/docs/nodes/devnet-2.md
@@ -51,7 +51,7 @@ Set seeds and peers:
 SEEDS="74c0c793db07edd9b9ec17b076cea1a02dca511f@46.101.28.34:26656"
 PEERS="34d4bfec8998a8fac6393a14c5ae151cf6a5762f@194.163.191.41:26656"
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/; s/^persistent_peers \
-*=.*/persistent_peers = \"$PEERS\"/" $HOME/.celestia-app/config/config.toml
+    *=.*/persistent_peers = \"$PEERS\"/" $HOME/.celestia-app/config/config.toml
 ```
 
 You can return back to where you left off in the Bridge Node guide [here](../nodes/validator-node.md#configure-pruning)
@@ -62,12 +62,12 @@ Run the following command to quick-sync from a snapshot for `devnet-2`:
 
 ```sh
 cd $HOME
-rm -rf ~/.celestia-app/data; \
-mkdir -p ~/.celestia-app/data;
+rm -rf ~/.celestia-app/data
+mkdir -p ~/.celestia-app/data
 SNAP_NAME=$(curl -s https://snaps.qubelabs.io/celestia/ | \
-egrep -o ">devnet-2.*tar" | tr -d ">"); wget -O - \
-https://snaps.qubelabs.io/celestia/${SNAP_NAME} | tar xf - \
--C ~/.celestia-app/data/
+    egrep -o ">devnet-2.*tar" | tr -d ">")
+wget -O - https://snaps.qubelabs.io/celestia/${SNAP_NAME} | tar xf - \
+    -C ~/.celestia-app/data/
 ```
 
 You can return back to where you left off in the Bridge Node guide [here](../nodes/validator-node.md#start-the-celestia-app-with-systemd)
@@ -78,13 +78,13 @@ To delegate tokens to the the `celesvaloper` validator, as an example you can ru
 
 ```sh
 celestia-appd tx staking delegate \
-celesvaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd 1000000celes \
---from=$VALIDATOR_WALLET --chain-id=devnet-2
+    celesvaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd 1000000celes \
+    --from=$VALIDATOR_WALLET --chain-id=devnet-2
 ```
 
 If successful, you should see a similar output as:
 
-```sh
+```console
 code: 0
 codespace: ""
 data: ""
@@ -118,7 +118,7 @@ For more information on `config.toml`, please navigate to [this link](../nodes/c
 nano ~/.celestia-bridge/config.toml
 ```
 
-```sh
+```toml
 ...
 [P2P]
   ...
@@ -146,26 +146,26 @@ MONIKER="your_moniker"
 VALIDATOR_WALLET="validator"
 
 celestia-appd tx staking create-validator \
---amount=1000000celes \
---pubkey=$(celestia-appd tendermint show-validator) \
---moniker=$MONIKER \
---chain-id=devnet-2 \
---commission-rate=0.1 \
---commission-max-rate=0.2 \
---commission-max-change-rate=0.01 \
---min-self-delegation=1000000 \
---from=$VALIDATOR_WALLET
+    --amount=1000000celes \
+    --pubkey=$(celestia-appd tendermint show-validator) \
+    --moniker=$MONIKER \
+    --chain-id=devnet-2 \
+    --commission-rate=0.1 \
+    --commission-max-rate=0.2 \
+    --commission-max-change-rate=0.01 \
+    --min-self-delegation=1000000 \
+    --from=$VALIDATOR_WALLET
 ```
 
 You will be prompted to confirm the transaction:
 
-```sh
+```console
 confirm transaction before signing and broadcasting [y/N]: y
 ```
 
 Inputting `y` should provide an output similar to:
 
-```sh
+```console
 code: 0
 codespace: ""
 data: ""

--- a/docs/nodes/devnet-2.md
+++ b/docs/nodes/devnet-2.md
@@ -12,9 +12,9 @@ in order to show you how to connect to them.
 You have a list of options on the type of nodes you can run in order to
 participate in Devnet-2:
 
-* [Bridge Node](../nodes/bridge-node)
-* [Validator Node](../nodes/validator-node)
-* [Light Node](../nodes/light-node)
+* [Bridge Node](../nodes/bridge-node.md)
+* [Validator Node](../nodes/validator-node.md)
+* [Light Node](../nodes/light-node.md)
 
 Select the type of node you would like to run and follow the instructions
 on each respective page. Whenever you are asked to select the type of network

--- a/docs/nodes/devnet-2.md
+++ b/docs/nodes/devnet-2.md
@@ -1,0 +1,179 @@
+# DevNet-2
+
+This guide contains the relevant sections for how to connect to Devnet, depending on the type of node you are running.
+
+Devnet-2 is a milestone in Celestia, allowing everyone to test out core functionalities on the network. You can read more on the announcement [here](https://blog.celestia.org/celestia-launches-devnet/)
+
+Your best approach to participating is to first determine which node you would like to run. Each node guides will link to the relevant network in order to show you how to connect to them.
+
+You have a list of options on the type of nodes you can run in order to participate in Devnet-2:
+
+- [Bridge Node](../nodes/bridge-node)
+- [Validator Node](../nodes/validator-node)
+- [Light Node](../nodes/light-node)
+
+Select the type of node you would like to run and follow the instructions on each respective page.
+
+Whenever you are asked to select the type of network you want to connect to in those guides, select `Devnet-2` in order to refer to the correct instructions on this page on how to connect to Devnet-2.
+
+## Setup P2P Network
+
+Now we will setup the P2P Networks by cloning the networks repository:
+
+```sh
+cd $HOME
+rm -rf networks
+git clone https://github.com/celestiaorg/networks.git
+```
+
+To initialize the network pick a "node-name" that describes your
+node. The --chain-id parameter we are using here is `devnet-2`. Keep in
+mind that this might change if a new testnet is deployed.
+
+```sh
+celestia-appd init "node-name" --chain-id devnet-2
+```
+
+Copy the `genesis.json` file. For devnet-2 we are using:
+
+```sh
+cp $HOME/networks/devnet-2/genesis.json $HOME/.celestia-app/config
+```
+
+Set seeds and peers:
+
+```sh
+SEEDS="74c0c793db07edd9b9ec17b076cea1a02dca511f@46.101.28.34:26656"
+PEERS="34d4bfec8998a8fac6393a14c5ae151cf6a5762f@194.163.191.41:26656"
+sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/; s/^persistent_peers \
+*=.*/persistent_peers = \"$PEERS\"/" $HOME/.celestia-app/config/config.toml
+```
+
+You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#configure-pruning)
+
+## Quick-Sync With Snapshot
+
+Run the following command to quick-sync from a snapshot for `devnet-2`:
+
+```sh
+cd $HOME
+rm -rf ~/.celestia-app/data; \
+mkdir -p ~/.celestia-app/data;
+SNAP_NAME=$(curl -s https://snaps.qubelabs.io/celestia/ | \
+egrep -o ">devnet-2.*tar" | tr -d ">"); wget -O - \
+https://snaps.qubelabs.io/celestia/${SNAP_NAME} | tar xf - \
+-C ~/.celestia-app/data/
+```
+
+
+You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#start-the-celestia-app-with-systemd)
+
+## Delegate to a Validator
+
+To delegate tokens to the the `celesvaloper` validator, as an example you can run:
+
+```sh
+celestia-appd tx staking delegate \
+celesvaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd 1000000celes \
+--from=$VALIDATOR_WALLET --chain-id=devnet-2
+```
+
+If successful, you should see a similar output as:
+
+```sh
+code: 0
+codespace: ""
+data: ""
+gas_used: "0"
+gas_wanted: "0"
+height: "0"
+info: ""
+logs: []
+raw_log: '[]'
+timestamp: ""
+tx: null
+txhash: <tx-hash>
+```
+
+You can check if the TX hash went through using the block explorer by
+inputting the `txhash` ID that was returned.
+
+
+You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#deploy-the-celestia-node)
+
+## Configure The Bridge Node
+
+In order for your Celestia Bridge Node to communicate with other Bridge Nodes,
+then you need to add them as `mutual peers` in the `config.toml` file and allow
+the peer exchange. Please navigate to
+`networks/devnet-2/celestia-node/mutual_peers.txt` to find the list of
+mutual peers
+
+For more information on `config.toml`, please navigate to [this link](../nodes/config-toml.md)
+
+```sh
+nano ~/.celestia-bridge/config.toml
+```
+
+```sh
+...
+[P2P]
+  ...
+  #add multiaddresses of other celestia bridge nodes
+  
+  MutualPeers = [
+    "/ip4/46.101.22.123/tcp/2121/p2p/12D3KooWD5wCBJXKQuDjhXFjTFMrZoysGVLtVht5hMoVbSLCbV22",
+    "/ip4/x.x.x.x/tcp/yyy/p2p/abc"] 
+    # the /ip4/x.x.x.x is only for example.
+    # Don't add it! 
+  PeerExchange = true #change this line to true. By default it's false
+  ...
+...
+```
+
+You can return back to where you left off in the Bridge Node guide [here](../nodes/bridge-node.md#start-the-bridge-node-with-systemd)
+
+## Connect Validator
+
+Continuing the Validator tutorial, here are the steps to connect your validator to Devnet:
+
+```sh
+MONIKER="your_moniker"
+VALIDATOR_WALLET="validator"
+
+celestia-appd tx staking create-validator \
+--amount=1000000celes \
+--pubkey=$(celestia-appd tendermint show-validator) \
+--moniker=$MONIKER \
+--chain-id=devnet-2 \
+--commission-rate=0.1 \
+--commission-max-rate=0.2 \
+--commission-max-change-rate=0.01 \
+--min-self-delegation=1000000 \
+--from=$VALIDATOR_WALLET
+```
+
+You will be prompted to confirm the transaction:
+
+```sh
+confirm transaction before signing and broadcasting [y/N]: y
+```
+
+Inputting `y` should provide an output similar to:
+
+```sh
+code: 0
+codespace: ""
+data: ""
+gas_used: "0"
+gas_wanted: "0"
+height: "0"
+info: ""
+logs: []
+raw_log: '[]'
+timestamp: ""
+tx: null
+txhash: <tx-hash>
+```
+
+You should now be able to see your validator from a block explorer like [here](https://celestia.observer/validators)

--- a/docs/nodes/light-node.md
+++ b/docs/nodes/light-node.md
@@ -103,7 +103,10 @@ Install the Celestia Node binary. Make sure that you have `git` and `golang` ins
 ```sh
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.2.0 -b v0.2.0
+APP_VERSION=$(curl -s \
+  https://api.github.com/repos/celestiaorg/celestia-node/releases/latest \
+  | jq -r ".tag_name")
+git checkout tags/$APP_VERSION -b $APP_VERSION
 make install
 ```
 

--- a/docs/nodes/light-node.md
+++ b/docs/nodes/light-node.md
@@ -1,4 +1,4 @@
-# Setting Up a Celestia Light Node
+# Setting Up A Celestia Light Node
 
 This tutorial will guide you through setting up a Celestia Light Node,
 which can allow you to do data-sampling on the Data Availability (DA)

--- a/docs/nodes/overview.md
+++ b/docs/nodes/overview.md
@@ -4,12 +4,12 @@ There are many ways you can participate in the Celestia network.
 
 Celestia node operators can run several options on the network:
 
-* Bridge Node (This node bridges blocks between the Data-Availability network
-  and the Consensus network)
-* Validator Node (Node operators who run a Bridge Node have the option to also
-  participate in Consensus by becoming a validator)
-* Light Client (Light clients conduct data availability sampling on the Data
-  Availability network)
+* [Bridge Node](../nodes/bridge-node.md): This node bridges blocks between the
+  Data-Availability network and the Consensus network.
+* [Validator Node](../nodes/validator-node.md): Node operators who run a Bridge
+  Node have the option to also participate in Consensus by becoming a Validator.
+* [Light Node](../nodes/light-node.md): Light clients conduct data availability
+  sampling on the Data Availability network.
 
 You can learn more about how to setup each different node by going through
 this tutorial guide.

--- a/docs/nodes/validator-node.md
+++ b/docs/nodes/validator-node.md
@@ -1,4 +1,4 @@
-# Setting Up A Validator Node
+# Setting Up A Celestia Validator Node
 
 Validator nodes allow you to participate in consensus in the Celestia network.
 

--- a/docs/nodes/validator-node.md
+++ b/docs/nodes/validator-node.md
@@ -2,16 +2,433 @@
 
 Validator nodes allow you to participate in consensus in the Celestia network.
 
-> Note: For this guide, you must complete the steps found in Bridge Node Tutorial
-  [here](../nodes/bridge-node.md) in order to proceed.
+## Hardware Requirements
 
-## Run a Validator Bridge Node
+The following hardware minimum requirements are recommended for running the
+bridge node:
 
-Optionally, if you want to join the active validator list, you can create your
-own validator on-chain following the instructions below. Keep in mind that
-these steps are necessary ONLY if you want to participate in the consensus.
+* Memory: 8 GB RAM
+* CPU: Quad-Core
+* Disk: 250 GB SSD Storage
+* Bandwidth: 1 Gbps for Download/100 Mbps for Upload
 
-Pick a MONIKER name of your choice! This is the validator name that will show
+## Setting Up Your Bridge Node
+
+The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64
+instance machine.
+
+### Setup The Dependencies
+
+Once you have setup your instance, ssh into the instance to begin setting up
+the box with all the needed dependencies in order to run your bridge node.
+
+First, make sure to update and upgrade the OS:
+
+```sh
+sudo apt update && sudo apt upgrade -y
+```
+
+These are essential packages that are necessary to execute many tasks like
+downloading files, compiling and monitoring the node:
+
+```sh
+sudo apt install curl tar wget clang pkg-config libssl-dev jq build-essential \
+git make ncdu -y
+```
+
+### Install Golang
+
+Golang will be installed on this machine in order for us to be able to build
+the necessary binaries for running the bridge node. For Golang specifically,
+it’s needed to be able to compile Celestia Application.
+
+```sh
+ver="1.17.2"
+cd $HOME
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"
+rm "go$ver.linux-amd64.tar.gz"
+```
+
+Now we need to add the `/usr/local/go/bin` directory to `$PATH`:
+
+```sh
+echo "export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin" >> $HOME/.bash_profile
+source $HOME/.bash_profile
+```
+
+To check if Go was installed correctly run:
+
+```sh
+go version
+```
+
+Output should be the version installed:
+
+```sh
+go version go1.17.2 linux/amd64
+```
+
+## Deploying The Celestia App
+
+This section describes part 1 of Celestia Bridge Node setup: running a Celestia
+App daemon with an internal Celestia Core node.
+
+> Note: Make sure you have at least 100+ Gb of free space to safely install+run
+  the Bridge Node.  
+
+### Install Celestia App
+
+The steps below will create a binary file named `celestia-appd`
+inside `$HOME/go/bin` folder which will be used later to run the node.
+
+```sh
+cd $HOME
+rm -rf celestia-app
+git clone https://github.com/celestiaorg/celestia-app.git
+cd celestia-app/
+APP_VERSION=$(curl -s \
+  https://api.github.com/repos/celestiaorg/celestia-app/releases/latest \
+  | jq -r ".tag_name")
+git checkout tags/$APP_VERSION -b $APP_VERSION
+make install
+```
+
+To check if the binary was successfully compiled you can run the binary
+using the `--help` flag:
+
+```sh
+celestia-appd --help
+```
+
+You should see a similar output (with helpful example commands):
+
+```text
+Stargate CosmosHub App
+
+Usage:
+  celestia-appd [command]
+
+Use "celestia-appd [command] --help" for more information about a command.
+```
+
+### Setup the P2P Networks
+
+For this section of the guide, select the network you want to connect to:
+
+* [Devnet-2](../nodes/devnet-2.md#setup-p2p-network)
+
+After that, you can proceed with the rest of the tutorial.
+
+### Configure Pruning
+
+For lower disk space usage we recommend setting up pruning using the
+configurations below. You can change this to your own pruning configurations
+if you want:
+
+```sh
+pruning="custom"
+pruning_keep_recent="100"
+pruning_keep_every="5000"
+pruning_interval="10"
+
+sed -i -e "s/^pruning *=.*/pruning = \"$pruning\"/" $HOME/.celestia-app/config/app.toml
+sed -i -e "s/^pruning-keep-recent *=.*/pruning-keep-recent = \
+\"$pruning_keep_recent\"/" $HOME/.celestia-app/config/app.toml
+sed -i -e "s/^pruning-keep-every *=.*/pruning-keep-every = \
+\"$pruning_keep_every\"/" $HOME/.celestia-app/config/app.toml
+sed -i -e "s/^pruning-interval *=.*/pruning-interval = \
+\"$pruning_interval\"/" $HOME/.celestia-app/config/app.toml
+```
+
+### Reset Network
+
+This will delete all data folders so we can start fresh:
+
+```sh
+celestia-appd unsafe-reset-all
+```
+
+### Optional: Quick-Sync with Snapshot
+
+Syncing from Genesis can take a long time, depending on your hardware. Using
+this method you can synchronize your Celestia node very quickly by downloading
+a recent snapshot of the blockchain. If you would like to sync from the Genesis,
+then you can skip this part.
+
+If you want to use snapshot, determine the network you would like to sync
+to from the list below:
+
+* [Devnet-2](../nodes/devnet-2.md#quick-sync-with-snapshot)
+
+### Start the Celestia-App with SystemD
+
+SystemD is a daemon service useful for running applications as background processes.
+
+Create Celestia-App systemd file:
+
+```sh
+sudo tee <<EOF >/dev/null /etc/systemd/system/celestia-appd.service
+[Unit]
+Description=celestia-appd Cosmos daemon
+After=network-online.target
+
+[Service]
+User=$USER
+ExecStart=$HOME/go/bin/celestia-appd start
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=4096
+
+[Install]
+WantedBy=multi-user.target
+EOF
+```
+
+If the file was created successfully you will be able to see its content:
+
+```sh
+cat /etc/systemd/system/celestia-appd.service
+```
+
+Now, download the address book. You have 2 options:
+
+```sh
+wget -O $HOME/.celestia-app/config/addrbook.json "https://raw.githubusercontent.com/maxzonder/celestia/main/addrbook.json"
+```
+
+OR
+
+```sh
+wget -O $HOME/.celestia-app/config/addrbook.json "https://raw.githubusercontent.com/qubelabsio/celestia/main/addrbook.json"
+```
+
+Enable and start celestia-appd daemon:
+
+```sh
+sudo systemctl enable celestia-appd
+sudo systemctl start celestia-appd
+```
+
+Check if daemon has been started correctly:
+
+```sh
+sudo systemctl status celestia-appd
+```
+
+Check daemon logs in real time:
+
+```sh
+sudo journalctl -u celestia-appd.service -f
+```
+
+To check if your node is in sync before going forward:
+
+```sh
+curl -s localhost:26657/status | jq .result | jq .sync_info
+```
+
+Make sure that you have `"catching_up": false`, otherwise leave it running
+until it is in sync.
+
+### Wallet
+
+#### Create a Wallet
+
+You can pick whatever wallet name you want. For our example we used
+“validator” as the wallet name:
+
+```sh
+celestia-appd keys add validator
+```
+
+Save the mnemonic output as this is the only way to recover your validator
+wallet in case you lose it!
+
+#### Fund a Wallet
+
+For the public celestia address, you can fund the previously created wallet via
+Discord by sending this message to #faucet channel:
+
+```text
+!faucet celes1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Wait to see if you get a confirmation that the tokens have been successfully
+sent. To check if tokens have arrived successfully to the destination wallet
+run the command below replacing the public address with your own:
+
+```sh
+celestia-appd q bank balances celes1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+### Delegate Stake to a Validator
+
+If you want to delegate more stake to any validator, including your own you
+will need the `celesvaloper` address of the validator in question. You can
+either check it using the block explorer mentioned above or you can run the
+command below to get the `celesvaloper` of your local validator wallet in
+case you want to delegate more to it:
+
+```sh
+celestia-appd keys show $VALIDATOR_WALLET --bech val -a
+```
+
+After entering the wallet passphrase you should see a similar output:
+
+```sh
+Enter keyring passphrase:
+celesvaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd
+```
+
+Next, select the network you want to use to delegate to a validator:
+
+* [Devnet-2](../nodes/devnet-2.md#delegate-to-a-validator)
+
+## Deploy the Celestia Node
+
+This section describes part 2 of Celestia Bridge Node setup: running a
+Celestia Node daemon.
+
+### Install Celestia Node
+
+Install the Celestia Node binary, which will be used to run the Bridge Node.
+
+```sh
+cd $HOME
+rm -rf celestia-node
+git clone https://github.com/celestiaorg/celestia-node.git
+cd celestia-node/
+APP_VERSION=$(curl -s \
+  https://api.github.com/repos/celestiaorg/celestia-node/releases/latest \
+  | jq -r ".tag_name")
+git checkout tags/$APP_VERSION -b $APP_VERSION
+make install
+```
+
+Verify that the binary is working and check the version with `celestia version` command:
+
+```sh
+$ celestia version
+Semantic version: v0.2.0
+Commit: 1fcf0c0bb5d5a4e18b51cf12440ce86a84cf7a72
+Build Date: Fri 04 Mar 2022 01:15:07 AM CET
+System version: amd64/linux
+Golang version: go1.17.5
+```
+
+### Get the trusted hash
+
+> Caveat: You need a running celestia-app in order to continue this guideline.
+  Please refer to
+  [celestia-app.md](https://github.com/celestiaorg/networks/celestia-app.md)
+  for installation.  
+
+You need to have the trusted server to initialize the Bridge Node. You can use
+`http://localhost:26657` for your local run of `celestia-app`. The trusted hash
+is an optional flag and does not need to be used. If you are not passing it,
+the Bridge Node will just sync from the beginning, which is also the preferred
+option of how to run it.
+
+An example of how to query your local celestia-app to get the trusted hash:
+
+```sh
+curl -s http://localhost:26657/block?height=1 | grep -A1 block_id | grep hash
+```
+
+### Initialize the Bridge Node
+
+```sh
+celestia bridge init --core.remote <ip:port of celestia-app>
+```
+
+If you want to use the trusted hash anyways, here is how to initialize it:
+
+```shell
+celestia bridge init --core.remote <ip:port of celestia-app> \
+--headers.trusted-hash <hash_from_celestia_app>
+```
+
+Example:
+
+```sh
+celestia bridge init --core.remote tcp://127.0.0.1:26657 --headers.trusted-hash 4632277C441CA6155C4374AC56048CF4CFE3CBB2476E07A548644435980D5E17
+```
+
+### Configure the Bridge Node
+
+To configure your Bridge Node to connect to your network of choice,
+select one of the networks you would like to connect to from this list and
+follow the instructions there before proceeding with the rest of this guide:
+
+* [Devnet-2](../nodes/devnet-2.md#configure-the-bridge-node)
+
+### Start the Bridge Node with SystemD
+
+SystemD is a daemon service useful for running applications as background processes.
+
+Create Celestia Bridge systemd file:
+
+```sh
+sudo tee <<EOF >/dev/null /etc/systemd/system/celestia-bridge.service
+[Unit]
+Description=celestia-bridge Cosmos daemon
+After=network-online.target
+
+[Service]
+User=$USER
+ExecStart=$HOME/go/bin/celestia bridge start
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=4096
+
+[Install]
+WantedBy=multi-user.target
+EOF
+```
+
+If the file was created successfully you will be able to see its content:
+
+```sh
+cat /etc/systemd/system/celestia-bridge.service
+```
+
+Enable and start celestia-bridge daemon:
+
+```sh
+sudo systemctl enable celestia-bridge
+sudo systemctl start celestia-bridge && sudo journalctl -u \
+celestia-bridge.service -f
+```
+
+Now, the Celestia bridge node will start syncing headers and storing blocks
+from Celestia application.
+
+> Note: At startup, we can see the `multiaddress` from Celestia Bridge Node.
+  This is **needed for future Light Node** connections and communication
+  between Celestia Bridge Nodes  
+
+Example:
+
+```sh
+/ip4/46.101.22.123/tcp/2121/p2p/12D3KooWD5wCBJXKQuDjhXFjTFMrZoysGVLtVht5hMoVbSLCbV22
+```
+
+You should be seeing logs coming through of the bridge node syncing.
+
+You have successfully set up a bridge node that is syncing with the network.
+
+If you want to next run a validator node, read the following tutorial [here](../nodes/validator-node.md).
+
+## Run a Validator Node
+
+After completing all the necessary steps, you are now ready to run a validator!
+In order to create your validator on-chain, follow the instructions below.
+Keep in mind that these steps are necessary ONLY if you want to participate
+in the consensus.
+
+Pick a `moniker` name of your choice! This is the validator name that will show
 up on public dashboards and explorers. `VALIDATOR_WALLET` must be the same you
 defined previously. Parameter `--min-self-delegation=1000000` defines the
 amount of tokens that are self delegated from your validator wallet.
@@ -20,4 +437,7 @@ Now, connect to the network of your choice.
 
 You have the following option of connecting to list of networks shown below:
 
-- [Devnet-2](../nodes/devnet-2.md#connect-validator)
+* [Devnet-2](../nodes/devnet-2.md#connect-validator)
+
+Complete the instructions in the respective network you want to validate in
+to complete the validator setup process.

--- a/docs/nodes/validator-node.md
+++ b/docs/nodes/validator-node.md
@@ -246,6 +246,12 @@ celestia-appd keys add validator
 Save the mnemonic output as this is the only way to recover your validator
 wallet in case you lose it!
 
+Create an environment variable for the address:
+
+```sh
+VALIDATOR_WALLET=<validator-address>
+```
+
 #### Fund a Wallet
 
 For the public celestia address, you can fund the previously created wallet via

--- a/docs/nodes/validator-node.md
+++ b/docs/nodes/validator-node.md
@@ -5,7 +5,6 @@ Validator nodes allow you to participate in consensus in the Celestia network.
 > Note: For this guide, you must complete the steps found in Bridge Node Tutorial
   [here](../nodes/bridge-node.md) in order to proceed.
 
-
 ## Run a Validator Bridge Node
 
 Optionally, if you want to join the active validator list, you can create your

--- a/docs/nodes/validator-node.md
+++ b/docs/nodes/validator-node.md
@@ -1,0 +1,24 @@
+# Setting Up A Validator Node
+
+Validator nodes allow you to participate in consensus in the Celestia network.
+
+> Note: For this guide, you must complete the steps found in Bridge Node Tutorial
+  [here](../nodes/bridge-node.md) in order to proceed.
+
+
+## Run a Validator Bridge Node
+
+Optionally, if you want to join the active validator list, you can create your
+own validator on-chain following the instructions below. Keep in mind that
+these steps are necessary ONLY if you want to participate in the consensus.
+
+Pick a MONIKER name of your choice! This is the validator name that will show
+up on public dashboards and explorers. `VALIDATOR_WALLET` must be the same you
+defined previously. Parameter `--min-self-delegation=1000000` defines the
+amount of tokens that are self delegated from your validator wallet.
+
+Now, connect to the network of your choice.
+
+You have the following option of connecting to list of networks shown below:
+
+- [Devnet-2](../nodes/devnet-2.md#connect-validator)

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,9 +1,70 @@
 const sidebars = {
   nodes: [
-    { type: "doc", label: "Overview", id: "nodes/overview" },
-    { type: "doc", label: "Bridge & Validator Node", id: "nodes/bridge-validator-node" },
-    { type: "doc", label: "Light Node", id: "nodes/light-node" },
-    { type: "doc", label: "Devops Resources", id: "nodes/devops-resources"},
+    { 
+      type: "doc", 
+      label: "Overview", 
+      id: "nodes/overview" 
+    },
+    { 
+      type: "category", 
+      label: "Types of Nodes", 
+      link: {
+        type: 'generated-index'
+      },
+      collapsed: false,
+      items: [
+       { 
+         type: "doc", 
+         label: "Bridge Node", 
+         id: "nodes/bridge-node" 
+       },
+      {
+        type: "doc",
+        label: "Validator Node",
+        id: "nodes/validator-node",
+      },
+      { 
+        type: "doc", 
+        label: "Light Node", 
+        id: "nodes/light-node" 
+      },
+      ]
+    },
+    {
+      type: "category",
+      label: "Participate",
+      link: {
+        type: 'generated-index'
+      },
+      collapsed: false,
+      items: [
+        {
+          type: "doc",
+          label: "Devnet-2",
+          id: "nodes/devnet-2"
+        }
+      ]
+    },
+    {
+      type: "category",
+      label: "Resources",
+      link: {
+        type: 'generated-index'
+      },
+      collapsed: false,
+      items: [
+        { 
+          type: "doc", 
+          label: "Devops Resources", 
+          id: "nodes/devops-resources"
+        },
+        {
+          type: "doc",
+          label: "Config.toml Guide",
+          id: "nodes/config-toml"
+        },
+      ]
+    },
   ],
   developers: [
     { type: "doc", label: "Overview", id: "developers/overview" },


### PR DESCRIPTION
* Creates a separate `Devnet-2` Page with its own instructions on how validator and bridge nodes can connect to it.
* Creates an un-ordered list of options for network selection in Bridge and Validator tutorial guides.
* Splits Bridge-Validator tutorial into separate Bridge Node and Validator Node Tutorial
* Includes a config-toml guide from the networks repo for reference
* Adds code for how to always pull latest version from `celestia-app` and `celestia-node`
<img width="1344" alt="Screen Shot 2022-05-20 at 1 10 41 PM" src="https://user-images.githubusercontent.com/9094204/169496160-cc12387c-4ce0-426f-a8cb-58811c683879.png">

