### PR TITLE
Bump celestia-node version

### DIFF
--- a/docs/developers/celestia-node.md
+++ b/docs/developers/celestia-node.md
@@ -13,10 +13,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-NODE_VERSION=$(curl -s \ 
-   https://api.github.com/repos/celestiaorg/celestia-node/releases/latest \ 
-   | jq -r ".tag_name") 
-git checkout tags/$NODE_VERSION -b $NODE_VERSION
+git checkout tags/v0.3.0-rc1
 make install
 ```
 

--- a/docs/developers/celestia-node.md
+++ b/docs/developers/celestia-node.md
@@ -26,7 +26,4 @@ Verify that the binary is working and check the version with `celestia version` 
 $ celestia version
 Semantic version: v0.3.0-rc1
 Commit: 5843c5e102651206fe11c685c163f267b141b103
-Build Date: Thu 26 May 2022 02:32:58 PM CEST
-System version: amd64/linux
-Golang version: go1.18.2
 ```

--- a/docs/developers/celestia-node.md
+++ b/docs/developers/celestia-node.md
@@ -13,6 +13,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
+git checkout tags/v0.3.0-rc1
 make install
 ```
 
@@ -20,9 +21,9 @@ Verify that the binary is working and check the version with `celestia version` 
 
 ```console
 $ celestia version
-Semantic version: v0.3.0-rc1-7-g45f23d8
-Commit: 45f23d8ecab4c3526a7729cd4bc9a0ebe561846e
-Build Date: Thu 26 May 2022 10:41:59 AM CEST
+Semantic version: v0.3.0-rc1
+Commit: 5843c5e102651206fe11c685c163f267b141b103
+Build Date: Thu 26 May 2022 02:32:58 PM CEST
 System version: amd64/linux
-Golang version: go1.18.1
+Golang version: go1.18.2
 ```

--- a/docs/developers/celestia-node.md
+++ b/docs/developers/celestia-node.md
@@ -13,7 +13,10 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.3.0-rc1
+APP_VERSION=$(curl -s \ 
+   https://api.github.com/repos/celestiaorg/celestia-app/releases/latest \ 
+   | jq -r ".tag_name") 
+git checkout tags/$APP_VERSION -b $APP_VERSION
 make install
 ```
 

--- a/docs/developers/celestia-node.md
+++ b/docs/developers/celestia-node.md
@@ -20,9 +20,9 @@ Verify that the binary is working and check the version with `celestia version` 
 
 ```console
 $ celestia version
-Semantic version: v0.2.0
-Commit: 1fcf0c0bb5d5a4e18b51cf12440ce86a84cf7a72
-Build Date: Fri 04 Mar 2022 01:15:07 AM CET
+Semantic version: v0.3.0-rc1-7-g45f23d8
+Commit: 45f23d8ecab4c3526a7729cd4bc9a0ebe561846e
+Build Date: Thu 26 May 2022 10:41:59 AM CEST
 System version: amd64/linux
-Golang version: go1.17.5
+Golang version: go1.18.1
 ```

--- a/docs/developers/celestia-node.md
+++ b/docs/developers/celestia-node.md
@@ -13,10 +13,10 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-APP_VERSION=$(curl -s \ 
-   https://api.github.com/repos/celestiaorg/celestia-app/releases/latest \ 
+NODE_VERSION=$(curl -s \ 
+   https://api.github.com/repos/celestiaorg/celestia-node/releases/latest \ 
    | jq -r ".tag_name") 
-git checkout tags/$APP_VERSION -b $APP_VERSION
+git checkout tags/$NODE_VERSION -b $NODE_VERSION
 make install
 ```
 


### PR DESCRIPTION
this is the output now for using the above command, some people check commit here it seems and use the older one which doesnt have the grpc flag in there yet