### PR TITLE
Instructions to use --keyring-backend=test

### DIFF
--- a/docs/developers/wallet.md
+++ b/docs/developers/wallet.md
@@ -3,11 +3,13 @@
 ## Create a Wallet
 
 First we need to create an application CLI configuration file:
+
  ```sh
  celestia-appd config keyring-backend test
  ```
 
 You can pick whatever wallet name you want. For our example we used "validator" as the wallet name:
+
 ```sh
 celestia-appd keys add validator
 ```
@@ -16,6 +18,7 @@ Save the mnemonic output as this is the only way to
 recover your validator wallet in case you lose it!
 
 To check all your wallets you can run:
+
 ```sh
 celestia-appd keys list
 ```

--- a/docs/developers/wallet.md
+++ b/docs/developers/wallet.md
@@ -8,7 +8,8 @@ First, create an application CLI configuration file:
  celestia-appd config keyring-backend test
  ```
 
-You can pick whatever wallet name you want. For our example we used "validator" as the wallet name:
+You can pick whatever wallet name you want.
+For our example we used "validator" as the wallet name:
 
 ```sh
 celestia-appd keys add validator

--- a/docs/developers/wallet.md
+++ b/docs/developers/wallet.md
@@ -2,7 +2,7 @@
 
 ## Create a Wallet
 
-First we need to create an application CLI configuration file:
+First, create an application CLI configuration file:
 
  ```sh
  celestia-appd config keyring-backend test

--- a/docs/developers/wallet.md
+++ b/docs/developers/wallet.md
@@ -2,15 +2,23 @@
 
 ## Create a Wallet
 
-You can pick whatever wallet name you want.
-For our example we used "validator" as the wallet name:
+First we need to create an application CLI configuration file:
+ ```sh
+ celestia-appd config keyring-backend test
+ ```
 
+You can pick whatever wallet name you want. For our example we used "validator" as the wallet name:
 ```sh
 celestia-appd keys add validator
 ```
 
 Save the mnemonic output as this is the only way to
 recover your validator wallet in case you lose it!
+
+To check all your wallets you can run:
+```sh
+celestia-appd keys list
+```
 
 ## Fund a Wallet
 

--- a/docs/nodes/mamaki-testnet.md
+++ b/docs/nodes/mamaki-testnet.md
@@ -35,7 +35,7 @@ to the correct instructions on this page on how to connect to Mamaki.
 There is a list of RPC endpoints you can use to connect to Mamaki Testnet:
 
 * [https://rpc-mamaki.pops.one](https://rpc-mamaki.pops.one)
-* [https://rpc-1.celestia.nodes.guru/](https://rpc-1.celestia.nodes.guru/)
+* [https://rpc-1.celestia.nodes.guru](https://rpc-1.celestia.nodes.guru)
 
 ## Mamaki Testnet Faucet
 
@@ -167,7 +167,8 @@ celestia-appd tx staking create-validator \
     --commission-max-rate=0.2 \
     --commission-max-change-rate=0.01 \
     --min-self-delegation=1000000 \
-    --from=$VALIDATOR_WALLET
+    --from=$VALIDATOR_WALLET \
+    --keyring-backend=test
 ```
 
 You will be prompted to confirm the transaction:


### PR DESCRIPTION
These instructions avoid issues with wallets on current SDK version. Without this, users will get this error:
Error: rpc error: code = NotFound desc = rpc error: code = NotFound desc = account not found: key not found