### PR TITLE
fix: broken link

### DIFF
--- a/docs/nodes/light-node.md
+++ b/docs/nodes/light-node.md
@@ -43,7 +43,7 @@ Follow the tutorial on setting up your dependencies [here](../../developers/envi
 
 > Note: Make sure that you have at least 5+ Gb of free space for Celestia Light Node
 
-Follow the tutorial on installing Celestia Node [here](../developers/celestia-node)
+Follow the tutorial on installing Celestia Node [here](../../developers/celestia-node)
 
 ### Initialize the Light Node
 

--- a/docs/nodes/light-node.md
+++ b/docs/nodes/light-node.md
@@ -37,7 +37,7 @@ The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64 instance machi
 
 ### Setup The Dependencies
 
-Follow the tutorial on setting up your dependencies [here](../developers/environment).
+Follow the tutorial on setting up your dependencies [here](../../developers/environment).
 
 ## Install Celestia Node
 


### PR DESCRIPTION
This is a very weird bug where links in this doc: https://docs.celestia.org/nodes/light-node
get the `nodes` added in the url if you do the following:

1. Go to Light Node doc as linked above
2. Click on `here` under either dependencies or under Celestia Node
3. Now go back in the browser to Light Node page
4. Now do a refresh on the light node page
5. Click `here` again on either dependencies or Celestia Node
6. You will get a 404 because `developers` is added in the url