### PR TITLE
Sentence case titles

### DIFF
--- a/docs/nodes/bridge-node.md
+++ b/docs/nodes/bridge-node.md
@@ -1,11 +1,11 @@
-# Setting Up A Celestia Bridge Node
+# Setting up a Celestia Bridge Node
 
 This tutorial will go over the steps to setting up your Celestia Bridge node.
 
 Bridge nodes connect the data availability layer and the consensus layer
 while also having the option of becoming a validator.
 
-## Overview of Bridge Nodes
+## Overview of bridge nodes
 
 A Celestia bridge node has the following properties:
 
@@ -38,7 +38,7 @@ From an implementation perspective, Bridge Nodes run two separate processes:
       serves data availability sampling requests. The team sometimes refer to
       this as the “halo” network.
 
-## Hardware Requirements
+## Hardware requirements
 
 The following hardware minimum requirements are recommended for running the
 bridge node:
@@ -48,33 +48,33 @@ bridge node:
 * Disk: 250 GB SSD Storage
 * Bandwidth: 1 Gbps for Download/100 Mbps for Upload
 
-## Setting Up Your Bridge Node
+## Setting up your bridge node
 
 The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64 instance machine.
 
-### Setup The Dependencies
+### Setup the dependencies
 
 Follow the tutorial here installing the dependencies [here](../developers/environment.md).
 
-## Deploy the Celestia Bridge Node
+## Deploy the Celestia bridge node
 
-### Install Celestia Node
+### Install Celestia node
 
 Install the Celestia Node binary, which will be used to run the Bridge Node.
 
 Follow the tutorial for installing Celestia Node [here](../developers/celestia-node.md).
 
-### Initialize the Bridge Node
+### Initialize the bridge node
 
 Run the following:
 
 ```sh
-celestia bridge init --core.remote tcp://<ip-address>:26657 
+celestia bridge init --core.remote tcp://<ip-address>:26657
 ```
 
 If you need a list of RPC endpoints to connect to, you can check from the list [here](./mamaki-testnet.md#rpc-endpoints)
 
-### Run the Bridge Node
+### Run the bridge node
 
 Start the Bridge Node with a connection to a validator node's gRPC endpoint
 (which is usually exposed on port 9090):
@@ -103,7 +103,7 @@ You can find the address by running the following command:
 
 Mamaki Testnet tokens can be requested [here](./mamaki-testnet.md#mamaki-testnet-faucet).
 
-#### Optional: Run the Bridge Node with a Custom Key
+#### Optional: run the bridge node with a custom key
 
 In order to run a bridge node using a custom key:
 
@@ -115,7 +115,7 @@ In order to run a bridge node using a custom key:
 celestia bridge start --core.grpc http://<ip>:9090 --keyring.accname <name_of_custom_key>
 ```
 
-### Optional: Start the Bridge Node with SystemD
+### Optional: start the bridge node with SystemD
 
 Follow the tutorial on setting up the bridge node as a background process with
 SystemD [here](./systemd.md#celestia-bridge-node).

--- a/docs/nodes/config-toml.md
+++ b/docs/nodes/config-toml.md
@@ -10,7 +10,7 @@
     - [[Services]](#services)
       - [TrustedHash and TrustedPeer](#trustedhash-and-trustedpeer)
 
-## Pre-Requisites
+## Prerequisites
 
 Please, make sure that you have installed and initialized celestia node
 
@@ -42,7 +42,7 @@ If you want your node to be a bootstrapper, then activate `Bootstrapper = true`.
 If you want to add your own manually, you need to provide the
 multiaddresses of the peers.
 
-#### Mutual Peers
+#### Mutual peers
 
 The purpose of this config is to set up a bidirectional communication.
 This is usually the case for Celestia Bridge Nodes. In addition, you

--- a/docs/nodes/consensus-full-node.md
+++ b/docs/nodes/consensus-full-node.md
@@ -1,10 +1,10 @@
-# Setting Up A Celestia Consensus Full Node
+# Setting up a Celestia Consensus Full Node
 <!-- markdownlint-disable MD013 -->
 
 Consensus Full Nodes allow you to sync blockchain history in the Celestia
 Consensus Layer.
 
-## Hardware Requirements
+## Hardware requirements
 
 The following hardware minimum requirements are recommended for running the
 Consensus Full Node:
@@ -14,28 +14,28 @@ Consensus Full Node:
 * Disk: 250 GB SSD Storage
 * Bandwidth: 1 Gbps for Download/100 Mbps for Upload
 
-## Setting Up Your Consensus Full Node
+## Setting up your consensus full node
 
 The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64
 instance machine.
 
-### Setup The Dependencies
+### Setup the dependencies
 
 Follow the instructions on installing the dependencies [here](../developers/environment.md).
 
-## Deploying The Celestia App
+## Deploying the celestia-app
 
 This section describes part 1 of Celestia Validator Node setup:
 running a Celestia App daemon with an internal Celestia Core node.
 
 > Note: Make sure you have at least 100+ Gb of free space to safely install+run
-  the Validator Node.  
+  the Validator Node.
 
-### Install Celestia App
+### Install celestia-app
 
 Follow the tutorial on installing Celestia App [here](../developers/celestia-app.md).
 
-### Setup the P2P Networks
+### Setup the P2P networks
 
 For this section of the guide, select the network you want to connect to:
 
@@ -43,7 +43,7 @@ For this section of the guide, select the network you want to connect to:
 
 After that, you can proceed with the rest of the tutorial.
 
-### Configure Pruning
+### Configure pruning
 
 For lower disk space usage we recommend setting up pruning using the
 configurations below. You can change this to your own pruning configurations
@@ -61,7 +61,7 @@ sed -i -e "s/^pruning-interval *=.*/pruning-interval = \
 \"$PRUNING_INTERVAL\"/" $HOME/.celestia-app/config/app.toml
 ```
 
-### Reset Network
+### Reset network
 
 This will delete all data folders so we can start fresh:
 
@@ -69,7 +69,7 @@ This will delete all data folders so we can start fresh:
 celestia-appd tendermint unsafe-reset-all --home $HOME/.celestia-app
 ```
 
-### Optional: Quick-Sync with Snapshot
+### Optional: quick-sync with snapshot
 
 Syncing from Genesis can take a long time, depending on your hardware. Using
 this method you can synchronize your Celestia node very quickly by downloading
@@ -81,7 +81,7 @@ to from the list below:
 
 * [Mamaki](./mamaki-testnet.md#quick-sync-with-snapshot)
 
-### Start the Celestia App
+### Start the celestia-app
 
 In order to start your consensus full node, run the following:
 
@@ -91,7 +91,7 @@ celestia-appd start
 
 This will let you sync the Celestia blockchain history.
 
-### Optional: Configure For RPC Endpoint
+### Optional: configure for RPC endpoint
 
 You can configure your Consensus Full Node to be a public RPC endpoint
 and listen to any connections from Data Availability Nodes in order to
@@ -109,7 +109,7 @@ sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ~/.celestia-app/confi
 
 Restart `celestia-appd` in the previous step to load those configs.
 
-### Start the Celestia-App with SystemD
+### Start the celestia-app with SystemD
 
 Follow the tutorial on setting up Celestia-App as a background process
 with SystemD [here](./systemd.md#start-the-celestia-app-with-systemd).

--- a/docs/nodes/full-storage-node.md
+++ b/docs/nodes/full-storage-node.md
@@ -1,10 +1,10 @@
-# Setting Up A Celestia Full Storage Node
+# Setting up a Celestia Full Storage Node
 
 This tutorial will guide you through setting up a Celestia Full Storage
 Node, which is a Celestia node that doesn't connect to Celestia App
 (hence not a full node) but stores all the data.
 
-## Hardware Requirements
+## Hardware requirements
 
 The following hardware minimum requirements are recommended for running
 the full storage node:
@@ -14,24 +14,24 @@ the full storage node:
 * Disk: 250 GB SSD Storage
 * Bandwidth: 1 Gbps for Download/100 Mbps for Upload
 
-## Setting Up Your Full Storage Node
+## Setting up your full storage node
 
 The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64 instance machine.
 
-### Setup The Dependencies
+### Setup the dependencies
 
 You can follow the tutorial for setting up your dependencies [here](../developers/environment.md)
 
-## Install Celestia Node
+## Install Celestia node
 
 > Note: Make sure that you have at least 250+ Gb of free space for
   Celestia Full Storage Node
 
 You can follow the tutorial for installing Celestia Node [here](../developers/celestia-node.md)
 
-### Run the Full Storage Node
+### Run the full storage node
 
-#### Initialize the Full Storage Node
+#### Initialize the full storage node
 
 Run the following command:
 
@@ -39,7 +39,7 @@ Run the following command:
 celestia full init
 ```
 
-#### Start the Full Storage Node
+#### Start the full storage node
 
 Start the Full Storage Node with a connection to a validator node's gRPC endpoint
 (which is usually exposed on port 9090):
@@ -69,7 +69,7 @@ You can find the address by running the following command:
 
 Mamaki Testnet tokens can be requested [here](./mamaki-testnet.md#mamaki-testnet-faucet).
 
-### Optional: Run the Full Storage Node with a Custom Key
+### Optional: run the full storage node with a custom key
 
 In order to run a full storage node using a custom key:
 
@@ -81,7 +81,7 @@ In order to run a full storage node using a custom key:
 celestia full start --core.grpc http://<ip>:9090 --keyring.accname <name_of_custom_key>
 ```
 
-### Optional: Start the Full Storage Node with SystemD
+### Optional: start the full storage node with SystemD
 
 Follow the tutorial on setting up the full storage node as a background
 process with SystemD [here](./systemd.md#celestia-full-storage-node).

--- a/docs/nodes/keys.md
+++ b/docs/nodes/keys.md
@@ -1,4 +1,4 @@
-# Using the Cel-Key Utility
+# Using the cel-key utility
 
 Inside the celestia-node repository is a utility called `cel-key` that uses
 the key utility provided by Cosmos-SDK under the hood. The utility can be

--- a/docs/nodes/light-node.md
+++ b/docs/nodes/light-node.md
@@ -1,4 +1,4 @@
-# Setting Up A Celestia Light Node
+# Setting up a Celestia Light Node
 
 This tutorial will guide you through setting up a Celestia light node, which
 will allow you to perform data availability sampling on the data
@@ -6,7 +6,7 @@ availability (DA) network.
 
 > To view a video tutorial for setting up a Celestia light node, click [here](../developers/light-node-video.md)
 
-## Overview of Light Nodes
+## Overview of light nodes
 
 Light nodes ensure data availability. This is the most common
 way to interact with the Celestia network.
@@ -19,7 +19,7 @@ Light nodes have the following behavior:
    Celestia nodes of new block headers and relevant DA metadata.
 2. They perform data availability sampling (DAS) on the received headers
 
-## Hardware Requirements
+## Hardware requirements
 
 The following minimum hardware requirements are recommended for running
 a light node:
@@ -29,19 +29,19 @@ a light node:
 * Disk: 5 GB SSD Storage
 * Bandwidth: 56 Kbps for Download/56 Kbps for Upload
 
-## Setting Up Your Light Node
+## Setting up your light node
 
 This tutorial was performed on an Ubuntu Linux 20.04 (LTS) x64 instance machine.
 
-### Setup The Dependencies
+### Setup the dependencies
 
 Follow the tutorial on setting up your dependencies [here](../developers/environment.md).
 
-## Install Celestia Node
+## Install Celestia node
 
 Follow the tutorial on installing Celestia node [here](../developers/celestia-node.md)
 
-### Initialize the Light Node
+### Initialize the light node
 
 Run the following command:
 
@@ -60,7 +60,7 @@ $ celestia light init
 ```
 <!-- markdownlint-enable MD013 -->
 
-### Start the Light Node
+### Start the light node
 
 Start the light node with a connection to a validator node's gRPC endpoint (which
 is usually exposed on port 9090):
@@ -89,7 +89,7 @@ You can find the address by running the following command:
 
 Mamaki Testnet tokens can be requested [here](./mamaki-testnet.md#mamaki-testnet-faucet).
 
-### Optional: Run the Light Node with a Custom Key
+### Optional: run the light node with a custom key
 
 In order to run a light node using a custom key:
 
@@ -101,12 +101,12 @@ In order to run a light node using a custom key:
 celestia light start --core.grpc http://<ip>:9090 --keyring.accname <name_of_custom_key>
 ```
 
-### Optional: Start Light Node with SystemD
+### Optional: start light node with SystemD
 
 Follow the tutorial on setting up the light node as a background
 process with SystemD [here](./systemd.md#celestia-light-node).
 
-## Data Availability Sampling (DAS)
+## Data availability sampling (DAS)
 
 With your light node running, you can check out this tutorial on
 submitting `PayForData` transactions [here](../developers/node-tutorial.md).

--- a/docs/nodes/mamaki-testnet.md
+++ b/docs/nodes/mamaki-testnet.md
@@ -31,7 +31,7 @@ on each respective page. Whenever you are asked to select the type of network
 you want to connect to in those guides, select `Mamaki` in order to refer
 to the correct instructions on this page on how to connect to Mamaki.
 
-## RPC Endpoints
+## RPC endpoints
 
 There is a list of RPC endpoints you can use to connect to Mamaki Testnet:
 
@@ -41,7 +41,7 @@ There is a list of RPC endpoints you can use to connect to Mamaki Testnet:
 * [https://celestia-testnet-rpc.polkachu.com/](https://celestia-testnet-rpc.polkachu.com/)
 * [https://rpc.celestia.testnet.run](https://rpc.celestia.testnet.run/)
 
-## Mamaki Testnet Faucet
+## Mamaki Testnet faucet
 
 > USING THIS FAUCET DOES NOT ENTITLE YOU TO ANY AIRDROP OR OTHER
   DISTRIBUTION OF MAINNET CELESTIA TOKENS. MAINNET CELESTIA TOKENS
@@ -52,7 +52,7 @@ You can request from Mamaki Testnet Faucet on the #faucet channel on
 Celestia's Discord server with the following command:
 
 ```text
-$request <CELESTIA-ADDRESS> 
+$request <CELESTIA-ADDRESS>
 ```
 
 Where `<CELESTIA-ADDRESS>` is a `celestia1******` generated address.
@@ -66,7 +66,7 @@ There are several explorers you can use for Mamaki:
 * [https://celestia.explorers.guru/](https://celestia.explorers.guru/)
 * [https://celestiascan.vercel.app/](https://celestiascan.vercel.app/)
 
-## Setup P2P Network
+## Setup P2P network
 
 Now we will setup the P2P Networks by cloning the networks repository:
 
@@ -103,7 +103,7 @@ Note: You can find more peers [here](https://github.com/celestiaorg/networks/blo
 
 You can return back to where you left off in the Bridge Node guide [here](validator-node.md#configure-pruning)
 
-## Quick-Sync With Snapshot
+## Quick-sync with snapshot
 
 Run the following command to quick-sync from a snapshot for `mamaki`:
 
@@ -119,7 +119,7 @@ wget -O - https://snaps.qubelabs.io/celestia/${SNAP_NAME} | tar xf - \
 
 You can return back to where you left off in the Bridge Node guide [here](./validator-node.md#start-the-celestia-app-with-systemd)
 
-## Delegate to a Validator
+## Delegate to a validator
 
 To delegate tokens to the the `celestiavaloper` validator, as an example you can run:
 
@@ -151,7 +151,7 @@ inputting the `txhash` ID that was returned.
 
 You can return back to where you left off in the Bridge Node guide [here](./validator-node#deploy-the-celestia-node)
 
-## Connect Validator
+## Connect validator
 
 Continuing the Validator tutorial, here are the steps to connect your
 validator to Mamaki:

--- a/docs/nodes/overview.md
+++ b/docs/nodes/overview.md
@@ -1,4 +1,4 @@
-# Overview to Running Nodes on Celestia
+# Overview to running nodes on Celestia
 
 There are many ways you can participate in the Celestia network.
 

--- a/docs/nodes/systemd.md
+++ b/docs/nodes/systemd.md
@@ -1,13 +1,13 @@
-# Setting Up Your Node As A Background Process With SystemD
+# Setting up your node as a background process with SystemD
 
 SystemD is a daemon service useful for running applications as background processes.
 
-## Consensus Nodes
+## Consensus nodes
 
 If you are running a validator or consensus full node, here are
 the steps to setting up `celestia-appd` as a background process.
 
-### Start the Celestia-App with SystemD
+### Start the celestia-app with SystemD
 
 SystemD is a daemon service useful for running applications as background processes.
 
@@ -63,9 +63,9 @@ curl -s localhost:26657/status | jq .result | jq .sync_info
 Make sure that you have `"catching_up": false`, otherwise leave it running
 until it is in sync.
 
-## Data Availability Nodes
+## Data availability nodes
 
-### Celestia Full Storage Node
+### Celestia full storage node
 
 Create Celestia Full Storage Node systemd file:
 
@@ -103,7 +103,7 @@ celestia-full.service -f
 
 You should be seeing logs coming through of the full storage node syncing.
 
-### Celestia Bridge Node
+### Celestia bridge node
 
 Create Celestia Bridge systemd file:
 
@@ -155,7 +155,7 @@ NODE_IP=<ip-address>
 
 You should be seeing logs coming through of the bridge node syncing.
 
-### Celestia Light Node
+### Celestia light node
 
 Start the Light Node as daemon process in the background
 

--- a/docs/nodes/validator-node.md
+++ b/docs/nodes/validator-node.md
@@ -1,8 +1,8 @@
-# Setting Up A Celestia Validator Node
+# Setting up a Celestia Validator Node
 
 Validator nodes allow you to participate in consensus in the Celestia network.
 
-## Hardware Requirements
+## Hardware requirements
 
 The following hardware minimum requirements are recommended for running the
 validator node:
@@ -12,28 +12,28 @@ validator node:
 * Disk: 250 GB SSD Storage
 * Bandwidth: 1 Gbps for Download/100 Mbps for Upload
 
-## Setting Up Your Validator Node
+## Setting up your validator node
 
 The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64
 instance machine.
 
-### Setup The Dependencies
+### Setup the dependencies
 
 Follow the instructions on installing the dependencies [here](../developers/environment.md).
 
-## Deploying The Celestia App
+## Deploying the celestia-app
 
 This section describes part 1 of Celestia Validator Node setup:
 running a Celestia App daemon with an internal Celestia Core node.
 
 > Note: Make sure you have at least 100+ Gb of free space to safely install+run
-  the Validator Node.  
+  the Validator Node.
 
-### Install Celestia App
+### Install celestia-app
 
 Follow the tutorial on installing Celestia App [here](../developers/celestia-app.md).
 
-### Setup the P2P Networks
+### Setup the P2P networks
 
 For this section of the guide, select the network you want to connect to:
 
@@ -41,7 +41,7 @@ For this section of the guide, select the network you want to connect to:
 
 After that, you can proceed with the rest of the tutorial.
 
-### Configure Pruning
+### Configure pruning
 
 For lower disk space usage we recommend setting up pruning using the
 configurations below. You can change this to your own pruning configurations
@@ -59,13 +59,13 @@ sed -i -e "s/^pruning-interval *=.*/pruning-interval = \
 \"$PRUNING_INTERVAL\"/" $HOME/.celestia-app/config/app.toml
 ```
 
-### Configure Validator Mode
+### Configure validator mode
 
 ```sh
 sed -i.bak -e "s/^mode *=.*/mode = \"validator\"/" $HOME/.celestia-app/config/config.toml
 ```
 
-### Reset Network
+### Reset network
 
 This will delete all data folders so we can start fresh:
 
@@ -73,7 +73,7 @@ This will delete all data folders so we can start fresh:
 celestia-appd tendermint unsafe-reset-all --home $HOME/.celestia-app
 ```
 
-### Optional: Quick-Sync with Snapshot
+### Optional: quick-sync with snapshot
 
 Syncing from Genesis can take a long time, depending on your hardware. Using
 this method you can synchronize your Celestia node very quickly by downloading
@@ -85,7 +85,7 @@ to from the list below:
 
 * [Mamaki](./mamaki-testnet.md#quick-sync-with-snapshot)
 
-### Start the Celestia-App with SystemD
+### Start the celestia-app with SystemD
 
 Follow the tutorial on setting up Celestia-App as a background process
 with SystemD [here](./systemd.md#start-the-celestia-app-with-systemd).
@@ -94,7 +94,7 @@ with SystemD [here](./systemd.md#start-the-celestia-app-with-systemd).
 
 Follow the tutorial on creating a wallet [here](../developers/wallet.md).
 
-### Delegate Stake to a Validator
+### Delegate stake to a validator
 
 Create an environment variable for the address:
 
@@ -123,16 +123,16 @@ Next, select the network you want to use to delegate to a validator:
 
 * [Mamaki](./mamaki-testnet.md#delegate-to-a-validator)
 
-## Deploy the Celestia Node
+## Deploy the celestia-node
 
 This section describes part 2 of Celestia Validator Node setup: running a
 Celestia Bridge Node daemon.
 
-### Install Celestia Node
+### Install celestia-node
 
 You can follow the tutorial for installing Celestia Node [here](../developers/celestia-node.md)
 
-### Initialize the Bridge Node
+### Initialize the bridge node
 
 Run the following:
 
@@ -143,7 +143,7 @@ celestia bridge init --core.remote <ip:port of celestia-app> \
 
 If you need a list of RPC endpoints to connect to, you can check from the list [here](./mamaki-testnet.md#rpc-endpoints)
 
-### Run the Bridge Node
+### Run the bridge node
 
 Run the following:
 
@@ -151,14 +151,14 @@ Run the following:
 celestia bridge start
 ```
 
-### Optional: Start the Bridge Node with SystemD
+### Optional: start the bridge node with SystemD
 
 Follow the tutorial on setting up the bridge node as a background process with
 SystemD [here](./systemd.md#celestia-bridge-node).
 
 You have successfully set up a bridge node that is syncing with the network.
 
-## Run a Validator Node
+## Run a validator node
 
 After completing all the necessary steps, you are now ready to run a validator!
 In order to create your validator on-chain, follow the instructions below.


### PR DESCRIPTION
I preserved capitalization for H1s where the noun was the sidebar name (ex. `Full Storage Node`, `Bridge Node`, etc.) and sentence cased all other titles (H2+).

Resolves https://github.com/celestiaorg/docs/issues/161