### PR TITLE
Adding protocol to initialize bridge node

### DIFF
--- a/docs/nodes/validator-node.md
+++ b/docs/nodes/validator-node.md
@@ -137,7 +137,7 @@ You can follow the tutorial for installing Celestia Node [here](../developers/ce
 Run the following:
 
 ```sh
-celestia bridge init --core.remote <ip:port of celestia-app> \
+celestia bridge init --core.remote tcp://<ip:port of celestia-app> \
   --core.grpc http://<ip:port>
 ```
 


### PR DESCRIPTION
It is required to add the protocol to the `core.remote` flag else the error returned is `Error: cmd: while parsing 'core.remote': both protocol and host must present in the address`