### PR TITLE
Inconsistencies with golang versions

### DIFF
--- a/docs/developers/node-tutorial.md
+++ b/docs/developers/node-tutorial.md
@@ -52,7 +52,7 @@ Celestia-app and celestia-node are written in [Golang](https://go.dev/)
 so we must install Golang to build and run them.
 
 ```sh
-ver="1.19.1"
+ver="1.18.2"
 cd $HOME
 wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"
 sudo rm -rf /usr/local/go

--- a/docs/nodes/light-node.md
+++ b/docs/nodes/light-node.md
@@ -68,7 +68,7 @@ Celestia-app and celestia-node are written in [Golang](https://go.dev/) so we mu
 install Golang to build and run them.
 
 ```sh
-ver="1.19.1"
+ver="1.18.2"
 cd $HOME
 wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"
 sudo rm -rf /usr/local/go


### PR DESCRIPTION
Fixing golang version inconsistencies on node setup pages from 1.19.1 -> 1.18.2