### PR TITLE
update golang version docs

### DIFF
--- a/docs/developers/node-tutorial.md
+++ b/docs/developers/node-tutorial.md
@@ -76,7 +76,7 @@ go version
 The output should be the version installed:
 
 ```sh
-go version go1.18.2 linux/amd64
+go version go1.19.1 linux/amd64
 ```
 
 ## Celestia Node

--- a/docs/nodes/light-node.md
+++ b/docs/nodes/light-node.md
@@ -92,7 +92,7 @@ go version
 The output should be the version installed:
 
 ```sh
-go version go1.18.2 linux/amd64
+go version go1.19.1 linux/amd64
 ```
 
 ### Install Celestia node


### PR DESCRIPTION
I found incorrect version of golang in node-tutorial/light node page

![image](https://user-images.githubusercontent.com/7926274/196873701-6259713d-5f6e-410a-b2d7-7e6173cacae3.png)
