### PR TITLE
edit mamaki light node start & network switch commands

### DIFF
--- a/docs/developers/celestia-node.mdx
+++ b/docs/developers/celestia-node.mdx
@@ -73,6 +73,9 @@ Commit: 89892d8b96660e334741987d84546c36f0996fbe
 
 ## Network Selection
 
+<Tabs groupId="network">
+<TabItem value="arabica" label="Arabica">
+
 You can perform network selection in celestia-node between Arabica and
 Mamaki. However, you should note that networks work best on the celestia-node
 versions mentioned above.
@@ -81,3 +84,11 @@ versions mentioned above.
 celestia light init
 celestia light start --node.network arabica
 ```
+
+</TabItem>
+<TabItem value="mamaki" label="Mamaki">
+
+Network selection on v0.3.0-rc2 is not available.
+
+</TabItem>
+</Tabs>

--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -523,19 +523,23 @@ an example public Core Endpoint.
 celestia light start --core.ip <IP_address> --core.grpc.port <port>
 ```
 
+> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
+it in the command line, it will default to that port. You can use the flag
+to specify another port if you prefer.
+
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port>
+celestia light start --core.grpc <IP_address>:<port>
 ```
+
+> NOTE: The `--core.grpc` port defaults to 9090, so if you do not specify
+it in the command line, it will default to that port. You can use the flag
+to specify another port if you prefer.
 
 </TabItem>
 </Tabs>
-
-> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
-  it in the command line, it will default to that port. You can use the flag
-  to specify another port if you prefer.
 
 For example, your command along with an RPC endpoint might look like this:
 
@@ -550,7 +554,7 @@ celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.po
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote https://rpc-mamaki.pops.one --core.grpc.port 9090
+celestia light start --core.grpc https://rpc-mamaki.pops.one:9090
 ```
 
 </TabItem>
@@ -578,7 +582,7 @@ celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.ac
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port> --keyring.accname <key_name>
+celestia light start --core.grpc <IP_address>:<port> --keyring.accname <key_name>
 ```
 
 </TabItem>

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -475,12 +475,6 @@ is usually exposed on port 9090):
   account balance, a gRPC endpoint of a validator (core) node must be passed as
   directed below.
 
-For ports:
-
-> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
-  it in the command line, it will default to that port. You can use the flag
-  to specify another port if you prefer.
-
 <Tabs groupId="network">
 <TabItem value="arabica" label="Arabica">
 
@@ -488,12 +482,24 @@ For ports:
 celestia light start --core.ip <IP_address> --core.grpc.port <port>
 ```
 
+For ports:
+
+> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
+  it in the command line, it will default to that port. You can use the flag
+  to specify another port if you prefer.
+
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port>
+celestia light start --core.grpc <IP_address>:<port>
 ```
+
+For ports:
+
+> NOTE: The `--core.grpc` port defaults to 9090, so if you do not specify
+  it in the command line, it will default to that port. You can add the port
+  after the IP address.
 
 </TabItem>
 </Tabs>
@@ -505,11 +511,9 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 
 For example, your command might look something like this:
 
-<!-- markdownlint-disable MD013 -->
 ```sh
 celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090
 ```
-<!-- markdownlint-enable MD013 -->
 
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
@@ -519,7 +523,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.remote https://rpc-mamaki.pops.one --core.grpc.port 9090
+celestia light start --core.grpc https://rpc-mamaki.pops.one:9090
 ```
 
 </TabItem>
@@ -547,7 +551,7 @@ celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.ac
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port> --keyring.accname <key_name>
+celestia light start --core.grpc <IP_address>:<port> --keyring.accname <key_name>
 ```
 
 </TabItem>
@@ -605,7 +609,7 @@ celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.ac
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port> --keyring.accname <name_of_custom_key>
+celestia light start --core.grpc <IP_address>:<port> --keyring.accname <name_of_custom_key>
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/developers/node-tutorial.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/developers/node-tutorial.mdx
@@ -523,19 +523,23 @@ an example public Core Endpoint.
 celestia light start --core.ip <IP_address> --core.grpc.port <port>
 ```
 
+> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
+it in the command line, it will default to that port. You can use the flag
+to specify another port if you prefer.
+
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port>
+celestia light start --core.grpc <IP_address>:<port>
 ```
+
+> NOTE: The `--core.grpc` port defaults to 9090, so if you do not specify
+it in the command line, it will default to that port. You can use the flag
+to specify another port if you prefer.
 
 </TabItem>
 </Tabs>
-
-> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
-  it in the command line, it will default to that port. You can use the flag
-  to specify another port if you prefer.
 
 For example, your command along with an RPC endpoint might look like this:
 
@@ -550,7 +554,7 @@ celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.po
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote https://rpc-mamaki.pops.one --core.grpc.port 9090
+celestia light start --core.grpc https://rpc-mamaki.pops.one:9090
 ```
 
 </TabItem>
@@ -578,7 +582,7 @@ celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.ac
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port> --keyring.accname <key_name>
+celestia light start --core.grpc <IP_address>:<port> --keyring.accname <key_name>
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/nodes/light-node.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/nodes/light-node.mdx
@@ -475,12 +475,6 @@ is usually exposed on port 9090):
   account balance, a gRPC endpoint of a validator (core) node must be passed as
   directed below.
 
-For ports:
-
-> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
-  it in the command line, it will default to that port. You can use the flag
-  to specify another port if you prefer.
-
 <Tabs groupId="network">
 <TabItem value="arabica" label="Arabica">
 
@@ -488,12 +482,24 @@ For ports:
 celestia light start --core.ip <IP_address> --core.grpc.port <port>
 ```
 
+For ports:
+
+> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
+  it in the command line, it will default to that port. You can use the flag
+  to specify another port if you prefer.
+
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port>
+celestia light start --core.grpc <IP_address>:<port>
 ```
+
+For ports:
+
+> NOTE: The `--core.grpc` port defaults to 9090, so if you do not specify
+  it in the command line, it will default to that port. You can add the port
+  after the IP address.
 
 </TabItem>
 </Tabs>
@@ -505,11 +511,9 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 
 For example, your command might look something like this:
 
-<!-- markdownlint-disable MD013 -->
 ```sh
 celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090
 ```
-<!-- markdownlint-enable MD013 -->
 
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
@@ -519,7 +523,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.remote https://rpc-mamaki.pops.one --core.grpc.port 9090
+celestia light start --core.grpc https://rpc-mamaki.pops.one:9090
 ```
 
 </TabItem>
@@ -547,7 +551,7 @@ celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.ac
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port> --keyring.accname <key_name>
+celestia light start --core.grpc <IP_address>:<port> --keyring.accname <key_name>
 ```
 
 </TabItem>
@@ -605,7 +609,7 @@ celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.ac
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port> --keyring.accname <name_of_custom_key>
+celestia light start --core.grpc <IP_address>:<port> --keyring.accname <name_of_custom_key>
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/developers/node-tutorial.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/developers/node-tutorial.mdx
@@ -523,19 +523,23 @@ an example public Core Endpoint.
 celestia light start --core.ip <IP_address> --core.grpc.port <port>
 ```
 
+> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
+it in the command line, it will default to that port. You can use the flag
+to specify another port if you prefer.
+
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port>
+celestia light start --core.grpc <IP_address>:<port>
 ```
+
+> NOTE: The `--core.grpc` port defaults to 9090, so if you do not specify
+it in the command line, it will default to that port. You can use the flag
+to specify another port if you prefer.
 
 </TabItem>
 </Tabs>
-
-> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
-  it in the command line, it will default to that port. You can use the flag
-  to specify another port if you prefer.
 
 For example, your command along with an RPC endpoint might look like this:
 
@@ -550,7 +554,7 @@ celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.po
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote https://rpc-mamaki.pops.one --core.grpc.port 9090
+celestia light start --core.grpc https://rpc-mamaki.pops.one:9090
 ```
 
 </TabItem>
@@ -578,7 +582,7 @@ celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.ac
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port> --keyring.accname <key_name>
+celestia light start --core.grpc <IP_address>:<port> --keyring.accname <key_name>
 ```
 
 </TabItem>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/nodes/light-node.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/nodes/light-node.mdx
@@ -475,12 +475,6 @@ is usually exposed on port 9090):
   account balance, a gRPC endpoint of a validator (core) node must be passed as
   directed below.
 
-For ports:
-
-> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
-  it in the command line, it will default to that port. You can use the flag
-  to specify another port if you prefer.
-
 <Tabs groupId="network">
 <TabItem value="arabica" label="Arabica">
 
@@ -488,12 +482,24 @@ For ports:
 celestia light start --core.ip <IP_address> --core.grpc.port <port>
 ```
 
+For ports:
+
+> NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
+  it in the command line, it will default to that port. You can use the flag
+  to specify another port if you prefer.
+
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port>
+celestia light start --core.grpc <IP_address>:<port>
 ```
+
+For ports:
+
+> NOTE: The `--core.grpc` port defaults to 9090, so if you do not specify
+  it in the command line, it will default to that port. You can add the port
+  after the IP address.
 
 </TabItem>
 </Tabs>
@@ -505,11 +511,9 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 
 For example, your command might look something like this:
 
-<!-- markdownlint-disable MD013 -->
 ```sh
 celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090
 ```
-<!-- markdownlint-enable MD013 -->
 
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
@@ -519,7 +523,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.remote https://rpc-mamaki.pops.one --core.grpc.port 9090
+celestia light start --core.grpc https://rpc-mamaki.pops.one:9090
 ```
 
 </TabItem>
@@ -547,7 +551,7 @@ celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.ac
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port> --keyring.accname <key_name>
+celestia light start --core.grpc <IP_address>:<port> --keyring.accname <key_name>
 ```
 
 </TabItem>
@@ -605,7 +609,7 @@ celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.ac
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.remote <IP_address> --core.grpc.port <port> --keyring.accname <name_of_custom_key>
+celestia light start --core.grpc <IP_address>:<port> --keyring.accname <name_of_custom_key>
 ```
 
 </TabItem>


### PR DESCRIPTION
this PR resolves:
- [x] broken start node commands for mamaki light nodes
- [x] adds note to switch network commands and versioning by tabs