### PR TITLE
add clarification for `cel-key` utility on `nodes/light-node` 

### DIFF
--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -1200,7 +1200,7 @@ After submitting your PFD transaction, upon success, the node will return
 the block height for which the PFD transaction was included. You can then
 use that block height and the namespace ID with which you submitted your
 PFD transaction to get your message shares returned to you. In this example,
-the block height we got was 589 which we will use for the following command.
+the block height we got was 2452 which we will use for the following command.
 
 ```sh
 curl -X GET \

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -405,6 +405,7 @@ git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
 git checkout tags/v0.4.2
 make install
+make cel-key
 ```
 
 Verify that the binary is working and check the version with the `celestia
@@ -434,6 +435,7 @@ git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
 git checkout tags/v0.4.2
 make install
+make cel-key
 ```
 
 Verify that the binary is working and check the version with the `celestia
@@ -463,6 +465,7 @@ git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
 git checkout tags/v0.4.2
 make go-install
+make cel-key
 ```
 
 Verify that the binary is working and check the version with the `celestia
@@ -492,6 +495,7 @@ git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
 git checkout tags/v0.4.2
 make go-install
+make cel-key
 ```
 
 Verify that the binary is working and check the version with the `celestia
@@ -527,6 +531,7 @@ git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
 git checkout tags/v0.3.0-rc2
 make install
+make cel-key
 ```
 
 Verify that the binary is working and check the version with the `celestia
@@ -553,6 +558,7 @@ git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
 git checkout tags/v0.3.0-rc2
 make install
+make cel-key
 ```
 
 Verify that the binary is working and check the version with the `celestia
@@ -579,6 +585,7 @@ git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
 git checkout tags/v0.3.0-rc2
 make go-install
+make cel-key
 ```
 
 Verify that the binary is working and check the version with the `celestia
@@ -605,6 +612,7 @@ git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
 git checkout tags/v0.3.0-rc2
 make go-install
+make cel-key
 ```
 
 Verify that the binary is working and check the version with the `celestia
@@ -705,7 +713,7 @@ celestia light start --core.grpc https://rpc-mamaki.pops.one:9090
 
 ### Keys and wallets
 
-You can create your key for your node by running the following command:
+You can create your key for your node by running the following command with the [`cel-key`](./keys.md) utility:
 
 ```sh
 ./cel-key add <key_name> --keyring-backend test --node.type light


### PR DESCRIPTION
# PULL REQUEST

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->
- [x] add clarification for `cel-key` utility on `nodes/light-node`
- [x] and add `make cel-key` command in instructions on `nodes/light-node` page
- [x] fix height on `developers/node-tutorial`: 589 -> 2452

## Overview

<!-- 
Please provide an explanation of the PR, including the apprioprate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

This PR adds installation commands for `cel-key` on the `nodes/light-node` page of Documentation. It also clarifies that creating keys uses the `cel-key` utility.

Generated from user feedback: `so I have found that you need to make cel-key (https://docs.celestia.org/nodes/keys/#installation) might be worth pointing to this in the Node setup part of the docs as it is not mentioned (https://docs.celestia.org/nodes/light-node/#install-celestia-node)`

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user-facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203328889144160