### PR TITLE
add error workaround for Mamaki

### DIFF
--- a/docs/developers/celestia-node.mdx
+++ b/docs/developers/celestia-node.mdx
@@ -304,5 +304,38 @@ celestia light start --node.network arabica
 
 Network selection on v0.3.0-rc2 is not available.
 
+### Errors
+
+If you an encounter an error, it is likely that an old config file is present:
+
+```sh
+Error: nodebuilder/share: interval must be positive; nodebuilder/core: invalid IP addr given:
+
+# or
+
+Error: nodebuilder/share: interval must be positive
+```
+
+You can re-initialize your node with the following command:
+
+```sh
+rm -rf ~./celestia-light && celestia light init
+```
+
+Your output will look similar to below:
+
+```sh
+@ ~ % rm -rf ./celestia-light-arabica-1 && celestia light init
+2022-11-01T22:23:19.581+0100	INFO	node	nodebuilder/init.go:20	Initializing Light Node Store over '/Users/joshstein/.celestia-light'
+2022-11-01T22:23:19.582+0100	INFO	node	nodebuilder/init.go:51	Saving config	{"path": "/Users/joshstein/.celestia-light/config.toml"}
+2022-11-01T22:23:19.582+0100	INFO	node	nodebuilder/init.go:52	Node Store initialized
+```
+
+Then start your node:
+
+```sh
+celestia light start
+```
+
 </TabItem>
 </Tabs>


### PR DESCRIPTION
# PULL REQUEST

- [x] add error workaround for reinitializing node to Mamaki tabs, previously was only under Arabica
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the apprioprate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

This is a PR to add commands to resolve error when a node needs to be reinitialized for Mamaki

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203328889144183