### PR TITLE
add docker instructions for `celestia-node`

### DIFF
--- a/docs/developers/docker.mdx
+++ b/docs/developers/docker.mdx
@@ -1,0 +1,441 @@
+---
+sidebar_label: Docker Setup
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# 🐳 Docker Setup
+
+This page has installation instructions to run `celestia-node` using Docker. If you are looking for instructions to run `celestia-node` using a binary, please refer to the [Celestia Node](./celestia-node.mdx) page.
+
+Using Docker is the easiest way to run `celestia-node` for most users. Docker is a containerization platform that allows you to run `celestia-node` in an isolated environment. This means that you can run `celestia-node` on your machine without having to worry about installing and configuring all of the dependencies required to run the node.
+
+The easiest way to install Docker is to use the official Docker Desktop installer. You can find the instructions for your operating system [here](https://docs.docker.com/get-docker/).
+
+## Prerequisites
+- [Docker](https://docs.docker.com/get-docker/) and basic understanding of Docker
+
+<Tabs groupId="operating-systems">
+<TabItem value="arabica" label="Arabica">
+
+## Arabica Setup
+
+<Tabs groupId="node-type">
+<TabItem value="light" label="Light Node">
+
+First, create a new directory `Dockerfiles` and create a new `Dockerfile` in your root directory with the file below:
+
+```dockerfile
+FROM alpine:latest
+FROM golang:1.19.1-alpine
+ 
+COPY --from=golang:1.19.1-alpine /usr/local/go/ /usr/local/go/
+ 
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN apk update
+RUN apk add curl tar wget clang pkgconfig libressl-dev jq alpine-sdk bash 
+RUN rm -rf celestia-node && git clone https://github.com/celestiaorg/celestia-node.git && cd celestia-node && git checkout tags/v0.4.2 && make install && make cel-key && celestia light init
+CMD celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090
+```
+
+Then `cd` into your new directory with the following command:
+
+```bash
+cd Dockerfiles
+```
+
+Then, build the image using the following command:
+
+```bash
+docker build -t yourname/arabica-node .
+```
+
+Lastly, run the image using the following command:
+
+```bash
+docker run -d -p 9090:26658 --name arabica-light yourname/arabica-node
+```
+
+---
+
+### Following Logs
+
+To follow the logs of the container, use the following command:
+
+```bash
+docker logs --follow arabica-light
+```
+
+---
+
+### Stopping the Container
+
+In the case where you want to stop the node (and container), use the following command:
+
+```bash
+docker stop arabica-light
+```
+
+---
+
+### Removing the Container
+
+If you would like to delete the container, use the following command:
+
+```bash
+docker rm arabica-light
+````
+
+</TabItem>
+
+<TabItem value="full" label="Full Node">
+
+First, create a new directory `Dockerfiles` and create a new `Dockerfile` in your root directory with the file below:
+
+```dockerfile
+FROM alpine:latest
+FROM golang:1.19.1-alpine
+ 
+COPY --from=golang:1.19.1-alpine /usr/local/go/ /usr/local/go/
+ 
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN apk update
+RUN apk add curl tar wget clang pkgconfig libressl-dev jq alpine-sdk bash 
+RUN rm -rf celestia-node && git clone https://github.com/celestiaorg/celestia-node.git && cd celestia-node && git checkout tags/v0.4.2 && make install && make cel-key && celestia full init
+CMD celestia full start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090
+```
+
+Then `cd` into your new directory with the following command:
+
+```bash
+cd Dockerfiles
+```
+
+Then, build the image using the following command:
+
+```bash
+docker build -t yourname/arabica-node .
+```
+
+Lastly, run the image using the following command:
+
+```bash
+docker run -d -p 9090:26658 --name arabica-full yourname/arabica-node
+```
+
+---
+
+### Following Logs
+
+To follow the logs of the container, use the following command:
+
+```bash
+docker logs --follow arabica-full
+```
+
+---
+
+### Stopping the Container
+
+In the case where you want to stop the node (and container), use the following command:
+
+```bash
+docker stop arabica-full
+```
+
+---
+
+### Removing the Container
+
+If you would like to delete the container, use the following command:
+
+```bash
+docker rm arabica-full
+````
+
+</TabItem>
+
+<TabItem value="bridge" label="Bridge Node">
+
+First, create a new directory `Dockerfiles` and create a new `Dockerfile` in your root directory with the file below:
+
+```dockerfile
+FROM alpine:latest
+FROM golang:1.19.1-alpine
+ 
+COPY --from=golang:1.19.1-alpine /usr/local/go/ /usr/local/go/
+ 
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN apk update
+RUN apk add curl tar wget clang pkgconfig libressl-dev jq alpine-sdk bash 
+RUN rm -rf celestia-node && git clone https://github.com/celestiaorg/celestia-node.git && cd celestia-node && git checkout tags/v0.4.2 && make install && make cel-key && celestia bridge init
+CMD celestia bridge start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090
+```
+
+Then `cd` into your new directory with the following command:
+
+```bash
+cd Dockerfiles
+```
+
+Then, build the image using the following command:
+
+```bash
+docker build -t yourname/arabica-node .
+```
+
+Lastly, run the image using the following command:
+
+```bash
+docker run -d -p 9090:26658 --name arabica-bridge yourname/arabica-node
+```
+
+---
+
+### Following Logs
+
+To follow the logs of the container, use the following command:
+
+```bash
+docker logs --follow arabica-bridge
+```
+
+---
+
+### Stopping the Container
+
+In the case where you want to stop the node (and container), use the following command:
+
+```bash
+docker stop arabica-bridge
+```
+
+---
+
+### Removing the Container
+
+If you would like to delete the container, use the following command:
+
+```bash
+docker rm arabica-bridge
+````
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="mamaki" label="Mamaki">
+
+## Mamaki Setup
+
+<Tabs groupId="node-type">
+<TabItem value="light" label="Light Node">
+
+First, create a new directory `Dockerfiles` and create a new `Dockerfile` in your root directory with the file below:
+
+```dockerfile
+FROM alpine:latest
+FROM golang:1.18.2-alpine
+ 
+COPY --from=golang:1.18.2-alpine /usr/local/go/ /usr/local/go/
+ 
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN apk update
+RUN apk add curl tar wget clang pkgconfig libressl-dev jq alpine-sdk bash 
+RUN rm -rf celestia-node && git clone https://github.com/celestiaorg/celestia-node.git && cd celestia-node && git checkout tags/v0.3.0-rc2 && make install && make cel-key && celestia light init 
+CMD celestia light start --core.grpc https://rpc-mamaki.pops.one:9090
+```
+
+Then `cd` into your new directory with the following command:
+
+```bash
+cd Dockerfiles
+```
+
+Then, build the image using the following command:
+
+```bash
+docker build -t yourname/mamaki-node .
+```
+
+Lastly, run the image using the following command:
+
+```bash
+docker run -d -p 9090:26658 --name mamaki-light yourname/mamaki-node
+```
+
+---
+
+### Following Logs
+
+To follow the logs of the container, use the following command:
+
+```bash
+docker logs --follow mamaki-light
+```
+
+---
+
+### Stopping the Container
+In the case where you want to stop the node (and container), use the following command:
+
+```bash
+docker stop mamaki-light
+```
+
+---
+
+### Removing the Container
+
+If you would like to delete the container, use the following command:
+
+```bash
+docker rm mamaki-light
+````
+
+</TabItem>
+
+<TabItem value="full" label="Full Node">
+
+First, create a new directory `Dockerfiles` and create a new `Dockerfile` in your root directory with the file below:
+
+```dockerfile
+FROM alpine:latest
+FROM golang:1.18.2-alpine
+ 
+COPY --from=golang:1.18.2-alpine /usr/local/go/ /usr/local/go/
+ 
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN apk update
+RUN apk add curl tar wget clang pkgconfig libressl-dev jq alpine-sdk bash 
+RUN rm -rf celestia-node && git clone https://github.com/celestiaorg/celestia-node.git && cd celestia-node && git checkout tags/v0.3.0-rc2 && make install && make cel-key && celestia full init 
+CMD celestia full start --core.grpc https://rpc-mamaki.pops.one:9090
+```
+
+Then `cd` into your new directory with the following command:
+
+```bash
+cd Dockerfiles
+```
+
+Then, build the image using the following command:
+
+```bash
+docker build -t yourname/mamaki-node .
+```
+
+Lastly, run the image using the following command:
+
+```bash
+docker run -d -p 9090:26658 --name mamaki-full yourname/mamaki-node
+```
+
+---
+
+### Following Logs
+
+To follow the logs of the container, use the following command:
+
+```bash
+docker logs --follow mamaki-full
+```
+
+---
+
+### Stopping the Container
+
+In the case where you want to stop the node (and container), use the following command:
+
+```bash
+docker stop mamaki-full
+```
+
+---
+
+### Removing the Container
+
+If you would like to delete the container, use the following command:
+
+```bash
+docker rm mamaki-full
+````
+
+</TabItem>
+
+<TabItem value="bridge" label="Bridge Node">
+
+First, create a new directory `Dockerfiles` and create a new `Dockerfile` in your root directory with the file below:
+
+```dockerfile
+FROM alpine:latest
+FROM golang:1.18.2-alpine
+ 
+COPY --from=golang:1.18.2-alpine /usr/local/go/ /usr/local/go/
+ 
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN apk update
+RUN apk add curl tar wget clang pkgconfig libressl-dev jq alpine-sdk bash 
+RUN rm -rf celestia-node && git clone https://github.com/celestiaorg/celestia-node.git && cd celestia-node && git checkout tags/v0.3.0-rc2 && make install && make cel-key && celestia bridge init
+CMD celestia bridge start --core.grpc https://rpc-mamaki.pops.one:9090 --core.remote tcp://rpc-mamaki.pops.one:26657
+```
+
+Then `cd` into your new directory with the following command:
+
+```bash
+cd Dockerfiles
+```
+
+Then, build the image using the following command:
+
+```bash
+docker build -t yourname/mamaki-node .
+```
+
+Lastly, run the image using the following command:
+
+```bash
+docker run -d -p 9090:26658 --name mamaki-bridge yourname/mamaki-node
+```
+
+---
+
+### Following Logs
+
+To follow the logs of the container, use the following command:
+
+```bash
+docker logs --follow mamaki-bridge
+```
+
+---
+
+### Stopping the Container
+
+In the case where you want to stop the node (and container), use the following command:
+
+```bash
+docker stop mamaki-bridge
+```
+
+---
+
+### Removing the Container
+
+If you would like to delete the container, use the following command:
+
+```bash
+docker rm mamaki-bridge
+````
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>

--- a/sidebars.js
+++ b/sidebars.js
@@ -190,7 +190,12 @@ const sidebars = {
           type: "doc", 
           label: "Node API", 
           id: "developers/node-api" 
-        }
+        },
+        { 
+          type: "doc", 
+          label: "Docker Setup", 
+          id: "developers/docker" 
+        },
       ]
     },
     {


### PR DESCRIPTION
# PULL REQUEST
 This adds instructions to run Docker `celestia-node` containers.
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
 - [x] Dockerfiles and instructions for light, full, bridge node on Mamaki & Arabica 
<!-- 
Please provide an explanation of the PR, including the apprioprate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
