### PR TITLE
add back `--gateway` flags with no args

### DIFF
--- a/docs/developers/celestia-node-metrics.md
+++ b/docs/developers/celestia-node-metrics.md
@@ -19,7 +19,7 @@ command:
 
 <!-- markdownlint-disable MD013 -->
 ```sh
-celestia light start --core.ip <ip-address> --core.grpc.port <port> --metrics --metrics.endpoint <ip-address:port> --gateway.addr <ip-address> --gateway.port <port>
+celestia light start --core.ip <ip-address> --core.grpc.port <port> --metrics --metrics.endpoint <ip-address:port> --gateway --gateway.addr <ip-address> --gateway.port <port>
 ```
 <!-- markdownlint-enable MD013 -->
 

--- a/docs/developers/instantiate-testnet.md
+++ b/docs/developers/instantiate-testnet.md
@@ -145,7 +145,7 @@ include other participants as persistent peers:
 
 ```text
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "[validator_address]@[ip-address]:[port],[validator_address]@[ip-address]:[port]"
+persistent_peers = "[validator_address]@[ip_address]:[port],[validator_address]@[ip_address]:[port]"
 ```
 
 You can find `validator_address` by running the following command:

--- a/docs/developers/instantiate-testnet.md
+++ b/docs/developers/instantiate-testnet.md
@@ -145,7 +145,7 @@ include other participants as persistent peers:
 
 ```text
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "[validator_address]@[ip_address]:[port],[validator_address]@[ip_address]:[port]"
+persistent_peers = "[validator_address]@[ip-address]:[port],[validator_address]@[ip-address]:[port]"
 ```
 
 You can find `validator_address` by running the following command:

--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -650,7 +650,7 @@ to specify another port if you prefer.
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.grpc <IP_address>:<port>
+celestia light start --core.grpc <ip-address>:<port>
 ```
 
 > NOTE: The `--core.grpc` port defaults to 9090, so if you do not specify
@@ -694,14 +694,14 @@ following command:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.accname <key_name> --gateway --gateway.addr localhost --gateway.port 26659
+celestia light start --core.ip <ip-address> --core.grpc.port <port> --keyring.accname <key_name> --gateway --gateway.addr localhost --gateway.port 26659
 ```
 
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.grpc <IP_address>:<port> --keyring.accname <key_name>
+celestia light start --core.grpc <ip-address>:<port> --keyring.accname <key_name>
 ```
 
 </TabItem>

--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -639,7 +639,7 @@ an example public Core Endpoint.
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <ip-address> --core.grpc.port <port> --gateway.addr <ip-address> --gateway.port <port>
+celestia light start --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port>
 ```
 
 > NOTE: The `--core.grpc.port` defaults to 9090, so if you do not specify
@@ -666,7 +666,7 @@ For example, your command along with an RPC endpoint might look like this:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090 --gateway.addr localhost --gateway.port 26659
+celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090 --gateway --gateway.addr localhost --gateway.port 26659
 ```
 
 </TabItem>
@@ -694,7 +694,7 @@ following command:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.accname <key_name> --gateway.addr localhost --gateway.port 26659
+celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.accname <key_name> --gateway --gateway.addr localhost --gateway.port 26659
 ```
 
 </TabItem>

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -662,7 +662,7 @@ is usually exposed on port 9090):
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <IP_address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port>
+celestia light start --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port>
 ```
 
 For ports:
@@ -675,7 +675,7 @@ For ports:
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.grpc <IP_address>:<port>
+celestia light start --core.grpc <ip-address>:<port>
 ```
 
 For ports:
@@ -783,14 +783,14 @@ In order to run a light node using a custom key:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port>
+celestia light start --core.ip <ip-address> --core.grpc.port <port> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port>
 ```
 
 </TabItem>
 <TabItem value="mamaki" label="Mamaki">
 
 ```sh
-celestia light start --core.grpc <IP_address>:<port> --keyring.accname <name_of_custom_key>
+celestia light start --core.grpc <ip-address>:<port> --keyring.accname <name_of_custom_key>
 ```
 
 </TabItem>

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -662,7 +662,7 @@ is usually exposed on port 9090):
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <IP_address> --core.grpc.port <port> --gateway.addr <ip-address> --gateway.port <port>
+celestia light start --core.ip <IP_address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port>
 ```
 
 For ports:
@@ -695,7 +695,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090 --gateway.addr localhost --gateway.port 26659
+celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090 --gateway --gateway.addr localhost --gateway.port 26659
 ```
 
 </TabItem>
@@ -727,7 +727,7 @@ following command:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --keyring.accname <key_name> --core.ip <ip-address> --core.grpc.port <port> --gateway.addr <ip-address> --gateway.port <port>
+celestia light start --keyring.accname <key_name> --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port>
 ```
 
 </TabItem>
@@ -783,7 +783,7 @@ In order to run a light node using a custom key:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.accname <name_of_custom_key> --gateway.addr <ip-address> --gateway.port <port>
+celestia light start --core.ip <IP_address> --core.grpc.port <port> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port>
 ```
 
 </TabItem>


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

I may have broken this (on the docs) when I [removed](https://github.com/celestiaorg/docs/pull/317/commits/f0f563aa5cafe705e0a485b9760e1a28b38e685b) these flags 😬 . just reverted changes in this PR
- [x] add back `--gateway` flag
- [x] standardize "ip-address" across docs

<!-- 
Please provide an explanation of the PR, including the apprioprate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
