### PR TITLE
Fix: Remove zh due to encoding bugs, update cleanup script

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -2,3 +2,9 @@
 cd i18n
 find . -type f -name "*.md" -exec sed -i 's/- - -/---/g' {} +
 find . -type f -name "*.mdx" -exec sed -i 's/- - -/---/g' {} +
+find . -type f -name "*.md" -exec sed -i 's/“/"/g' {} +
+find . -type f -name "*.mdx" -exec sed -i 's/“/"/g' {} +
+find . -type f -name "*.md" -exec sed -i 's/”/"/g' {} +
+find . -type f -name "*.mdx" -exec sed -i 's/”/"/g' {} +
+find . -type f -name "*.md" -exec sed -i 's/：/:/g' {} +
+find . -type f -name "*.mdx" -exec sed -i 's/：/:/g' {} +

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,6 +8,5 @@ files:
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
 export_languages:
   - fr
-  - zh
   - ru
   - es

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,7 +76,7 @@ const config = {
   ],
   i18n: {
     defaultLocale: "en",
-    locales: ["en", "fr", "zh", "ru", "es"],
+    locales: ["en", "fr", "ru", "es"],
   },
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */


### PR DESCRIPTION
Removes zh language due to encoding issue, updates cleanup script to fix known encoding issues, and waiting on fixes from chinese community before retesting doc build with zh