### PR TITLE
Fixing block size typo

### DIFF
--- a/docs/concepts/how-celestia-works/data-availability-layer.md
+++ b/docs/concepts/how-celestia-works/data-availability-layer.md
@@ -63,7 +63,7 @@ feasible for resource-limited light nodes. However, in order to validate
 block headers, Celestia light nodes need to download the 4k intermediate
 Merkle roots.
 
-For a block data size of n bytes, this means that every light node must
+For a block data size of $n^2$ bytes, this means that every light node must
 download O(n) bytes. Therefore, any improvement in the bandwidth capacity
 of Celestia light nodes has a quadratic effect on the throughput of Celestia's
 DA layer.


### PR DESCRIPTION
I think the block size in bytes is misquoted in the docs, because k x k chunks = O(k^2) bytes
