### PR TITLE
Missing installation steps

### DIFF
--- a/docs/developers/gm-query.md
+++ b/docs/developers/gm-query.md
@@ -134,6 +134,18 @@ func (k Keeper) Gm(goCtx context.Context, req *types.QueryGmRequest) (*types.Que
 <!-- markdownlint-enable MD010 -->
 <!-- markdownlint-enable MD013 -->
 
+## Install your Sovereign Rollup
+We need to build the app before running it in the next section:
+```
+cd cmd/gmd
+go install .
+cd -
+```
+You might also need to add GOPATH to your PATH to be able to run gmd:
+```
+export PATH=$PATH:$(go env GOPATH)
+```
+
 ## 🟢 Start your Sovereign Rollup
 
 We have a handy `init.sh` found in this repo


### PR DESCRIPTION
The ignite cli app installs the runs the app for us when we run `ignite chain serve`. However, we are not starting the app via ignite here. So we need to add steps to build gmd before the `init.sh` script can call it.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
