### PR TITLE
docs: update wordle-key from recipe-key to match init.sh

### DIFF
--- a/docs/developers/run-wordle.md
+++ b/docs/developers/run-wordle.md
@@ -48,7 +48,7 @@ With that, we have kickstarted our `wordled` network!
 In another window, run the following to submit a Wordle:
 
 ```sh
-wordled tx wordle submit-wordle giant --from recipes-key --keyring-backend test --chain-id wordle -b async -y
+wordled tx wordle submit-wordle giant --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 
 > NOTE: We are submitting a transaction asynchronously due to avoiding
@@ -139,7 +139,7 @@ This should display an output like the following:
 Test out a few things for fun:
 
 ```sh
-wordled tx wordle submit-guess 12345 --from recipes-key --keyring-backend test --chain-id wordle -b async -y
+wordled tx wordle submit-guess 12345 --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 
 After confirming the transaction, query the `txhash`
@@ -149,7 +149,7 @@ an Invalid Error because you submitted integers.
 Now try:
 
 ```sh
-wordled tx wordle submit-guess ABCDEFG --from recipes-key --keyring-backend test --chain-id wordle -b async -y
+wordled tx wordle submit-guess ABCDEFG --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 
 After confirming the transaction, query the `txhash` given the same
@@ -159,7 +159,7 @@ an Invalid Error because you submitted a word larger than 5 characters.
 Now try to submit another wordle even though one was already submitted
 
 ```sh
-wordled tx wordle submit-wordle meter --from recipes-key --keyring-backend test --chain-id wordle -b async -y
+wordled tx wordle submit-wordle meter --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 
 After submitting the transactions and confirming, query the `txhash`
@@ -169,12 +169,12 @@ has already been submitted for the day.
 Now let’s try to guess a five letter word:
 
 ```sh
-wordled tx wordle submit-guess least --from recipes-key --keyring-backend test --chain-id wordle -b async -y
+wordled tx wordle submit-guess least --from wordle-key --keyring-backend test --chain-id wordle -b async -y
 ```
 
 After submitting the transactions and confirming, query the `txhash`
 given the same way you did above. Given you didn’t guess the correct
-word, it will increment the guess count for recipes-key's account.
+word, it will increment the guess count for wordle-key's account.
 
 We can verify this by querying the list:
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
This fixes a mistake in key name in commands for the Wordle tutorial. Previously, it had `recipes-key` but needs to be `wordle-key` to match the `init.sh` script.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
