### PR TITLE
docs: remove unnecessary port on RPC URL

### DIFF
--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -711,7 +711,7 @@ celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.po
 <TabItem value="mocha" label="Mocha">
 
 ```sh
-celestia light start --core.ip https://rpc-mocha.pops.one:9090 --core.grpc.port 9090 --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
+celestia light start --core.ip https://rpc-mocha.pops.one --core.grpc.port 9090 --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 ```
 
 </TabItem>

--- a/docs/nodes/bridge-node.mdx
+++ b/docs/nodes/bridge-node.mdx
@@ -118,7 +118,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 Here is an example of initializing the bridge node:
 
 ```sh
-celestia bridge init --core.ip https://rpc-mocha.pops.one:9090
+celestia bridge init --core.ip https://rpc-mocha.pops.one
 ```
 
 </TabItem>

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -754,7 +754,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.ip https://rpc-mocha.pops.one:9090 --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
+celestia light start --core.ip https://rpc-mocha.pops.one --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
 ```
 
 </TabItem>


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Removes an unnecessary port from older versions of `celestia-node`. There is a note in the docs for the port already, if the user uses a custom RPC, etc.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
