### PR TITLE
update: fix p2p network label for 0.6.1 arabica

### DIFF
--- a/docs/developers/celestia-node-key.mdx
+++ b/docs/developers/celestia-node-key.mdx
@@ -60,7 +60,7 @@ import TabItem from '@theme/TabItem';
 To generate a key for a Celestia bridge node, do the following:
 
 ```sh
-./cel-key add <key-name> --keyring-backend test --node.type bridge
+./cel-key add <key-name> --keyring-backend test --node.type bridge --p2p.network <network>
 ```
 
 This will load the key `<key-name>` into the directory of the bridge node.
@@ -71,7 +71,7 @@ This will load the key `<key-name>` into the directory of the bridge node.
 To generate a key for a Celestia full node, do the following:
 
 ```sh
-./cel-key add <key-name> --keyring-backend test --node.type full
+./cel-key add <key-name> --keyring-backend test --node.type full --p2p.network <network>
 ```
 
 This will load the key `<key-name>` into the directory of the full node.
@@ -83,7 +83,7 @@ This will load the key `<key-name>` into the directory of the full node.
 To generate a key for a Celestia light node, do the following:
 
 ```sh
-./cel-key add <key-name> --keyring-backend test --node.type light
+./cel-key add <key-name> --keyring-backend test --node.type light --p2p.network <network>
 ```
 
 This will load the key `<key-name>` into the directory of the light node.
@@ -116,7 +116,7 @@ the default one will always be `mocha`.
 You can export a private key from the local keyring in encrypted and ASCII-armored format.
 
 ```sh
-./cel-key export <key-name> --keyring-backend test --node.type bridge
+./cel-key export <key-name> --keyring-backend test --node.type bridge --p2p.network <network>
 ```
 
 You can then import your key with `celestia-appd`:
@@ -132,7 +132,7 @@ celestia-appd keys import <new-key-name>
 You can export a private key from the local keyring in encrypted and ASCII-armored format.
 
 ```sh
-./cel-key export <key-name> --keyring-backend test --node.type full
+./cel-key export <key-name> --keyring-backend test --node.type full --p2p.network <network>
 ```
 
 You can then import your key with `celestia-appd`:
@@ -148,7 +148,7 @@ celestia-appd keys import <new-key-name>
 You can export a private key from the local keyring in encrypted and ASCII-armored format.
 
 ```sh
-./cel-key export <key-name> --keyring-backend test --node.type light
+./cel-key export <key-name> --keyring-backend test --node.type light --p2p.network <network>
 ```
 
 You can then import your key with `celestia-appd`:
@@ -171,7 +171,7 @@ celestia-appd keys import <new-key-name>
 Importing from a mnemonic:
 
 ```sh
-./cel-key add <key-name> --recover --keyring-backend test --node.type bridge
+./cel-key add <key-name> --recover --keyring-backend test --node.type bridge --p2p.network <network>
 ```
 
 You will then be prompted to enter your bip39 mnemonic.
@@ -179,7 +179,7 @@ You will then be prompted to enter your bip39 mnemonic.
 Example:
 
 ```sh
-./cel-key add alice --recover --keyring-backend test --node.type bridge
+./cel-key add alice --recover --keyring-backend test --node.type bridge --p2p.network <network>
 ```
 
 </TabItem>
@@ -188,7 +188,7 @@ Example:
 Importing from a mnemonic:
 
 ```sh
-./cel-key add <key-name> --recover --keyring-backend test --node.type full
+./cel-key add <key-name> --recover --keyring-backend test --node.type full --p2p.network <network>
 ```
 
 You will then be prompted to enter your bip39 mnemonic.
@@ -196,7 +196,7 @@ You will then be prompted to enter your bip39 mnemonic.
 Example:
 
 ```sh
-./cel-key add alice --recover --keyring-backend test --node.type full
+./cel-key add alice --recover --keyring-backend test --node.type full --p2p.network <network>
 ```
 
 </TabItem>
@@ -205,7 +205,7 @@ Example:
 Importing from a mnemonic:
 
 ```sh
-./cel-key add <key-name> --recover --keyring-backend test --node.type light
+./cel-key add <key-name> --recover --keyring-backend test --node.type light --p2p.network <network>
 ```
 
 You will then be prompted to enter your bip39 mnemonic.
@@ -213,7 +213,7 @@ You will then be prompted to enter your bip39 mnemonic.
 Example:
 
 ```sh
-./cel-key add alice --recover --keyring-backend test --node.type light
+./cel-key add alice --recover --keyring-backend test --node.type light --p2p.network <network>
 ```
 
 </TabItem>
@@ -229,7 +229,9 @@ $ ./cel-key --help
 Keyring management commands. These keys may be in any format supported by the
 Tendermint crypto library and can be used by light-clients, full nodes, or any other application
 that needs to sign with a private key.
+
 The keyring supports the following backends:
+
     os          Uses the operating system's default credentials store.
     file        Uses encrypted file-based keystore within the app's configuration directory.
                 This keyring will request a password each time it is accessed, which may occur
@@ -238,13 +240,17 @@ The keyring supports the following backends:
     pass        Uses the pass command line utility to store and retrieve keys.
     test        Stores keys insecurely to disk. It does not prompt for a password to be unlocked
                 and it should be use only for testing purposes.
+
 kwallet and pass backends depend on external tools. Refer to their respective documentation for more
 information:
     KWallet     https://github.com/KDE/kwallet
     pass        https://www.passwordstore.org/
+
 The pass backend requires GnuPG: https://gnupg.org/
+
 Usage:
   keys [command]
+
 Available Commands:
   add         Add an encrypted private key (either newly generated or recovered), encrypt it, and save to <name> file
   completion  Generate the autocompletion script for the specified shell
@@ -258,13 +264,15 @@ Available Commands:
   parse       Parse address from hex to bech32 and vice versa
   rename      Rename an existing key
   show        Retrieve key information by name or address
+
 Flags:
   -h, --help                     help for keys
       --home string              The application home directory (default "~")
       --keyring-backend string   Select keyring's backend (os|file|test) (default "os")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
-      --node.network string      Sets key utility to use the node network's directory (e.g. ~/.celestia-light-mynetwork if --node.network MyNetwork is passed). (default "arabica-1")
-      --node.type string         Sets key utility to use the node type's directory (e.g. ~/.celestia-light-arabica-1 if --node.type light is passed).
+      --node.type string         Sets key utility to use the node type's directory (e.g. ~/.celestia-light-mocha if --node.type light is passed).
       --output string            Output format (text|json) (default "text")
+      --p2p.network string       Sets key utility to use the node network's directory (e.g. ~/.celestia-light-mynetwork if --node.network MyNetwork is passed). (default "mocha")
+
 Use "keys [command] --help" for more information about a command.
 ```

--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -722,7 +722,7 @@ celestia light start --core.ip https://rpc-mocha.pops.one --core.grpc.port 9090 
 You can create your key for your node by running the following command:
 
 ```sh
-./cel-key add <key_name> --keyring-backend test --node.type light
+./cel-key add <key_name> --keyring-backend test --node.type light --p2p.network <network>
 ```
 
 You can start your light node with the key created above by running the
@@ -754,7 +754,7 @@ You can find the address by running the following command in
 the `celestia-node` directory:
 
 ```sh
-./cel-key list --node.type light --keyring-backend test
+./cel-key list --node.type light --keyring-backend test --p2p.network <network>
 ```
 
 If you would like to fund your wallet with testnet tokens, head over

--- a/docs/nodes/bridge-node.mdx
+++ b/docs/nodes/bridge-node.mdx
@@ -184,7 +184,7 @@ PayForData transactions.
 You can find the address by running the following command:
 
 ```sh
-./cel-key list --node.type bridge --keyring-backend test
+./cel-key list --node.type bridge --keyring-backend test --p2p.network <network>
 ```
 
 You have two networks to get testnet tokens from:

--- a/docs/nodes/full-storage-node.mdx
+++ b/docs/nodes/full-storage-node.mdx
@@ -110,7 +110,7 @@ PayForData transactions.
 You can find the address by running the following command:
 
 ```sh
-./cel-key list --node.type full --keyring-backend test
+./cel-key list --node.type full --keyring-backend test --p2p.network <network>
 ```
 
 You have two networks to get testnet tokens from:

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -660,13 +660,13 @@ Run the following command:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light init --p2p.network arabica
+celestia light init --p2p.network arabica-2
 ```
 
 You should see output like:
 
 ```output
-$ celestia light init --p2p.network arabica
+$ celestia light init --p2p.network arabica-2
 2022-12-19T21:45:00.802Z        INFO    node    nodebuilder/init.go:19  Initializing Light Node Store over '/root/.celestia-light-arabica-2'
 2022-12-19T21:45:00.803Z        INFO    node    nodebuilder/init.go:50  Saving config   {"path": "/root/.celestia-light-arabica-2/config.toml"}
 2022-12-19T21:45:00.803Z        INFO    node    nodebuilder/init.go:51  Node Store initialized
@@ -708,7 +708,7 @@ is usually exposed on port 9090):
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
+celestia light start --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica-2
 ```
 
 For ports:
@@ -743,7 +743,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090 --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
+celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090 --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica-2
 ```
 
 </TabItem>
@@ -765,8 +765,10 @@ celestia light start --core.ip https://rpc-mocha.pops.one --core.grpc.port <port
 You can create your key for your node by running the following command with the [`cel-key`](../developers/celestia-node-key) utility:
 
 ```sh
-./cel-key add <key_name> --keyring-backend test --node.type light
+./cel-key add <key_name> --keyring-backend test --node.type light --p2p.network <p2p_network>
 ```
+
+For `arabica`, if you are on `0.6.1`, make sure to use `--p2p.network arabica-2` when generating your keys.
 
 You can start your light node with the key created above by running the
 following command:
@@ -775,7 +777,7 @@ following command:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --keyring.accname <key_name> --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
+celestia light start --keyring.accname <key_name> --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica-2
 ```
 
 </TabItem>
@@ -831,7 +833,7 @@ In order to run a light node using a custom key:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <ip-address> --core.grpc.port <port> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
+celestia light start --core.ip <ip-address> --core.grpc.port <port> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica-2
 ```
 
 </TabItem>

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -765,7 +765,7 @@ celestia light start --core.ip https://rpc-mocha.pops.one --core.grpc.port <port
 You can create your key for your node by running the following command with the [`cel-key`](../developers/celestia-node-key) utility:
 
 ```sh
-./cel-key add <key_name> --keyring-backend test --node.type light --p2p.network <p2p_network>
+./cel-key add <key_name> --keyring-backend test --node.type light --p2p.network <network>
 ```
 
 For `arabica`, if you are on `0.6.1`, make sure to use `--p2p.network arabica-2` when generating your keys.
@@ -798,7 +798,7 @@ You can find the address by running the following command in the
 `celestia-node` directory:
 
 ```sh
-./cel-key list --node.type light --keyring-backend test
+./cel-key list --node.type light --keyring-backend test --p2p.network <network>
 ```
 
 You have two networks to get testnet tokens from:

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -660,13 +660,13 @@ Run the following command:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light init --p2p.network arabica-2
+celestia light init --p2p.network arabica
 ```
 
 You should see output like:
 
 ```output
-$ celestia light init --p2p.network arabica-2
+$ celestia light init --p2p.network arabica
 2022-12-19T21:45:00.802Z        INFO    node    nodebuilder/init.go:19  Initializing Light Node Store over '/root/.celestia-light-arabica-2'
 2022-12-19T21:45:00.803Z        INFO    node    nodebuilder/init.go:50  Saving config   {"path": "/root/.celestia-light-arabica-2/config.toml"}
 2022-12-19T21:45:00.803Z        INFO    node    nodebuilder/init.go:51  Node Store initialized
@@ -708,7 +708,7 @@ is usually exposed on port 9090):
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica-2
+celestia light start --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
 ```
 
 For ports:
@@ -743,7 +743,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090 --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica-2
+celestia light start --core.ip https://limani.celestia-devops.dev --core.grpc.port 9090 --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
 ```
 
 </TabItem>
@@ -768,7 +768,7 @@ You can create your key for your node by running the following command with the 
 ./cel-key add <key_name> --keyring-backend test --node.type light --p2p.network <network>
 ```
 
-For `arabica`, if you are on `0.6.1`, make sure to use `--p2p.network arabica-2` when generating your keys.
+For `arabica`, if you are on `0.6.1`, make sure to use `--p2p.network arabica` when generating your keys.
 
 You can start your light node with the key created above by running the
 following command:
@@ -777,7 +777,7 @@ following command:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --keyring.accname <key_name> --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica-2
+celestia light start --keyring.accname <key_name> --core.ip <ip-address> --core.grpc.port <port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
 ```
 
 </TabItem>
@@ -833,7 +833,7 @@ In order to run a light node using a custom key:
 <TabItem value="arabica" label="Arabica">
 
 ```sh
-celestia light start --core.ip <ip-address> --core.grpc.port <port> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica-2
+celestia light start --core.ip <ip-address> --core.grpc.port <port> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
 ```
 
 </TabItem>


### PR DESCRIPTION
## Overview

This PR changes a few commands to use `arabica-2` when wanting to run against arabica using `0.6.1`, commands include:

- init command
- key generation command
- start command

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
