### PR TITLE
Update Keyring Backends with `celestia-node` PR #1565

### DIFF
--- a/docs/developers/celestia-node-key.mdx
+++ b/docs/developers/celestia-node-key.mdx
@@ -48,6 +48,15 @@ make install-key
 
 For the purpose of this guide, we will use the `make cel-key` command.
 
+### `keyring-backend` usage
+
+`keyring-backend` configures the keyring's backend, where the keys are stored.
+
+Supported options are: `file` and `test`. The default used in Celestia's documentation is `test`.
+
+You can learn more about the keyring on the [Cosmos documentation](https://docs.cosmos.network/main/run-node/keyring.html)
+or [Go Package documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk/crypto/keyring).
+
 ### Steps for generating node keys
 
 ````mdx-code-block

--- a/docs/developers/celestia-node-key.mdx
+++ b/docs/developers/celestia-node-key.mdx
@@ -52,7 +52,7 @@ For the purpose of this guide, we will use the `make cel-key` command.
 
 `keyring-backend` configures the keyring's backend, how the keys are stored.
 
-Supported options are: `file` and `test`. The default used in Celestia's documentation is `test`.
+Fully supported options are: `file` and `test`. Other options are also available to use at user's discretion. The default used in `celestia-node` and Celestia's documentation is `test`.
 
 You can learn more about the keyring on the [Cosmos documentation](https://docs.cosmos.network/main/run-node/keyring.html)
 or [Go Package documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk/crypto/keyring).

--- a/docs/developers/celestia-node-key.mdx
+++ b/docs/developers/celestia-node-key.mdx
@@ -50,7 +50,7 @@ For the purpose of this guide, we will use the `make cel-key` command.
 
 ### `keyring-backend` usage
 
-`keyring-backend` configures the keyring's backend, where the keys are stored.
+`keyring-backend` configures the keyring's backend, how the keys are stored.
 
 Supported options are: `file` and `test`. The default used in Celestia's documentation is `test`.
 

--- a/docs/developers/celestia-node-key.mdx
+++ b/docs/developers/celestia-node-key.mdx
@@ -69,7 +69,7 @@ import TabItem from '@theme/TabItem';
 To generate a key for a Celestia bridge node, do the following:
 
 ```sh
-./cel-key add <key-name> --keyring-backend test --node.type bridge --p2p.network <network>
+./cel-key add <key-name> --keyring-backend test --keyring-dir ~/.celestia-bridge-<p2p_network>/keys
 ```
 
 This will load the key `<key-name>` into the directory of the bridge node.
@@ -80,7 +80,7 @@ This will load the key `<key-name>` into the directory of the bridge node.
 To generate a key for a Celestia full node, do the following:
 
 ```sh
-./cel-key add <key-name> --keyring-backend test --node.type full --p2p.network <network>
+./cel-key add <key-name> --keyring-backend test --keyring-dir ~/.celestia-full-<p2p_network>/keys
 ```
 
 This will load the key `<key-name>` into the directory of the full node.
@@ -92,7 +92,7 @@ This will load the key `<key-name>` into the directory of the full node.
 To generate a key for a Celestia light node, do the following:
 
 ```sh
-./cel-key add <key-name> --keyring-backend test --node.type light --p2p.network <network>
+./cel-key add <key-name> --keyring-backend test --keyring-dir ~/.celestia-light-<p2p_network>/keys
 ```
 
 This will load the key `<key-name>` into the directory of the light node.
@@ -107,11 +107,13 @@ Further flags you can use to customize your key are the following:
   save your node data and configurations. Expects a path to a directory.
 * `--p2p.network`: Specifies which network you want the key for. Values
   are `arabica` and `mocha`. Please note the default network will be `mocha`.
+* `--node.type`: Specifies which node type you want the node for. Values
+  are `bridge`, `full`, and `light`.
 
 Keep in mind that your Celestia Node will only pick up keys that 
 are inside the `node.store` directory under `/keys` so you should make
-sure to point `cel-key` utility to the correct directory via the
-`node.store` or `p2p.network` flags if you have specified a custom
+sure to point `cel-key` utility to the correct directory via either the `--keyring-dir` flag, or `node.store` and `p2p.network` flags if
+you have specified a custom
 directory or network other than Mocha.
 
 Also keep in mind that if you do not specify a network with `--p2p.network`,
@@ -125,14 +127,7 @@ the default one will always be `mocha`.
 You can export a private key from the local keyring in encrypted and ASCII-armored format.
 
 ```sh
-./cel-key export <key-name> --keyring-backend test --node.type bridge --p2p.network <network>
-```
-
-You can then import your key with `celestia-appd`:
-
-```sh
-celestia-appd keys import <new-key-name> 
-  <key-file-location>
+./cel-key export <key-name> --keyring-backend test --keyring-dir ~/.celestia-bridge-<p2p_network>/keys
 ```
 
 </TabItem>
@@ -141,14 +136,7 @@ celestia-appd keys import <new-key-name>
 You can export a private key from the local keyring in encrypted and ASCII-armored format.
 
 ```sh
-./cel-key export <key-name> --keyring-backend test --node.type full --p2p.network <network>
-```
-
-You can then import your key with `celestia-appd`:
-
-```sh
-celestia-appd keys import <new-key-name> 
-  <key-file-location>
+./cel-key export <key-name> --keyring-backend test --keyring-dir ~/.celestia-full-<p2p_network>/keys
 ```
 
 </TabItem>
@@ -157,14 +145,7 @@ celestia-appd keys import <new-key-name>
 You can export a private key from the local keyring in encrypted and ASCII-armored format.
 
 ```sh
-./cel-key export <key-name> --keyring-backend test --node.type light --p2p.network <network>
-```
-
-You can then import your key with `celestia-appd`:
-
-```sh
-celestia-appd keys import <new-key-name> 
-  <key-file-location>
+./cel-key export <key-name> --keyring-backend test --keyring-dir ~/.celestia-light-<p2p_network>/keys
 ```
 
 </TabItem>
@@ -180,7 +161,7 @@ celestia-appd keys import <new-key-name>
 Importing from a mnemonic:
 
 ```sh
-./cel-key add <key-name> --recover --keyring-backend test --node.type bridge --p2p.network <network>
+./cel-key add <key-name> --recover --keyring-backend test --keyring-dir ~/.celestia-bridge-<p2p_network>/keys
 ```
 
 You will then be prompted to enter your bip39 mnemonic.
@@ -188,7 +169,7 @@ You will then be prompted to enter your bip39 mnemonic.
 Example:
 
 ```sh
-./cel-key add alice --recover --keyring-backend test --node.type bridge --p2p.network <network>
+./cel-key add alice --recover --keyring-backend test --keyring-dir ~/.celestia-bridge-<p2p_network>/keys
 ```
 
 </TabItem>
@@ -197,7 +178,7 @@ Example:
 Importing from a mnemonic:
 
 ```sh
-./cel-key add <key-name> --recover --keyring-backend test --node.type full --p2p.network <network>
+./cel-key add <key-name> --recover --keyring-backend test --keyring-dir ~/.celestia-full-<p2p_network>/keys
 ```
 
 You will then be prompted to enter your bip39 mnemonic.
@@ -205,7 +186,7 @@ You will then be prompted to enter your bip39 mnemonic.
 Example:
 
 ```sh
-./cel-key add alice --recover --keyring-backend test --node.type full --p2p.network <network>
+./cel-key add alice --recover --keyring-backend test --keyring-dir ~/.celestia-full-<p2p_network>/keys
 ```
 
 </TabItem>
@@ -214,7 +195,7 @@ Example:
 Importing from a mnemonic:
 
 ```sh
-./cel-key add <key-name> --recover --keyring-backend test --node.type light --p2p.network <network>
+./cel-key add <key-name> --recover --keyring-backend test --keyring-dir ~/.celestia-light-<p2p_network>/keys
 ```
 
 You will then be prompted to enter your bip39 mnemonic.
@@ -222,7 +203,7 @@ You will then be prompted to enter your bip39 mnemonic.
 Example:
 
 ```sh
-./cel-key add alice --recover --keyring-backend test --node.type light --p2p.network <network>
+./cel-key add alice --recover --keyring-backend test --keyring-dir ~/.celestia-light-<p2p_network>/keys
 ```
 
 </TabItem>

--- a/docs/developers/celestia-node-key.mdx
+++ b/docs/developers/celestia-node-key.mdx
@@ -225,54 +225,5 @@ Example:
 ### View all options for `cel-key`
 
 ```sh
-$ ./cel-key --help
-Keyring management commands. These keys may be in any format supported by the
-Tendermint crypto library and can be used by light-clients, full nodes, or any other application
-that needs to sign with a private key.
-
-The keyring supports the following backends:
-
-    os          Uses the operating system's default credentials store.
-    file        Uses encrypted file-based keystore within the app's configuration directory.
-                This keyring will request a password each time it is accessed, which may occur
-                multiple times in a single command resulting in repeated password prompts.
-    kwallet     Uses KDE Wallet Manager as a credentials management application.
-    pass        Uses the pass command line utility to store and retrieve keys.
-    test        Stores keys insecurely to disk. It does not prompt for a password to be unlocked
-                and it should be use only for testing purposes.
-
-kwallet and pass backends depend on external tools. Refer to their respective documentation for more
-information:
-    KWallet     https://github.com/KDE/kwallet
-    pass        https://www.passwordstore.org/
-
-The pass backend requires GnuPG: https://gnupg.org/
-
-Usage:
-  keys [command]
-
-Available Commands:
-  add         Add an encrypted private key (either newly generated or recovered), encrypt it, and save to <name> file
-  completion  Generate the autocompletion script for the specified shell
-  delete      Delete the given keys
-  export      Export private keys
-  help        Help about any command
-  import      Import private keys into the local keybase
-  list        List all keys
-  migrate     Migrate keys from amino to proto serialization format
-  mnemonic    Compute the bip39 mnemonic for some input entropy
-  parse       Parse address from hex to bech32 and vice versa
-  rename      Rename an existing key
-  show        Retrieve key information by name or address
-
-Flags:
-  -h, --help                     help for keys
-      --home string              The application home directory (default "~")
-      --keyring-backend string   Select keyring's backend (os|file|test) (default "os")
-      --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
-      --node.type string         Sets key utility to use the node type's directory (e.g. ~/.celestia-light-mocha if --node.type light is passed).
-      --output string            Output format (text|json) (default "text")
-      --p2p.network string       Sets key utility to use the node network's directory (e.g. ~/.celestia-light-mynetwork if --node.network MyNetwork is passed). (default "mocha")
-
-Use "keys [command] --help" for more information about a command.
-```
+./cel-key --help
+````

--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -722,7 +722,7 @@ celestia light start --core.ip https://rpc-mocha.pops.one --core.grpc.port 9090 
 You can create your key for your node by running the following command:
 
 ```sh
-./cel-key add <key_name> --keyring-backend test --node.type light --p2p.network <network>
+./cel-key add <key_name> --keyring-backend test --keyring-dir ~/.celestia-light-<p2p_network>/keys
 ```
 
 You can start your light node with the key created above by running the
@@ -754,7 +754,7 @@ You can find the address by running the following command in
 the `celestia-node` directory:
 
 ```sh
-./cel-key list --node.type light --keyring-backend test --p2p.network <network>
+./cel-key list --keyring-backend test --keyring-dir ~/.celestia-light-<p2p_network>/keys
 ```
 
 If you would like to fund your wallet with testnet tokens, head over

--- a/docs/nodes/bridge-node.mdx
+++ b/docs/nodes/bridge-node.mdx
@@ -184,7 +184,7 @@ PayForData transactions.
 You can find the address by running the following command:
 
 ```sh
-./cel-key list --node.type bridge --keyring-backend test --p2p.network <network>
+./cel-key list --keyring-backend test --keyring-dir ~/.celestia-bridge-<p2p_network>/keys
 ```
 
 You have two networks to get testnet tokens from:

--- a/docs/nodes/full-storage-node.mdx
+++ b/docs/nodes/full-storage-node.mdx
@@ -110,7 +110,7 @@ PayForData transactions.
 You can find the address by running the following command:
 
 ```sh
-./cel-key list --node.type full --keyring-backend test --p2p.network <network>
+./cel-key list --keyring-backend test --keyring-dir ~/.celestia-full-<p2p_network>/keys
 ```
 
 You have two networks to get testnet tokens from:

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -765,7 +765,7 @@ celestia light start --core.ip https://rpc-mocha.pops.one --core.grpc.port <port
 You can create your key for your node by running the following command with the [`cel-key`](../developers/celestia-node-key) utility:
 
 ```sh
-./cel-key add <key_name> --keyring-backend test --node.type light --p2p.network <network>
+./cel-key add <key_name> --keyring-backend test --keyring-dir ~/.celestia-light-<p2p_network>/keys
 ```
 
 For `arabica`, if you are on `0.6.1`, make sure to use `--p2p.network arabica` when generating your keys.
@@ -798,7 +798,7 @@ You can find the address by running the following command in the
 `celestia-node` directory:
 
 ```sh
-./cel-key list --node.type light --keyring-backend test --p2p.network <network>
+./cel-key list --keyring-backend test --keyring-dir ~/.celestia-light-<p2p_network>/keys
 ```
 
 You have two networks to get testnet tokens from:


### PR DESCRIPTION
This resolves issue with unsupported keyring backends in our documentation. It specifies that `test` and `file` are available, but others are not.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves https://github.com/celestiaorg/docs/issues/413

- [x] Remove `./cel-key --help` menu, because it shows unsupported keyring backends https://github.com/celestiaorg/docs/pull/414/commits/b199f319ff7c04ba4a3151402ca87a3403660839
- [x] add note about supported keyring backends in `docs/developers/celestia-node-key.mdx` https://github.com/celestiaorg/docs/pull/414/commits/a9d1d7c90b7c85d5ac50447d18528767d2987294
- [x] change `--node.type <node_type> --p2p.network <network>` to `--keyring-dir ~/.celestia-<node_type>-<p2p_network>/keys`

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203749804732586