### PR TITLE
chore(docs): use persistent_keys config for consensus full node

### DIFF
--- a/docs/nodes/consensus-full-node.md
+++ b/docs/nodes/consensus-full-node.md
@@ -67,9 +67,9 @@ Set seeds and peers:
 
 <!-- markdownlint-disable MD013 -->
 ```sh
-BOOTSTRAP_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/mocha/bootstrap-peers.txt | tr -d '\n')
-echo $BOOTSTRAP_PEERS
-sed -i.bak -e "s/^bootstrap-peers *=.*/bootstrap-peers = \"$BOOTSTRAP_PEERS\"/" $HOME/.celestia-app/config/config.toml
+PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/mocha/peers.txt | tr -d '\n')
+echo $PERSISTENT_PEERS
+sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/.celestia-app/config/config.toml
 ```
 <!-- markdownlint-enable MD013 -->
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Consensus Full Node docs reference non-existent files and settings in the `config.toml` file.

- The docs reference https://raw.githubusercontent.com/celestiaorg/networks/master/mocha/bootstrap-peers.txt which has changed to https://raw.githubusercontent.com/celestiaorg/networks/master/mocha/peers.txt
- The docs reference `bootstrap-peers` in the `.celestia-app/config/config.toml` file where there is no such configuration. Changing this to `persistent_peers` works.

These changes make it easier for a user to set up a Consensus Full Node and avoid getting stuck.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [X] N/A New and updated code has appropriate documentation
- [X] N/A New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [X] N/A Visual proof for any user facing features like CLI or documentation updates
- [X] Linked issues closed with keywords: No linked issue
