### PR TITLE
deps: version bump to 0.6.3 for mocha

### DIFF
--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -397,7 +397,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make install
 make cel-key
 ```
@@ -407,7 +407,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux
@@ -427,7 +427,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make install
 make cel-key
 ```
@@ -437,7 +437,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux
@@ -457,7 +457,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make go-install
 make cel-key
 ```
@@ -467,7 +467,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux
@@ -487,7 +487,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make go-install
 make cel-key
 ```
@@ -497,7 +497,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux

--- a/docs/nodes/celestia-node.mdx
+++ b/docs/nodes/celestia-node.mdx
@@ -31,7 +31,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make install
 make cel-key
 ```
@@ -41,7 +41,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux
@@ -61,7 +61,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make install
 make cel-key
 ```
@@ -71,7 +71,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux
@@ -91,7 +91,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make go-install
 make cel-key
 ```
@@ -101,7 +101,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux
@@ -121,7 +121,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make go-install
 make cel-key
 ```
@@ -131,7 +131,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux

--- a/docs/nodes/docker-images.mdx
+++ b/docs/nodes/docker-images.mdx
@@ -41,7 +41,7 @@ import TabItem from '@theme/TabItem';
 Run the image from the command line:
 
 ```bash 
-docker run -e NODE_TYPE=light -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:0.6.2 celestia light start --core.ip https://rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
+docker run -e NODE_TYPE=light -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:0.6.3 celestia light start --core.ip https://rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 ```
 
 Congratulations! You now have a Celestia Light Node running on the Mocha testnet.
@@ -86,7 +86,7 @@ you can refer to the
 Run the image from the command line:
 
 ```bash 
-docker run -e NODE_TYPE=bridge -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:0.6.2 celestia bridge start --core.ip https://rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
+docker run -e NODE_TYPE=bridge -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:0.6.3 celestia bridge start --core.ip https://rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 ```
 
 Congratulations! You now have a Celestia Bridge Node running on the Mocha network.
@@ -131,7 +131,7 @@ you can refer to the
 Run the image from the command line:
 
 ```bash 
-docker run -e NODE_TYPE=full -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:0.6.2 celestia full start --core.ip https://rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
+docker run -e NODE_TYPE=full -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:0.6.3 celestia full start --core.ip https://rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 ```
 
 Congratulations! You now have a Celestia Full Storage Node running on the Mocha network.

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -411,7 +411,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make install
 make cel-key
 ```
@@ -421,7 +421,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux
@@ -441,7 +441,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make install
 make cel-key
 ```
@@ -451,7 +451,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux
@@ -471,7 +471,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make go-install
 make cel-key
 ```
@@ -481,7 +481,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux
@@ -501,7 +501,7 @@ cd $HOME
 rm -rf celestia-node
 git clone https://github.com/celestiaorg/celestia-node.git
 cd celestia-node/
-git checkout tags/v0.6.2
+git checkout tags/v0.6.3
 make go-install
 make cel-key
 ```
@@ -511,7 +511,7 @@ version` command:
 
 ```console
 $ celestia version
-Semantic version: v0.6.2
+Semantic version: v0.6.3
 Commit: 3a58679ed84da966d01173f32780134c7b830594
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022
 System version: amd64/linux


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This upgrades Mocha to v0.6.3, Stable Mocha: https://github.com/celestiaorg/celestia-node/releases/tag/v0.6.3

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
