### PR TITLE
Remove incorrect command from celestia-node wallet page

### DIFF
--- a/docs/developers/celestia-node-key.mdx
+++ b/docs/developers/celestia-node-key.mdx
@@ -119,13 +119,6 @@ You can export a private key from the local keyring in encrypted and ASCII-armor
 ./cel-key export <key-name> --keyring-backend test --node.type bridge --p2p.network <network>
 ```
 
-You can then import your key with `celestia-appd`:
-
-```sh
-celestia-appd keys import <new-key-name> 
-  <key-file-location>
-```
-
 </TabItem>
 <TabItem value="full" label="Full">
 
@@ -135,13 +128,6 @@ You can export a private key from the local keyring in encrypted and ASCII-armor
 ./cel-key export <key-name> --keyring-backend test --node.type full --p2p.network <network>
 ```
 
-You can then import your key with `celestia-appd`:
-
-```sh
-celestia-appd keys import <new-key-name> 
-  <key-file-location>
-```
-
 </TabItem>
 <TabItem value="light" label="Light">
 
@@ -149,13 +135,6 @@ You can export a private key from the local keyring in encrypted and ASCII-armor
 
 ```sh
 ./cel-key export <key-name> --keyring-backend test --node.type light --p2p.network <network>
-```
-
-You can then import your key with `celestia-appd`:
-
-```sh
-celestia-appd keys import <new-key-name> 
-  <key-file-location>
 ```
 
 </TabItem>


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

User was confused what the difference in `cel-key` and `celestia-appd` was. It is because there was a `celestia-app` command in the [guide](https://docs.celestia.org/developers/celestia-node-key/#steps-for-exporting-node-keys) for `celestia-node`. It's removed in this PR. 

Closes https://github.com/celestiaorg/docs/issues/455

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
