### PR TITLE
change Celestia blocktime to 15s

### DIFF
--- a/docs/developers/integrate-celestia.md
+++ b/docs/developers/integrate-celestia.md
@@ -68,7 +68,7 @@ fast-sync, state sync, and quick sync.
 ### Notable exceptions relative to other blockchains
 
 Relative to other Tendermint based chains, Celestia will have significantly
-longer blocktimes of around 30* seconds. The reason behind this block time is to
+longer blocktimes of around 15* seconds. The reason behind this block time is to
 optimize the bandwidth used by light clients that are sampling the chain, and
 is not because we have modified Tendermint consensus in any meaningful way.
 Validators will likely download/upload relatively large blocks. It should be


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This changes the Celesita block time from 30 seconds to 15 seconds on the Integration page.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
