### PR TITLE
update variable name

### DIFF
--- a/docs/nodes/validator-node.md
+++ b/docs/nodes/validator-node.md
@@ -127,7 +127,7 @@ Follow the tutorial on creating a wallet [here](../developers/celestia-app-walle
 Create an environment variable for the address:
 
 ```sh
-VALIDATOR_WALLET=<validator-address>
+VALIDATOR_WALLET=<validator-wallet-name>
 ```
 
 If you want to delegate more stake to any validator, including your own you


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Under the [delegate stake section](https://docs.celestia.org/nodes/validator-node/#delegate-stake-to-a-validator)

It asks you to setup an env variable for your key as such:
```
VALIDATOR_WALLET=<validator-address>
```
The following step asks to run the following command to output the wallet address:
```
celestia-appd keys show $VALIDATOR_WALLET --bech val -a
```

The error is that the env variable should be example within `<>` should be `<validator-key-name>` and not `<validator-address>`. Otherwise you would receive the following error:
```
Error: <validator-address> is not a valid name or address: invalid Bech32 prefix; expected celestia, got celestiavaloper
```

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
