### PR TITLE
Fix tutorial order and menu

### DIFF
--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: RPC API tutorial
+sidebar_label: Gateway API tutorial
 ---
 
 import constants from "../../versions/constants.js";
@@ -7,9 +7,9 @@ import arabicaVersions from "../../versions/arabica_versions.js";
 import mochaVersions from "../../versions/mocha_versions.js";
 import blockspaceraceVersions from "../../versions/blockspacerace_versions.js";
 
-# Getting and sending transactions with celestia-node RPC API
+# Getting and sending transactions with celestia-node gateway API
 
-In this tutorial, we will cover how to use the celestia-node RPC API to submit and
+In this tutorial, we will cover how to use the celestia-node gateway API to submit and
 retrieve messages from the Data Availability Layer by their namespace ID.
 
 This tutorial assumes you are working in a Linux environment.

--- a/docs/developers/rpc-tutorial.mdx
+++ b/docs/developers/rpc-tutorial.mdx
@@ -1,10 +1,10 @@
 ---
-sidebar_label: Gateway API tutorial
+sidebar_label: RPC API tutorial
 ---
 
-# Gateway API tutorial
+# RPC API tutorial
 
-This tutorial will teach you how to interact with a node's gateway API.
+This tutorial will teach you how to interact with a node's RPC API.
 
 First, [install celestia-node](../../nodes/light-node).
 
@@ -22,8 +22,8 @@ celestia <node_type> start --p2p.network <network>
 
 ## cURL guide
 
-In another terminal instance, run the following command to generate the JWT auth token
-and set it as a variable:
+In another terminal instance, run the following command to generate the JWT (JSON Web Token)
+auth token and set it as a variable:
 
 ```bash
 # make sure to add network flags if you're using a network other than the default

--- a/sidebars.js
+++ b/sidebars.js
@@ -255,15 +255,15 @@ const sidebars = {
           },
           collapsed: false,
           items: [
+            { 
+              type: "doc", 
+              label: "Gateway API tutorial", 
+              id: "developers/node-tutorial" 
+            },
             {
               type: "doc",
               label: "Gateway API docs",
               id: "developers/node-gateway-docs"
-            },
-            { 
-              type: "doc", 
-              label: "Gateway API tutorial", 
-              id: "developers/gateway-api-tutorial" 
             },
           ]
         },
@@ -275,15 +275,15 @@ const sidebars = {
           },
           collapsed: false,
           items: [
-            {
-              type: "link",
-              label: "Node RPC docs",
-              href: "https://node-rpc-docs.celestia.org/"
-            },
             { 
               type: "doc", 
               label: "RPC API tutorial", 
-              id: "developers/node-tutorial" 
+              id: "developers/rpc-tutorial" 
+            },
+            {
+              type: "link",
+              label: "RPC API docs",
+              href: "https://node-rpc-docs.celestia.org/"
             },
           ]
         },


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

- swaps RPC/Gateway tutorials because they were in wrong place
- switches order of `1. docs 2. tutorial` to `1. tutorial 2. docs`

<img width="581" alt="Screenshot 2023-03-23 at 3 06 59 PM" src="https://user-images.githubusercontent.com/46639943/227229365-7cc4c188-7030-43b1-960c-e84b0bb6d85f.png">

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
