### PR TITLE
Simple typo correction

### DIFF
--- a/docs/developers/full-stack-modular-development-guide.md
+++ b/docs/developers/full-stack-modular-development-guide.md
@@ -219,10 +219,10 @@ forge test -vv
 Now that we've tested the contract, let's try deploying it locally using
 [Solidity Scripting](https://book.getfoundry.sh/tutorials/solidity-scripting.html).
 
-To do so, update the deloyment script at `script/Contracts.s.sol` with the
+To do so, update the deloyment script at `script/Contract.s.sol` with the
 following code:
 
-```solidity title="script/Contracts.s.sol"
+```solidity title="script/Contract.s.sol"
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 


### PR DESCRIPTION
The documentation tells the reader to create a deployment script named `Contracts.s.sol` however later deployment commands refer to `Contract.s.sol` resulting in a failed deployment.