### PR TITLE
feat: remove importMarkdown.mjs from yarn start & build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "import-md": "node importMarkdown.mjs",
     "docusaurus": "docusaurus",
-    "start": "node importMarkdown.mjs && docusaurus start",
-    "build": "node importMarkdown.mjs && docusaurus build",
+    "start": "docusaurus start",
+    "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This removes the `importMarkdown.mjs` script from the `yarn build` and `yarn start` commands, leaving it to be manually run with `yarn import-md`.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
