### PR TITLE
added Neuler RPC node

### DIFF
--- a/docs/nodes/blockspace-race.mdx
+++ b/docs/nodes/blockspace-race.mdx
@@ -209,7 +209,7 @@ provided by the community here and their status provided by Brightly Stake
 * [https://celestia-bsr-rpc.qubelabs.io/](https://celestia-bsr-rpc.qubelabs.io/)  
 * [https://rpc-celestia.notional.ventures/](https://rpc-celestia.notional.ventures/)
 * [http://31.220.87.152:26657/](http://31.220.87.152:26657/)
-
+* [http://celestia.blockspace.rpc.neuler.xyz:26657/](http://celestia.blockspace.rpc.neuler.xyz:26657/)
 </details>
 
 ##### Websocket endpoints


### PR DESCRIPTION
This PR adds the Neuler RPC endpoint to the blockspace race doc page.
