### PR TITLE
docs: remove extra spaces from code blocks from variables

### DIFF
--- a/docs/developers/keplr.mdx
+++ b/docs/developers/keplr.mdx
@@ -211,14 +211,14 @@ we are passing to the `AddNetworkKeplr`
 function:
 
 <pre><code>
-import '@site/src/components/AddNetworkKeplr' <br/>
+import '@site/src/components/AddNetworkKeplr'<br/>
 <br/>
 export const ARABICA_PARAMS = {`{
   chainId: '${constants.arabicaChainId}',
   chainName: 'Arabica Devnet',
   rpc: 'https://rpc.limani.celestia-devops.dev',
   rest: 'https://api.limani.celestia-devops.dev'
-}`} <br/>
+}`}<br/>
 <br/>
 {`<AddNetworkKeplr params={ARABICA_PARAMS}/>`}
 </code></pre>

--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -153,48 +153,48 @@ so we must install Golang to build and run them.
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz" <br/>
-rm "go$ver.linux-arm64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz"<br/>
+rm "go$ver.linux-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz" <br/>
-rm "go$ver.darwin-arm64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz"<br/>
+rm "go$ver.darwin-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz" <br/>
-rm "go$ver.darwin-amd64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz"<br/>
+rm "go$ver.darwin-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
@@ -267,48 +267,48 @@ go version go{constants.golangNodeBSR} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz" <br/>
-rm "go$ver.linux-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz"<br/>
+rm "go$ver.linux-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz" <br/>
-rm "go$ver.darwin-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz"<br/>
+rm "go$ver.darwin-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz" <br/>
-rm "go$ver.darwin-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz"<br/>
+rm "go$ver.darwin-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
@@ -381,48 +381,48 @@ go version go{constants.golangNodeOther} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz" <br/>
-rm "go$ver.linux-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz"<br/>
+rm "go$ver.linux-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz" <br/>
-rm "go$ver.darwin-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz"<br/>
+rm "go$ver.darwin-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz" <br/>
-rm "go$ver.darwin-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz"<br/>
+rm "go$ver.darwin-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
@@ -510,26 +510,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -541,26 +541,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/linux <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/linux<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -572,26 +572,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/darwin <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/darwin<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -603,26 +603,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/darwin <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/darwin<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -640,26 +640,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -671,26 +671,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -702,26 +702,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -733,26 +733,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -770,26 +770,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -801,26 +801,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -832,26 +832,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -863,26 +863,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>

--- a/docs/developers/prompt-scavenger.mdx
+++ b/docs/developers/prompt-scavenger.mdx
@@ -38,13 +38,13 @@ Run the following to install golang on your machine:
 
 ````mdx-code-block
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
+ver="{constants.golangNodeBSR}"<br/>
 <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 Now we need to add the `/usr/local/go/bin` directory to `$PATH`:
@@ -71,24 +71,24 @@ go version go{constants.golangNodeBSR} linux/amd64
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 ````
 

--- a/docs/nodes/celestia-app.mdx
+++ b/docs/nodes/celestia-app.mdx
@@ -27,39 +27,39 @@ import TabItem from '@theme/TabItem';
 <TabItem value="blockspacerace" label="Blockspace Race">
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-app <br/>
-git clone https://github.com/celestiaorg/celestia-app.git <br/>
-cd celestia-app/ <br/>
-APP_VERSION={blockspaceraceVersions['app-latest-tag']} <br/>
-git checkout tags/$APP_VERSION -b $APP_VERSION <br/>
-make install <br/>
+cd $HOME<br/>
+rm -rf celestia-app<br/>
+git clone https://github.com/celestiaorg/celestia-app.git<br/>
+cd celestia-app/<br/>
+APP_VERSION={blockspaceraceVersions['app-latest-tag']}<br/>
+git checkout tags/$APP_VERSION -b $APP_VERSION<br/>
+make install<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mocha" label="Mocha">
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-app <br/>
-git clone https://github.com/celestiaorg/celestia-app.git <br/>
-cd celestia-app/ <br/>
-APP_VERSION={mochaVersions['app-latest-tag']} <br/>
-git checkout tags/$APP_VERSION -b $APP_VERSION <br/>
-make install <br/>
+cd $HOME<br/>
+rm -rf celestia-app<br/>
+git clone https://github.com/celestiaorg/celestia-app.git<br/>
+cd celestia-app/<br/>
+APP_VERSION={mochaVersions['app-latest-tag']}<br/>
+git checkout tags/$APP_VERSION -b $APP_VERSION<br/>
+make install<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arabica" label="Arabica 🏗️">
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-app <br/>
-git clone https://github.com/celestiaorg/celestia-app.git <br/>
-cd celestia-app/ <br/>
-APP_VERSION={arabicaVersions['app-latest-tag']} <br/>
-git checkout tags/$APP_VERSION -b $APP_VERSION <br/>
-make install <br/>
+cd $HOME<br/>
+rm -rf celestia-app<br/>
+git clone https://github.com/celestiaorg/celestia-app.git<br/>
+cd celestia-app/<br/>
+APP_VERSION={arabicaVersions['app-latest-tag']}<br/>
+git checkout tags/$APP_VERSION -b $APP_VERSION<br/>
+make install<br/>
 </code></pre>
 
 </TabItem>

--- a/docs/nodes/celestia-node.mdx
+++ b/docs/nodes/celestia-node.mdx
@@ -34,26 +34,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -65,26 +65,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/linux <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/linux<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -96,26 +96,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/darwin <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/darwin<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -127,26 +127,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/darwin <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/darwin<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -164,26 +164,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -195,26 +195,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -226,26 +226,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -257,26 +257,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -294,26 +294,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -325,26 +325,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -356,26 +356,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -387,26 +387,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>

--- a/docs/nodes/environment.mdx
+++ b/docs/nodes/environment.mdx
@@ -143,48 +143,48 @@ so we must install Golang to build and run them.
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz" <br/>
-rm "go$ver.linux-arm64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz"<br/>
+rm "go$ver.linux-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz" <br/>
-rm "go$ver.darwin-arm64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz"<br/>
+rm "go$ver.darwin-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz" <br/>
-rm "go$ver.darwin-amd64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz"<br/>
+rm "go$ver.darwin-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
@@ -257,48 +257,48 @@ go version go{constants.golangNodeBSR} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz" <br/>
-rm "go$ver.linux-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz"<br/>
+rm "go$ver.linux-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz" <br/>
-rm "go$ver.darwin-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz"<br/>
+rm "go$ver.darwin-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz" <br/>
-rm "go$ver.darwin-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz"<br/>
+rm "go$ver.darwin-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
@@ -371,48 +371,48 @@ go version go{constants.golangNodeOther} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz" <br/>
-rm "go$ver.linux-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz"<br/>
+rm "go$ver.linux-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz" <br/>
-rm "go$ver.darwin-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz"<br/>
+rm "go$ver.darwin-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz" <br/>
-rm "go$ver.darwin-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz"<br/>
+rm "go$ver.darwin-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -172,48 +172,48 @@ so we must install Golang to build and run them.
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz" <br/>
-rm "go$ver.linux-arm64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz"<br/>
+rm "go$ver.linux-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz" <br/>
-rm "go$ver.darwin-arm64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz"<br/>
+rm "go$ver.darwin-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeBSR}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz" <br/>
-rm "go$ver.darwin-amd64.tar.gz" <br/>
+ver="{constants.golangNodeBSR}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz"<br/>
+rm "go$ver.darwin-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
@@ -286,48 +286,48 @@ go version go{constants.golangNodeBSR} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz" <br/>
-rm "go$ver.linux-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz"<br/>
+rm "go$ver.linux-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz" <br/>
-rm "go$ver.darwin-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz"<br/>
+rm "go$ver.darwin-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz" <br/>
-rm "go$ver.darwin-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz"<br/>
+rm "go$ver.darwin-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
@@ -400,48 +400,48 @@ go version go{constants.golangNodeOther} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz" <br/>
-rm "go$ver.linux-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-amd64.tar.gz"<br/>
+rm "go$ver.linux-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz" <br/>
-rm "go$ver.linux-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.linux-arm64.tar.gz"<br/>
+rm "go$ver.linux-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz" <br/>
-rm "go$ver.darwin-arm64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-arm64.tar.gz"<br/>
+rm "go$ver.darwin-arm64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}" <br/>
-cd $HOME <br/>
-wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz" <br/>
-sudo rm -rf /usr/local/go <br/>
-sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz" <br/>
-rm "go$ver.darwin-amd64.tar.gz" <br/>
+ver="{constants.golangNodeOther}"<br/>
+cd $HOME<br/>
+wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
+sudo rm -rf /usr/local/go<br/>
+sudo tar -C /usr/local -xzf "go$ver.darwin-amd64.tar.gz"<br/>
+rm "go$ver.darwin-amd64.tar.gz"<br/>
 </code></pre>
 
 </TabItem>
@@ -527,26 +527,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -558,26 +558,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/linux <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/linux<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -589,26 +589,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/darwin <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/darwin<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -620,26 +620,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{blockspaceraceVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{blockspaceraceVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {blockspaceraceVersions['node-latest-tag']} <br/>
-Commit: {blockspaceraceVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/darwin <br/>
-Golang version: go{constants.golangNodeBSR} <br/>
+$ celestia version<br/>
+Semantic version: {blockspaceraceVersions['node-latest-tag']}<br/>
+Commit: {blockspaceraceVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/darwin<br/>
+Golang version: go{constants.golangNodeBSR}<br/>
 </code></pre>
 
 </TabItem>
@@ -657,26 +657,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -688,26 +688,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -719,26 +719,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -750,26 +750,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{mochaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{mochaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {mochaVersions['node-latest-tag']} <br/>
-Commit: {mochaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {mochaVersions['node-latest-tag']}<br/>
+Commit: {mochaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -787,26 +787,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -818,26 +818,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/linux <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/linux<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -849,26 +849,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: arm64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: arm64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -880,26 +880,26 @@ to be compatible with the network.
 Install the `celestia-node` binary by running the following commands:
 
 <pre><code>
-cd $HOME <br/>
-rm -rf celestia-node <br/>
-git clone https://github.com/celestiaorg/celestia-node.git <br/>
-cd celestia-node/ <br/>
-git checkout tags/{arabicaVersions['node-latest-tag']} <br/>
-make build <br/>
-make go-install <br/>
-make cel-key <br/>
+cd $HOME<br/>
+rm -rf celestia-node<br/>
+git clone https://github.com/celestiaorg/celestia-node.git<br/>
+cd celestia-node/<br/>
+git checkout tags/{arabicaVersions['node-latest-tag']}<br/>
+make build<br/>
+make go-install<br/>
+make cel-key<br/>
 </code></pre>
 
 Verify that the binary is working and check the version with the `celestia
 version` command:
 
 <pre><code>
-$ celestia version <br/>
-Semantic version: {arabicaVersions['node-latest-tag']} <br/>
-Commit: {arabicaVersions['node-latest-sha']} <br/>
-Build Date: Thu Dec 15 10:19:22 PM UTC 2022 <br/>
-System version: amd64/darwin <br/>
-Golang version: go{constants.golangNodeOther} <br/>
+$ celestia version<br/>
+Semantic version: {arabicaVersions['node-latest-tag']}<br/>
+Commit: {arabicaVersions['node-latest-sha']}<br/>
+Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
+System version: amd64/darwin<br/>
+Golang version: go{constants.golangNodeOther}<br/>
 </code></pre>
 
 </TabItem>
@@ -956,10 +956,10 @@ celestia light init --p2p.network arabica
 You should see output like:
 
 <pre><code>
-$ celestia light init --p2p.network arabica <br/>
-2022-12-19T21:45:00.802Z        INFO    node    nodebuilder/init.go:19  Initializing Light Node Store over '/root/.celestia-light-{constants.arabicaChainId}' <br/>
-2022-12-19T21:45:00.803Z        INFO    node    nodebuilder/init.go:50  Saving config   {`{"path": "/root/.celestia-light-${constants.arabicaChainId}/config.toml"}`}` <br/>
-2022-12-19T21:45:00.803Z        INFO    node    nodebuilder/init.go:51  Node Store initialized <br/>
+$ celestia light init --p2p.network arabica<br/>
+2022-12-19T21:45:00.802Z        INFO    node    nodebuilder/init.go:19  Initializing Light Node Store over '/root/.celestia-light-{constants.arabicaChainId}'<br/>
+2022-12-19T21:45:00.803Z        INFO    node    nodebuilder/init.go:50  Saving config   {`{"path": "/root/.celestia-light-${constants.arabicaChainId}/config.toml"}`}`<br/>
+2022-12-19T21:45:00.803Z        INFO    node    nodebuilder/init.go:51  Node Store initialized<br/>
 </code></pre>
 </TabItem>
 </Tabs>

--- a/docs/nodes/qgb-binary.mdx
+++ b/docs/nodes/qgb-binary.mdx
@@ -18,9 +18,9 @@ relays them to the target EVM chain.
 2. Clone the `https://github.com/celestiaorg/orchestrator-relayer` repository:
 
     <pre><code>
-    git clone https://github.com/celestiaorg/orchestrator-relayer.git <br />
-    cd orchestrator-relayer <br />
-    git checkout {constants.orchrelayVersion} <br />
+    git clone https://github.com/celestiaorg/orchestrator-relayer.git<br />
+    cd orchestrator-relayer<br />
+    git checkout {constants.orchrelayVersion}<br />
     </code></pre>
 ````
 3. Install the QGB CLI


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR removes extra spaces from code blocks from adding variables. I added an extra space before the `<br />` which resulted in an extra space showing up in the code blocks.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
