### PR TITLE
docs: add Go variable for Arabica and for Mocha

### DIFF
--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -267,7 +267,7 @@ go version go{constants.golangNodeBSR} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -279,7 +279,7 @@ rm "go$ver.linux-amd64.tar.gz"<br/>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -291,7 +291,7 @@ rm "go$ver.linux-arm64.tar.gz"<br/>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -303,7 +303,7 @@ rm "go$ver.darwin-arm64.tar.gz"<br/>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -347,28 +347,28 @@ The output should be the version installed:
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/amd64
+go version go{constants.golangNodeMocha} linux/amd64
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/arm64
+go version go{constants.golangNodeMocha} linux/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/arm64
+go version go{constants.golangNodeMocha} darwin/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/amd64
+go version go{constants.golangNodeMocha} darwin/amd64
 </code></pre>
 
 </TabItem>
@@ -381,7 +381,7 @@ go version go{constants.golangNodeOther} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -393,7 +393,7 @@ rm "go$ver.linux-amd64.tar.gz"<br/>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -405,7 +405,7 @@ rm "go$ver.linux-arm64.tar.gz"<br/>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -417,7 +417,7 @@ rm "go$ver.darwin-arm64.tar.gz"<br/>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -461,28 +461,28 @@ The output should be the version installed:
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/amd64
+go version go{constants.golangNodeArabica} linux/amd64
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/arm64
+go version go{constants.golangNodeArabica} linux/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/arm64
+go version go{constants.golangNodeArabica} darwin/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/amd64
+go version go{constants.golangNodeArabica} darwin/amd64
 </code></pre>
 
 </TabItem>
@@ -659,7 +659,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -690,7 +690,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -721,7 +721,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -752,7 +752,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -789,7 +789,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>
@@ -820,7 +820,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>
@@ -851,7 +851,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>
@@ -882,7 +882,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>

--- a/docs/nodes/celestia-node.mdx
+++ b/docs/nodes/celestia-node.mdx
@@ -183,7 +183,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -214,7 +214,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -245,7 +245,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -276,7 +276,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -313,7 +313,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>
@@ -344,7 +344,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>
@@ -375,7 +375,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>
@@ -406,7 +406,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>

--- a/docs/nodes/environment.mdx
+++ b/docs/nodes/environment.mdx
@@ -257,7 +257,7 @@ go version go{constants.golangNodeBSR} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -269,7 +269,7 @@ rm "go$ver.linux-amd64.tar.gz"<br/>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -281,7 +281,7 @@ rm "go$ver.linux-arm64.tar.gz"<br/>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -293,7 +293,7 @@ rm "go$ver.darwin-arm64.tar.gz"<br/>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -337,28 +337,28 @@ The output should be the version installed:
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/amd64
+go version go{constants.golangNodeMocha} linux/amd64
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/arm64
+go version go{constants.golangNodeMocha} linux/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/arm64
+go version go{constants.golangNodeMocha} darwin/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/amd64
+go version go{constants.golangNodeMocha} darwin/amd64
 </code></pre>
 
 </TabItem>
@@ -371,7 +371,7 @@ go version go{constants.golangNodeOther} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -383,7 +383,7 @@ rm "go$ver.linux-amd64.tar.gz"<br/>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -395,7 +395,7 @@ rm "go$ver.linux-arm64.tar.gz"<br/>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -407,7 +407,7 @@ rm "go$ver.darwin-arm64.tar.gz"<br/>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -451,28 +451,28 @@ The output should be the version installed:
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/amd64
+go version go{constants.golangNodeArabica} linux/amd64
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/arm64
+go version go{constants.golangNodeArabica} linux/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/arm64
+go version go{constants.golangNodeArabica} darwin/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/amd64
+go version go{constants.golangNodeArabica} darwin/amd64
 </code></pre>
 
 </TabItem>

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -286,7 +286,7 @@ go version go{constants.golangNodeBSR} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -298,7 +298,7 @@ rm "go$ver.linux-amd64.tar.gz"<br/>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -310,7 +310,7 @@ rm "go$ver.linux-arm64.tar.gz"<br/>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -322,7 +322,7 @@ rm "go$ver.darwin-arm64.tar.gz"<br/>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeMocha}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -366,28 +366,28 @@ The output should be the version installed:
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/amd64
+go version go{constants.golangNodeMocha} linux/amd64
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/arm64
+go version go{constants.golangNodeMocha} linux/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/arm64
+go version go{constants.golangNodeMocha} darwin/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/amd64
+go version go{constants.golangNodeMocha} darwin/amd64
 </code></pre>
 
 </TabItem>
@@ -400,7 +400,7 @@ go version go{constants.golangNodeOther} darwin/amd64
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -412,7 +412,7 @@ rm "go$ver.linux-amd64.tar.gz"<br/>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.linux-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -424,7 +424,7 @@ rm "go$ver.linux-arm64.tar.gz"<br/>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-arm64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -436,7 +436,7 @@ rm "go$ver.darwin-arm64.tar.gz"<br/>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-ver="{constants.golangNodeOther}"<br/>
+ver="{constants.golangNodeArabica}"<br/>
 cd $HOME<br/>
 wget "https://golang.org/dl/go$ver.darwin-amd64.tar.gz"<br/>
 sudo rm -rf /usr/local/go<br/>
@@ -480,28 +480,28 @@ The output should be the version installed:
 <TabItem value="amd" label="Ubuntu (AMD)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/amd64
+go version go{constants.golangNodeArabica} linux/amd64
 </code></pre>
 
 </TabItem>
 <TabItem value="arm" label="Ubuntu (ARM)">
 
 <pre><code>
-go version go{constants.golangNodeOther} linux/arm64
+go version go{constants.golangNodeArabica} linux/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="apple" label="Mac (Apple)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/arm64
+go version go{constants.golangNodeArabica} darwin/arm64
 </code></pre>
 
 </TabItem>
 <TabItem value="mac" label="Mac (Intel)">
 
 <pre><code>
-go version go{constants.golangNodeOther} darwin/amd64
+go version go{constants.golangNodeArabica} darwin/amd64
 </code></pre>
 
 </TabItem>
@@ -676,7 +676,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -707,7 +707,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -738,7 +738,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -769,7 +769,7 @@ Semantic version: {mochaVersions['node-latest-tag']}<br/>
 Commit: {mochaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeMocha}<br/>
 </code></pre>
 
 </TabItem>
@@ -806,7 +806,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>
@@ -837,7 +837,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/linux<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>
@@ -868,7 +868,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: arm64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>
@@ -899,7 +899,7 @@ Semantic version: {arabicaVersions['node-latest-tag']}<br/>
 Commit: {arabicaVersions['node-latest-sha']}<br/>
 Build Date: Thu Dec 15 10:19:22 PM UTC 2022<br/>
 System version: amd64/darwin<br/>
-Golang version: go{constants.golangNodeOther}<br/>
+Golang version: go{constants.golangNodeArabica}<br/>
 </code></pre>
 
 </TabItem>

--- a/versions/constants.js
+++ b/versions/constants.js
@@ -1,6 +1,7 @@
 const constants = Object.freeze({
     golangNodeBSR: "1.20.2",
-    golangNodeOther: "1.19.1",
+    golangNodeMocha: "1.19.1",
+    golangNodeArabica: "1.20.2",
     golangApp: "1.19.1",
     golangCore: "1.19.1",
     golang: "1.19.1",


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR adds another variable to track go versions between different networks.

It replaces `golangNodeOther` with `golangNodeArabica` and uses `golangNodeMocha` for Mocha versions.
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
