### PR TITLE
Revert "feat: add algolia API key as secret (#778)"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-      ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
     permissions: write-all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,12 +20,8 @@ jobs:
 
       - name: Install
         run: yarn install --frozen-lockfile
-
       - name: Build
         run: BASE_URL='/pr-preview/pr-${{ github.event.number }}/' yarn build
-        env:
-          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-
       - name: Add CNAME file
         run: echo docs.celestia.org > ./build/CNAME
 

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -17,5 +17,3 @@ jobs:
           cache: npm
       - run: yarn install --frozen-lockfile
       - run: yarn build
-        env:
-          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,7 +111,7 @@ const config = {
       ],
       algolia: {
         appId: "2KRXIFZ5YL",
-        apiKey: process.env.ALGOLIA_API_KEY,
+        apiKey: "00d6c432aa0b7c20c92283ec9bec23c4",
         indexName: "celestia",
         contextualSearch: true,
         debug: false,


### PR DESCRIPTION
This reverts commit 91471b0f242d7b40e481afdfca91dc5284d72ad0.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Using the public key as a secret is proving to create a blocker for contributing to docs, so reverting until we have a better path forward.

Potential solution: look into if algolia has a developer mode

```Shell
[INFO] Starting the development server...
[ERROR] ValidationError: "algolia.apiKey" is required
```
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
