### PR TITLE
Update light-node.mdx

### DIFF
--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -1067,7 +1067,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.ip consensus-full-arabica-8.celestia-arabica.co --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
+celestia light start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
 ```
 
 </TabItem>


### PR DESCRIPTION
The current command to start the light node in the docs "https://docs.celestia.org/nodes/light-node/" is provided with an incomplete RPC endpoint. A minor correction to -> "consensus-full-arabica-8.celestia-arabica.com" solves this.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
