### PR TITLE
deps: add gateway deprecated flag

### DIFF
--- a/docs/developers/celestia-node-key.mdx
+++ b/docs/developers/celestia-node-key.mdx
@@ -222,6 +222,7 @@ Run the Docker image (in this example, we are using a Light Node):
 docker run --name celestia-node -e NODE_TYPE=light -e P2P_NETWORK=mocha -p 26659:26659 \
 ghcr.io/celestiaorg/celestia-node:sha-747c9e5 celestia light start \
 --core.ip rpc-mocha.pops.one \
+--gateway.deprecated-endpoints \
 --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 ```
 
@@ -274,7 +275,7 @@ services:
     image: celestia-node
     environment:
       - NODE_TYPE=light
-    command: celestia light start --core.ip rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha --keyring.accname my_celes_key
+    command: celestia light start --core.ip rpc-mocha.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha --keyring.accname my_celes_key
     volumes:
       - ${PWD}/keys:/root/.celestia-light-mocha/keys
     ports:

--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -974,7 +974,7 @@ an example public core endpoint.
   purposes. You can find a list of RPC endpoints [here](../../nodes/blockspace-race).
 
 ```sh
-celestia light start --core.ip <ip-address> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network blockspacerace
+celestia light start --core.ip <ip-address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network blockspacerace
 ```
 
 :::tip
@@ -1000,7 +1000,7 @@ an example public core endpoint.
   purposes. You can find a list of RPC endpoints [here](../../nodes/mocha-testnet#rpc-endpoints).
 
 ```sh
-celestia light start --core.ip <ip-address> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
+celestia light start --core.ip <ip-address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
 ```
 
 :::tip
@@ -1026,7 +1026,7 @@ an example public core endpoint.
   purposes. You can find a list of RPC endpoints [here](../../nodes/arabica-devnet#rpc-endpoints).
 
 ```sh
-celestia light start --core.ip <ip-address> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
+celestia light start --core.ip <ip-address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
 ```
 
 :::tip
@@ -1050,7 +1050,7 @@ For example, your command along with an RPC endpoint might look like this:
 <TabItem value="blockspacerace" label="Blockspace Race">
 
 ```sh
-celestia light start --core.ip <ip-address> --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
+celestia light start --core.ip <ip-address> --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
 ```
 
 :::tip
@@ -1062,7 +1062,7 @@ which ports are required to be open on your machine.
 <TabItem value="mocha" label="Mocha">
 
 ```sh
-celestia light start --core.ip rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
+celestia light start --core.ip rpc-mocha.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 ```
 
 :::tip
@@ -1074,7 +1074,7 @@ which ports are required to be open on your machine.
 <TabItem value="arabica" label="Arabica 🏗️">
 
 ```sh
-celestia light start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
+celestia light start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
 ```
 
 :::tip
@@ -1100,7 +1100,7 @@ following command:
 <TabItem value="blockspacerace" label="Blockspace Race">
 
 ```sh
-celestia light start --core.ip <ip-address> --keyring.accname <key_name> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network blockspacerace
+celestia light start --core.ip <ip-address> --keyring.accname <key_name> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network blockspacerace
 ```
 
 :::tip
@@ -1112,7 +1112,7 @@ which ports are required to be open on your machine.
 <TabItem value="mocha" label="Mocha">
 
 ```sh
-celestia light start --core.ip <ip-address> --keyring.accname <key_name> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
+celestia light start --core.ip <ip-address> --keyring.accname <key_name> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
 ```
 
 :::tip
@@ -1124,7 +1124,7 @@ which ports are required to be open on your machine.
 <TabItem value="arabica" label="Arabica 🏗️">
 
 ```sh
-celestia light start --core.ip <ip-address> --keyring.accname <key_name> --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
+celestia light start --core.ip <ip-address> --keyring.accname <key_name> --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
 ```
 
 :::tip

--- a/docs/developers/prompt-scavenger.mdx
+++ b/docs/developers/prompt-scavenger.mdx
@@ -130,7 +130,7 @@ celestia light init --p2p.network blockspacerace
 Next, we will start our node:
 
 ```sh
-celestia light start --core.ip $CORE_IP --p2p.network $NETWORK --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --keyring.accname $KEYNAME
+celestia light start --core.ip $CORE_IP --p2p.network $NETWORK --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --keyring.accname $KEYNAME
 ```
 
 :::tip

--- a/docs/nodes/celestia-node-metrics.md
+++ b/docs/nodes/celestia-node-metrics.md
@@ -20,7 +20,7 @@ command:
 
 <!-- markdownlint-disable MD013 -->
 ```sh
-celestia light start --core.ip <ip-address> --metrics --metrics.endpoint <ip-address:port> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network <network>
+celestia light start --core.ip <ip-address> --metrics --metrics.endpoint <ip-address:port> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network <network>
 ```
 
 :::tip

--- a/docs/nodes/celestia-node-troubleshooting.mdx
+++ b/docs/nodes/celestia-node-troubleshooting.mdx
@@ -74,7 +74,7 @@ Note: If you do not select a network, the default network will be 'Mocha'.
 
 ```sh
 celestia <node-type> init --p2p.network <network>
-celestia <node-type> start --p2p.network <network> --core.ip <address> --gateway --gateway.addr <ip-address> --gateway.port <port>
+celestia <node-type> start --p2p.network <network> --core.ip <address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port>
 ```
 
 :::tip
@@ -276,7 +276,7 @@ Your output will look similar to below:
 Then start your node:
 
 ```sh
-celestia light start --p2p.network blockspacerace --core.ip <address> --gateway --gateway.addr <ip-address> --gateway.port <port>
+celestia light start --p2p.network blockspacerace --core.ip <address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port>
 ```
 
 </TabItem>

--- a/docs/nodes/docker-images.mdx
+++ b/docs/nodes/docker-images.mdx
@@ -50,7 +50,7 @@ import TabItem from '@theme/TabItem';
 Run the image from the command line:
 
 <pre><code>
-docker run -e NODE_TYPE=light -e P2P_NETWORK=blockspacerace ghcr.io/celestiaorg/celestia-node:{blockspaceraceVersions['node-latest-tag']} celestia light start --core.ip rpc-blockspacerace.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
+docker run -e NODE_TYPE=light -e P2P_NETWORK=blockspacerace ghcr.io/celestiaorg/celestia-node:{blockspaceraceVersions['node-latest-tag']} celestia light start --core.ip rpc-blockspacerace.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
 </code></pre>
 
 :::tip
@@ -72,7 +72,7 @@ you can refer to the
 Run the image from the command line:
 
 <pre><code>
-docker run -e NODE_TYPE=light -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:sha-{mochaVersions['node-latest-sha'].slice(0, 7)} celestia light start --core.ip rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
+docker run -e NODE_TYPE=light -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:sha-{mochaVersions['node-latest-sha'].slice(0, 7)} celestia light start --core.ip rpc-mocha.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 </code></pre>
 
 :::tip
@@ -96,7 +96,7 @@ you can refer to the
 Run the image from the command line:
 
 <pre><code>
-docker run -e NODE_TYPE=light -e P2P_NETWORK=arabica ghcr.io/celestiaorg/celestia-node:{arabicaVersions['node-latest-tag']} celestia light start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
+docker run -e NODE_TYPE=light -e P2P_NETWORK=arabica ghcr.io/celestiaorg/celestia-node:{arabicaVersions['node-latest-tag']} celestia light start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
 </code></pre>
 
 :::tip
@@ -125,7 +125,7 @@ you can refer to the
 Run the image from the command line:
 
 <pre><code>
-docker run -e NODE_TYPE=bridge -e P2P_NETWORK=blockspacerace ghcr.io/celestiaorg/celestia-node:{blockspaceraceVersions['node-latest-tag']} celestia bridge start --core.ip rpc-blockspacerace.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
+docker run -e NODE_TYPE=bridge -e P2P_NETWORK=blockspacerace ghcr.io/celestiaorg/celestia-node:{blockspaceraceVersions['node-latest-tag']} celestia bridge start --core.ip rpc-blockspacerace.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
 </code></pre>
 
 :::tip
@@ -147,7 +147,7 @@ you can refer to the
 Run the image from the command line:
 
 <pre><code>
-docker run -e NODE_TYPE=bridge -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:sha-{mochaVersions['node-latest-sha'].slice(0, 7)} celestia bridge start --core.ip rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
+docker run -e NODE_TYPE=bridge -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:sha-{mochaVersions['node-latest-sha'].slice(0, 7)} celestia bridge start --core.ip rpc-mocha.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 </code></pre>
 
 :::tip
@@ -171,7 +171,7 @@ you can refer to the
 Run the image from the command line:
 
 <pre><code>
-docker run -e NODE_TYPE=bridge -e P2P_NETWORK=arabica ghcr.io/celestiaorg/celestia-node:{arabicaVersions['node-latest-tag']} celestia bridge start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
+docker run -e NODE_TYPE=bridge -e P2P_NETWORK=arabica ghcr.io/celestiaorg/celestia-node:{arabicaVersions['node-latest-tag']} celestia bridge start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
 </code></pre>
 
 :::tip
@@ -200,7 +200,7 @@ you can refer to the
 Run the image from the command line:
 
 <pre><code>
-docker run -e NODE_TYPE=full -e P2P_NETWORK=blockspacerace ghcr.io/celestiaorg/celestia-node:{blockspaceraceVersions['node-latest-tag']} celestia full start --core.ip rpc-blockspacerace.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
+docker run -e NODE_TYPE=full -e P2P_NETWORK=blockspacerace ghcr.io/celestiaorg/celestia-node:{blockspaceraceVersions['node-latest-tag']} celestia full start --core.ip rpc-blockspacerace.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
 </code></pre>
 
 :::tip
@@ -222,7 +222,7 @@ you can refer to the
 Run the image from the command line:
 
 <pre><code>
-docker run -e NODE_TYPE=full -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:sha-{mochaVersions['node-latest-sha'].slice(0, 7)} celestia full start --core.ip rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
+docker run -e NODE_TYPE=full -e P2P_NETWORK=mocha ghcr.io/celestiaorg/celestia-node:sha-{mochaVersions['node-latest-sha'].slice(0, 7)} celestia full start --core.ip rpc-mocha.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 </code></pre>
 
 :::tip
@@ -246,7 +246,7 @@ you can refer to the
 Run the image from the command line:
 
 <pre><code>
-docker run -e NODE_TYPE=full -e P2P_NETWORK=arabica ghcr.io/celestiaorg/celestia-node:{arabicaVersions['node-latest-tag']} celestia full start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
+docker run -e NODE_TYPE=full -e P2P_NETWORK=arabica ghcr.io/celestiaorg/celestia-node:{arabicaVersions['node-latest-tag']} celestia full start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
 </code></pre>
 
 :::tip
@@ -326,7 +326,7 @@ a light node on Blockspace Race:
 
 ````mdx-code-block
 <pre><code>
-docker run -e NODE_TYPE=light -e P2P_NETWORK=blockspacerace -v $HOME/my-node-store:/home/celestia ghcr.io/celestiaorg/celestia-node:{blockspaceraceVersions['node-latest-tag']} celestia light start --core.ip rpc-blockspacerace.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
+docker run -e NODE_TYPE=light -e P2P_NETWORK=blockspacerace -v $HOME/my-node-store:/home/celestia ghcr.io/celestiaorg/celestia-node:{blockspaceraceVersions['node-latest-tag']} celestia light start --core.ip rpc-blockspacerace.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
 </code></pre>
 ````
 

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -987,7 +987,7 @@ required to be open on your machine.
 :::
 
 ```sh
-celestia light start --core.ip <ip-address> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network <network>
+celestia light start --core.ip <ip-address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network <network>
 ```
 
 </TabItem>
@@ -1009,7 +1009,7 @@ required to be open on your machine.
 :::
 
 ```sh
-celestia light start --core.ip <ip-address> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
+celestia light start --core.ip <ip-address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
 ```
 
 </TabItem>
@@ -1031,7 +1031,7 @@ required to be open on your machine.
 :::
 
 ```sh
-celestia light start --core.ip <ip-address> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network <network>
+celestia light start --core.ip <ip-address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network <network>
 ```
 
 </TabItem>
@@ -1045,7 +1045,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.ip rpc-blockspacerace.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
+celestia light start --core.ip rpc-blockspacerace.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network blockspacerace
 ```
 
 </TabItem>
@@ -1056,7 +1056,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.ip rpc-mocha.pops.one --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
+celestia light start --core.ip rpc-mocha.pops.one --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network mocha
 ```
 
 </TabItem>
@@ -1067,7 +1067,7 @@ If you need a list of RPC endpoints to connect to, you can check from the list [
 For example, your command might look something like this:
 
 ```sh
-celestia light start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
+celestia light start --core.ip consensus-full-arabica-8.celestia-arabica.com --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --p2p.network arabica
 ```
 
 </TabItem>
@@ -1090,7 +1090,7 @@ following command:
 <TabItem value="blockspacerace" label="Blockspace Race">
 
 ```sh
-celestia light start --core.ip <ip-address> --keyring.accname <key_name> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network blockspacerace
+celestia light start --core.ip <ip-address> --keyring.accname <key_name> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network blockspacerace
 ```
 
 Once you start the Light Node, a wallet key will be generated for you.
@@ -1101,7 +1101,7 @@ You will need to fund that address with testnet tokens to pay for
 <TabItem value="mocha" label="Mocha">
 
 ```sh
-celestia light start --core.ip <ip-address> --keyring.accname <key-name> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
+celestia light start --core.ip <ip-address> --keyring.accname <key-name> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
 ```
 
 Once you start the Light Node, a wallet key will be generated for you.
@@ -1112,7 +1112,7 @@ You will need to fund that address with testnet tokens to pay for
 <TabItem value="arabica" label="Arabica 🏗️">
 
 ```sh
-celestia light start --keyring.accname <key_name> --core.ip <ip-address> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
+celestia light start --keyring.accname <key_name> --core.ip <ip-address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
 ```
 
 Once you start the Light Node, a wallet key will be generated for you.
@@ -1162,21 +1162,21 @@ In order to run a light node using a custom key:
 <TabItem value="blockspacerace" label="Blockspace Race">
 
 ```sh
-celestia light start --core.ip <ip-address> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network blockspacerace
+celestia light start --core.ip <ip-address> --keyring.accname <name_of_custom_key> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network blockspacerace
 ```
 
 </TabItem>
 <TabItem value="mocha" label="Mocha">
 
 ```sh
-celestia light start --core.ip <ip-address> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
+celestia light start --core.ip <ip-address> --keyring.accname <name_of_custom_key> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
 ```
 
 </TabItem>
 <TabItem value="arabica" label="Arabica 🏗️">
 
 ```sh
-celestia light start --core.ip <ip-address> --keyring.accname <name_of_custom_key> --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
+celestia light start --core.ip <ip-address> --keyring.accname <name_of_custom_key> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
 ```
 
 </TabItem>


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This is meant to be merged once Mocha and Arabica are upgraded. 

This PR adds the `--gateway.deprecated-endpoints` flag in alignment with https://github.com/celestiaorg/celestia-node/pull/2360. This is meant to not break existing functionality for developers or users, including Rollkit tutorials which I have opened an issue for https://github.com/rollkit/docs/issues/189. I also opened an issue on docs to https://github.com/celestiaorg/docs/issues/850 follow up with guidance on the deprecation

Resolves #849 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
