### PR TITLE
bump version for node to rc7

### DIFF
--- a/versions/mocha_versions.js
+++ b/versions/mocha_versions.js
@@ -3,7 +3,7 @@ const mochaVersions = Object.freeze({
   "app-latest-sha": "2ad80bc4aa1be3ddae6b417189ce58088a93c666",
   "core-latest-tag": "v1.23.0-tm-v0.34.28",
   "core-latest-sha": "67cc27bcb051f911c40444530f4e5257b04dd469",
-  "node-latest-tag": "v0.11.0-rc6",
-  "node-latest-sha": "061b78881d7d3b968fafaff5ec2744f75b775954",
+  "node-latest-tag": "v0.11.0-rc7",
+  "node-latest-sha": "0d10cedaa0d0d117b18b618d1d3ccbe456097495",
 });
 export default mochaVersions;


### PR DESCRIPTION
## Overview

Bump version for mocha-3 to node v0.11.0-rc7

## Checklist
