### PR TITLE
docs: prefer install over build

### DIFF
--- a/docs/nodes/celestia-app.mdx
+++ b/docs/nodes/celestia-app.mdx
@@ -9,7 +9,7 @@ import blockspaceraceVersions  from   "../../versions/blockspacerace_versions.js
 
 # Celestia App
 
-This tutorial will guide you through building `celestia-app`. This
+This tutorial will guide you through installing `celestia-app`. This
 tutorial presumes you completed the steps in setting up your
 own environment [here](./environment.mdx).
 
@@ -66,7 +66,7 @@ make install<br/>
 </Tabs>
 ````
 
-To check if the binary was successfully compiled you can run the binary
+To check if the binary was successfully installed you can run the binary
 using the `--help` flag:
 
 ```sh


### PR DESCRIPTION
There is a subtle difference between installing and building. Since these steps use `make install` and not `make build`, proposal to use the word "install" instead of "build" or "compile".

Ref: https://github.com/celestiaorg/celestia-app/blob/65046dd363fd5b50d9cfc8d83290c28de10a22a2/Makefile#L25-L37