### PR TITLE
docs: fix typos

### DIFF
--- a/docs/developers/celestia-app-vesting.md
+++ b/docs/developers/celestia-app-vesting.md
@@ -74,7 +74,7 @@ The devnet is made up of one validator that is creating new blocks. This is the
 Celestia consensus network on your machine! The key that was created to
 run the validator also lives in a temporary directory for the devnet.
 
-Now you are ready to test creating a vesting accout on our devnet before going
+Now you are ready to test creating a vesting account on our devnet before going
 to Mocha, a live testnet.
 
 ### Setting up vesting account on devnet
@@ -220,7 +220,7 @@ balances to verify this.
 
 #### Query the devnet vesting account details
 
-Check that the account has been created and works as expected by quering
+Check that the account has been created and works as expected by querying
 the `TO_ADDRESS` account details:
 
 ```bash

--- a/docs/developers/optimism.mdx
+++ b/docs/developers/optimism.mdx
@@ -46,7 +46,7 @@ $HOME/.celestia-light-{constants.bsrChainId}/config.toml
 
 If you choose to use your own node store, the light node
 must be **fully synced** and **funded** for you to be able to submit
-and retreive `PayForBlobs` to a Celestia network.
+and retrieve `PayForBlobs` to a Celestia network.
 
 If it is not synced, you will run into [errors](https://github.com/celestiaorg/celestia-node/issues/2151/).
 

--- a/docs/nodes/itn-pfb-transaction.md
+++ b/docs/nodes/itn-pfb-transaction.md
@@ -17,7 +17,7 @@ tutorial [here](https://docs.celestia.org/developers/node-tutorial/#submit-a-pfb
 1. Submit the PFB using the wallet you submitted to us in Phase 2, task 1.
 2. Share PFB transaction hash you submitted.
 3. It has to be unique. We will be checking.
-4. If PFB will be sucessfull, there will a large output, the
+4. If PFB will be successful, there will a large output, the
 tx hash is found by simply checking the `txhash` field in
 the first line of the output.
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

2 typos in `docs/developers/celestia-app-vesting.md`
1 typo in `docs/developers/optimism.mdx`
1 typo in `docs/nodes/itn-pfb-transaction.md`


Best!