### PR TITLE
Add Nodejumper API endpoints for mocha-3 testnet

### DIFF
--- a/docs/nodes/mocha-testnet.mdx
+++ b/docs/nodes/mocha-testnet.mdx
@@ -64,6 +64,7 @@ Below is a list of RPC endpoints you can use to connect to Mocha testnet:
 * `rpc-celestia-mocha3.architectnodes.com`
 * `celestia-rpc.f5nodes.com`
 * `rpc-celestia-testnet.mms.team`
+* `celestia-testnet.nodejumper.io`
 
 ## API endpoints
 
@@ -84,6 +85,7 @@ The default port is 1317.
 * [https://rest-celestia-mocha3.architectnodes.com](https://rest-celestia-mocha3.architectnodes.com)
 * [https://celestia-api.f5nodes.com](https://celestia-api.f5nodes.com)
 * [https://api-celestia-testnet.mms.team](https://api-celestia-testnet.mms.team)
+* [https://celestia-testnet.nodejumper.io:1317](https://celestia-testnet.nodejumper.io:1317)
 
 ## gRPC endpoints
 
@@ -102,6 +104,7 @@ broadcast transactions.
 * [https://celestia.grpc.cumulo.org.es](https://celestia.grpc.cumulo.org.es)
 * [https://celestia-grpc.f5nodes.com](https://celestia-grpc.f5nodes.com)
 * [https://grpc-celestia-testnet.mms.team:12090](https://grpc-celestia-testnet.mms.team)
+* [https://celestia-testnet.nodejumper.io:9090](https://celestia-testnet.nodejumper.io:9090)
 
 ## Mocha testnet faucet
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Added Nodejumper API endpoints for mocha-3 testnet
- rpc - [https://celestia-testnet.nodejumper.io:443](https://celestia-testnet.nodejumper.io)
- api - [https://celestia-testnet.nodejumper.io:1317](https://celestia-testnet.nodejumper.io:1317)
- grpc - [https://celestia-testnet.nodejumper.io:9090](https://celestia-testnet.nodejumper.io:9090)

These endpoints have been tested and used by our web-app and governance telegram bot in production.
https://app.nodejumper.io/celestia-testnet
https://t.me/nodejumper_governance_bot

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
