### PR TITLE
fix: populate `--core.ip` for keys and wallet section

### DIFF
--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -1101,7 +1101,7 @@ You will need to fund that address with testnet tokens to pay for
 <TabItem value="mocha" label="Mocha">
 
 ```sh
-celestia light start --core.ip rpc-mocha.pops.one --keyring.accname <key-name> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
+celestia light start --core.ip rpc-mocha.pops.one --keyring.accname my_celes_key --p2p.network mocha
 ```
 
 Once you start the Light Node, a wallet key will be generated for you.
@@ -1112,7 +1112,7 @@ You will need to fund that address with testnet tokens to pay for
 <TabItem value="arabica" label="Arabica 🏗️">
 
 ```sh
-celestia light start --keyring.accname <key_name> --core.ip consensus-full-arabica-9.celestia-arabica.com --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
+celestia light start --keyring.accname my_celes_key --core.ip consensus-full-arabica-9.celestia-arabica.com --p2p.network arabica
 ```
 
 Once you start the Light Node, a wallet key will be generated for you.

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -10,10 +10,10 @@ import blockspaceraceVersions from "../../versions/blockspacerace_versions.js";
 
 # Setting up a Celestia light node
 
-````mdx-code-block
+```mdx-code-block
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-````
+```
 
 This tutorial will guide you through setting up a Celestia light node, which
 will allow you to perform data availability sampling on the data
@@ -514,7 +514,7 @@ go version go{constants.golangNodeArabica} darwin/amd64
 
 ### Install `celestia-node`
 
-````mdx-code-block
+```mdx-code-block
 <Tabs groupId="network">
 <TabItem value="blockspacerace" label="Blockspace Race">
 
@@ -907,7 +907,7 @@ Golang version: go{constants.golangNodeArabica}<br/>
 
 </TabItem>
 </Tabs>
-````
+```
 
 ## Initialize the light node
 
@@ -1101,7 +1101,7 @@ You will need to fund that address with testnet tokens to pay for
 <TabItem value="mocha" label="Mocha">
 
 ```sh
-celestia light start --core.ip <ip-address> --keyring.accname <key-name> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
+celestia light start --core.ip rpc-mocha.pops.one --keyring.accname <key-name> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network mocha
 ```
 
 Once you start the Light Node, a wallet key will be generated for you.
@@ -1112,7 +1112,7 @@ You will need to fund that address with testnet tokens to pay for
 <TabItem value="arabica" label="Arabica 🏗️">
 
 ```sh
-celestia light start --keyring.accname <key_name> --core.ip <ip-address> --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
+celestia light start --keyring.accname <key_name> --core.ip consensus-full-arabica-9.celestia-arabica.com --gateway.deprecated-endpoints --gateway --gateway.addr <ip-address> --gateway.port <port> --p2p.network arabica
 ```
 
 Once you start the Light Node, a wallet key will be generated for you.
@@ -1190,8 +1190,7 @@ process with SystemD [here](./systemd.md#celestia-light-node).
 
 ## Data availability sampling (DAS)
 
-
-````mdx-code-block
+```mdx-code-block
 <Tabs groupId="network">
 <TabItem value="blockspacerace" label="Blockspace Race">
 
@@ -1212,4 +1211,4 @@ submitting `PayForBlob` transactions [here](../../developers/node-tutorial).
 
 </TabItem>
 </Tabs>
-````
+```


### PR DESCRIPTION
Closes https://github.com/celestiaorg/docs/issues/910

It's possible these were intentionally left as placeholders in the keys and wallet section. If that's the case, the issue and PR can be closed as won't fix.