### PR TITLE
[bug] - resolve broken faucet link

### DIFF
--- a/docs/developers/deploy-on-bubs.md
+++ b/docs/developers/deploy-on-bubs.md
@@ -9,7 +9,7 @@ Bubs testnet.
 * [Node.js](https://nodejs.org/en)
 * Basic understanding of Ethereum
 * Basic understanding of Solidity and Node.js
-* Bubs ETH from the [Bubs faucet](https://bubsfaucet.com)
+* Bubs ETH from the [Bubs faucet](https://bubstestnet.com)
 * A Bubs RPC URL from the [Bubs testnet page](../bubs-testnet)
 
 ## Setup


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The faucet is set up to be used on https://bubstestnet.com, but there is a link in the documentation to https://bubsfaucet.com, which does not work due to auth.

<img width="420" alt="Screenshot 2023-07-28 at 10 51 48" src="https://github.com/celestiaorg/docs/assets/46639943/1ca2674a-2012-4df2-95e1-6a965624855c">

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
