### PR TITLE
Update full-consensus-node.mdx

### DIFF
--- a/docs/nodes/full-consensus-node.mdx
+++ b/docs/nodes/full-consensus-node.mdx
@@ -77,6 +77,19 @@ echo $PERSISTENT_PEERS<br/>
 sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/.celestia-app/config/config.toml<br/>
 </code></pre>
 
+> Mac users built-in `head` command does not accept negative numbers for `-c` flag.
+> Solution is to install `coreutils` package and use `ghead` command from it.
+>
+> ```
+> brew install coreutils
+> ```
+>
+> and optionally set alias from `head` to `ghead` in shell config (`~/.bashrc`, `~/.zshrc` etc):
+>
+> ```
+> alias head=ghead
+> ```
+
 Note: You can find more peers at:
 
 <pre><code>

--- a/docs/nodes/full-consensus-node.mdx
+++ b/docs/nodes/full-consensus-node.mdx
@@ -77,18 +77,21 @@ echo $PERSISTENT_PEERS<br/>
 sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/.celestia-app/config/config.toml<br/>
 </code></pre>
 
-> Mac users built-in `head` command does not accept negative numbers for `-c` flag.
-> Solution is to install `coreutils` package and use `ghead` command from it.
->
-> ```
-> brew install coreutils
-> ```
->
-> and optionally set alias from `head` to `ghead` in shell config (`~/.bashrc`, `~/.zshrc` etc):
->
-> ```
-> alias head=ghead
-> ```
+:::tip
+Mac users built-in `head` command does not accept negative numbers for `-c` flag.
+Solution is to install `coreutils` package and use `ghead` command from it.
+
+<pre><code>
+brew install coreutils
+</code></pre>
+
+and optionally set alias from `head` to `ghead` in shell config (`~/.bashrc`, `~/.zshrc` etc):
+
+<pre><code>
+alias head=ghead
+</code></pre>
+:::
+
 
 Note: You can find more peers at:
 

--- a/docs/nodes/full-consensus-node.mdx
+++ b/docs/nodes/full-consensus-node.mdx
@@ -47,7 +47,7 @@ rm -rf networks
 git clone https://github.com/celestiaorg/networks.git
 ```
 
-````mdx-code-block
+```mdx-code-block
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -147,7 +147,7 @@ https://github.com/celestiaorg/networks/blob/master/{constants.arabicaChainId}/p
 
 </TabItem>
 </Tabs>
-````
+```
 
 ### Configure pruning
 

--- a/docs/nodes/full-consensus-node.mdx
+++ b/docs/nodes/full-consensus-node.mdx
@@ -92,7 +92,6 @@ alias head=ghead
 </code></pre>
 :::
 
-
 Note: You can find more peers at:
 
 <pre><code>
@@ -120,10 +119,25 @@ cp $HOME/networks/{constants.arabicaChainId}/genesis.json $HOME/.celestia-app/co
 Set seeds and peers:
 
 <pre><code>
-PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{constants.arabicaChainId}/peers.txt | tr -d '\n')<br/>
+PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{constants.arabicaChainId}/peers.txt | head -c -1 | tr '\n' ',')<br/>
 echo $PERSISTENT_PEERS<br/>
 sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/.celestia-app/config/config.toml<br/>
 </code></pre>
+
+:::tip
+Mac users built-in `head` command does not accept negative numbers for `-c` flag.
+Solution is to install `coreutils` package and use `ghead` command from it.
+
+<pre><code>
+brew install coreutils
+</code></pre>
+
+and optionally set alias from `head` to `ghead` in shell config (`~/.bashrc`, `~/.zshrc` etc):
+
+<pre><code>
+alias head=ghead
+</code></pre>
+:::
 
 Note: You can find more peers at:
 

--- a/docs/nodes/full-consensus-node.mdx
+++ b/docs/nodes/full-consensus-node.mdx
@@ -47,7 +47,7 @@ rm -rf networks
 git clone https://github.com/celestiaorg/networks.git
 ```
 
-```mdx-code-block
+````mdx-code-block
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -147,7 +147,7 @@ https://github.com/celestiaorg/networks/blob/master/{constants.arabicaChainId}/p
 
 </TabItem>
 </Tabs>
-```
+````
 
 ### Configure pruning
 

--- a/docs/nodes/full-consensus-node.mdx
+++ b/docs/nodes/full-consensus-node.mdx
@@ -72,7 +72,7 @@ cp $HOME/networks/{constants.mochaChainId}/genesis.json $HOME/.celestia-app/conf
 Set seeds and peers:
 
 <pre><code>
-PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{constants.mochaChainId}/peers.txt | tr -d '\n')<br/>
+PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{constants.mochaChainId}/peers.txt | head -c -1 | tr '\n' ',')<br/>
 echo $PERSISTENT_PEERS<br/>
 sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/.celestia-app/config/config.toml<br/>
 </code></pre>


### PR DESCRIPTION
Fixed command for getting persistent peers.

## Overview

Previous version of command for saving persistent peers had bug with removing all new liners from peers list, and as a result node configuration was getting that list in non-readable form:

original list ([from here](https://raw.githubusercontent.com/celestiaorg/networks/master/mocha-4/peers.txt)):

``` 
34499b1ac473fbb03894c883178ecc83f0d6eaf6@64.227.18.169:26656
43e9da043318a4ea0141259c17fcb06ecff816af@rpc-1.celestia.nodes.guru:43656
f9e950870eccdb40e2386896d7b6a7687a103c99@rpc-2.celestia.nodes.guru:43656
daf2cecee2bd7f1b3bf94839f993f807c6b15fbf@celestia-testnet-peer.itrocket.net:11656
```

original command:

```
PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/mocha-4/peers.txt | tr -d '\n')
echo $PERSISTENT_PEERS
```

results in:

```
34499b1ac473fbb03894c883178ecc83f0d6eaf6@64.227.18.169:2665643e9da043318a4ea0141259c17fcb06ecff816af@rpc-1.celestia.nodes.guru:43656f9e950870eccdb40e2386896d7b6a7687a103c99@rpc-2.celestia.nodes.guru:43656daf2cecee2bd7f1b3bf94839f993f807c6b15fbf@celestia-testnet-peer.itrocket.net:11656
```

new command:

```
PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/mocha-4/peers.txt | head -c -1 | tr '\n' ',')
```

results in:

```
34499b1ac473fbb03894c883178ecc83f0d6eaf6@64.227.18.169:26656,43e9da043318a4ea0141259c17fcb06ecff816af@rpc-1.celestia.nodes.guru:43656,f9e950870eccdb40e2386896d7b6a7687a103c99@rpc-2.celestia.nodes.guru:43656,daf2cecee2bd7f1b3bf94839f993f807c6b15fbf@celestia-testnet-peer.itrocket.net:11656
```

## Known issues ##

Mac users built-in `head` command does not except negative numbers for `-c` flag.
Solution is to install `coreutils` package and use `ghead` command from it.

```
brew install coreutils
```

and optionally set alias from `head` to `ghead` in shell config (`~/.bashrc`, `~/.zshrc` etc):

```
alias head=ghead
```


## Checklist

- [+] New and updated code has appropriate documentation
- [+] New and updated code has new and/or updated testing
- [+] Required CI checks are passing
- [+] Visual proof for any user facing features like CLI or documentation updates
- [+] Linked issues closed with keywords
