### PR TITLE
fix: missed "no click heres"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ const versions = ["your-new-version", "v0.11.0-rc8"];
 In `docs/developers/node-api.md`, edit line 11:
 
 ```md
-can be found [here](/api/v0.11.0-rc8).
+[the API's documentation](/api/v0.11.0-rc13).
 ```
 
 Change the above to:
 
 ```md
-can be found [here](/api/your-new-version).
+[the API's documentation](/api/your-new-version).
 ```
 
 6. In the `docs/developers/node-tutorial.mdx` page,

--- a/docs/nodes/full-storage-node.mdx
+++ b/docs/nodes/full-storage-node.mdx
@@ -263,8 +263,7 @@ celestia full start --core.ip http://<ip-address> --keyring.accname <name-of-cus
 
 ### Optional: start the full storage node with SystemD
 
-Follow the tutorial on
-[setting up Celestia App as a background process with SystemD](./systemd.md).
+If you would like to run the full storage node as a background process, follow the [SystemD tutorial](./systemd.md).
 
 With that, you are now running a Celestia full storage node.
 

--- a/docs/nodes/full-storage-node.mdx
+++ b/docs/nodes/full-storage-node.mdx
@@ -263,8 +263,8 @@ celestia full start --core.ip http://<ip-address> --keyring.accname <name-of-cus
 
 ### Optional: start the full storage node with SystemD
 
-Follow the tutorial on setting up the full storage node as a background
-process with SystemD [here](./systemd.md).
+Follow the tutorial on
+[setting up Celestia App as a background process with SystemD](./systemd.md).
 
 With that, you are now running a Celestia full storage node.
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Issue #1073 was made to remove instances of "click here" in the documentation. #1093 resolved this issue, but I missed a few instances of this and noticed when I was[ updating the QGB source](https://github.com/celestiaorg/orchestrator-relayer/pull/511) with the same rule.

Note: a follow-up PR will be made to bring in changes from QGB source. This is why there are still instances of [here] in `qgb-*.md` pages on this branch and main.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
