### PR TITLE
chore: add missing --p2p.network flags

### DIFF
--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -956,7 +956,7 @@ celestia light init --p2p.network blockspacerace
 <TabItem value="mocha" label="Mocha">
 
 ```sh
-celestia light init
+celestia light init --p2p.network mocha
 ```
 
 </TabItem>
@@ -1359,7 +1359,7 @@ celestia blob submit [hex-encoded namespace] [hex-encoded data] \
   [optional: fee] [optional: gasLimit] [node store | auth token]
 ```
 
-We run the following to submit a blob to the network in hexadecimal format:
+We run the following to submit a blob to Mocha testnet in hexadecimal format:
 
 ```bash
 celestia blob submit 0x42690c204d39600fddd3 0x676d \

--- a/docs/developers/node-tutorial.mdx
+++ b/docs/developers/node-tutorial.mdx
@@ -1359,7 +1359,7 @@ celestia blob submit [hex-encoded namespace] [hex-encoded data] \
   [optional: fee] [optional: gasLimit] [node store | auth token]
 ```
 
-We run the following to submit a blob to Mocha testnet in hexadecimal format:
+We run the following to submit a blob to the network in hexadecimal format:
 
 ```bash
 celestia blob submit 0x42690c204d39600fddd3 0x676d \

--- a/docs/nodes/light-node.mdx
+++ b/docs/nodes/light-node.mdx
@@ -925,7 +925,7 @@ celestia light init --p2p.network blockspacerace
 You should see output like:
 
 ```output
-$ celestia light init
+$ celestia light init --p2p.network blockspacerace
 2022-12-19T21:45:24.591Z        INFO    node    nodebuilder/init.go:19  Initializing Light Node Store over '/root/.celestia-light-blockspacerace-0'
 2022-12-19T21:45:24.591Z        INFO    node    nodebuilder/init.go:50  Saving config   {"path": "/root/.celestia-light-blockspacerace-0/config.toml"}
 2022-12-19T21:45:24.592Z        INFO    node    nodebuilder/init.go:51  Node Store initialized
@@ -935,7 +935,7 @@ $ celestia light init
 <TabItem value="mocha" label="Mocha">
 
 ```sh
-celestia light init
+celestia light init --p2p.network mocha
 ```
 
 You should see output like:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Adds missing `--p2p.network string` flags where they are missing, ahead of mainnet and #1138.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
