### PR TITLE
feat: add celestia-app prebuilt binary script

### DIFF
--- a/nodes/celestia-app.md
+++ b/nodes/celestia-app.md
@@ -13,8 +13,45 @@ import mochaVersions from '/.vitepress/constants/mocha_versions.js'
 import coffeeVersions from '/.vitepress/constants/coffee_versions.js'
 </script>
 
-This tutorial will guide you through installing celestia-app. This
-tutorial presumes you completed the steps in
+This tutorial will guide you through installing celestia-app, both with
+[a pre-built binary](#installing-a-pre-built-binaries) and
+[from source](#building-binary-from-source).
+
+## Installing a pre-built binaries
+
+Installing a pre-built binary is the fastest way to get started with your
+Celestia consensus node. Versions containing
+[PR 2654](https://github.com/celestiaorg/celestia-app/pull/2654)
+will have these binaries available.
+
+Pre-built binaries are available for:
+
+- Operating systems: Darwin (Apple), Linux
+- Architectures: x86_64 (amd64), arm64
+
+To install the latest pre-built binary you can run this command in your
+terminal:
+
+```bash
+curl -L -s https://celestiaorg.github.io/docs/pr-preview/pr-1198/celestia-app.sh | bash
+```
+
+<!-- ```bash
+curl -L -s https://docs.celestia.org/celestia-app.sh | bash
+``` -->
+
+Follow the instructions in the terminal output to run and interact
+with the binary.
+
+View [the script](https://github.com/celestiaorg/docs/tree/jcs/add-prebuild-app-binaries/public/celestia-app.sh)
+to learn more about what it is doing.
+<!-- 
+View [the script](https://github.com/celestiaorg/docs/tree/main/public/celestia-app.sh)
+to learn more about what it is doing. -->
+
+## Building binary from source
+
+This section of the tutorial presumes you completed the steps in
 [setting up your own environment](./environment.md).
 
 The steps below will create a binary file named `celestia-appd`

--- a/nodes/celestia-app.md
+++ b/nodes/celestia-app.md
@@ -17,7 +17,7 @@ This tutorial will guide you through installing celestia-app, both with
 [a pre-built binary](#installing-a-pre-built-binaries) and
 [from source](#building-binary-from-source).
 
-## Installing a pre-built binaries
+## Installing a pre-built binary
 
 Installing a pre-built binary is the fastest way to get started with your
 Celestia consensus node. Versions containing

--- a/nodes/celestia-app.md
+++ b/nodes/celestia-app.md
@@ -20,9 +20,7 @@ This tutorial will guide you through installing celestia-app, both with
 ## Installing a pre-built binary
 
 Installing a pre-built binary is the fastest way to get started with your
-Celestia consensus node. Versions containing
-[PR 2654](https://github.com/celestiaorg/celestia-app/pull/2654)
-will have these binaries available.
+Celestia consensus node. Releases after celestia-app v1.3.0 should have these binaries available.
 
 Pre-built binaries are available for:
 

--- a/nodes/celestia-app.md
+++ b/nodes/celestia-app.md
@@ -14,7 +14,7 @@ import coffeeVersions from '/.vitepress/constants/coffee_versions.js'
 </script>
 
 This tutorial will guide you through installing celestia-app, both with
-[a pre-built binary](#installing-a-pre-built-binaries) and
+[a pre-built binary](#installing-a-pre-built-binary) and
 [from source](#building-binary-from-source).
 
 ## Installing a pre-built binary
@@ -31,21 +31,14 @@ To install the latest pre-built binary you can run this command in your
 terminal:
 
 ```bash
-curl -L -s https://celestiaorg.github.io/docs/pr-preview/pr-1198/celestia-app.sh | bash
-```
-
-<!-- ```bash
 curl -L -s https://docs.celestia.org/celestia-app.sh | bash
-``` -->
+```
 
 Follow the instructions in the terminal output to run and interact
 with the binary.
 
-View [the script](https://github.com/celestiaorg/docs/tree/jcs/add-prebuild-app-binaries/public/celestia-app.sh)
-to learn more about what it is doing.
-<!-- 
 View [the script](https://github.com/celestiaorg/docs/tree/main/public/celestia-app.sh)
-to learn more about what it is doing. -->
+to learn more about what it is doing.
 
 ## Building binary from source
 

--- a/public/celestia-app.sh
+++ b/public/celestia-app.sh
@@ -6,8 +6,6 @@ echo " _______ / /__ ___ / /_(_)__ ________ ____  ___ "
 echo "/ __/ -_) / -_|_-</ __/ / _ \`/___/ _ \`/ _ \/ _ \\"
 echo "\\__/\\__/_/\\__/___/\\__/_/\\_,_/    \\_,_/ .__/ .__/"
 echo "                                    /_/  /_/    "
-
-# Rest of your script...
 echo ""
 
 # Create a log file to capture detailed logs
@@ -32,7 +30,6 @@ touch "$LOGFILE"
 echo "Log file is located at: $LOGFILE" | tee -a "$LOGFILE"
 
 # Create a temporary directory to work from
-TEMP_DIR="$HOME/celestia-temp"
 mkdir -p "$TEMP_DIR"
 cd "$TEMP_DIR"
 

--- a/public/celestia-app.sh
+++ b/public/celestia-app.sh
@@ -36,7 +36,7 @@ cd "$TEMP_DIR"
 # Log and print a message
 echo "Working from temporary directory: $TEMP_DIR" | tee -a "$LOGFILE"
 
-# Comment out once all releases haev prebuilt binaries
+# Comment out once all releases have prebuilt binaries
 # Set the version manually, until all releases have prebuilt
 # binaries attached to them
 VERSION=v1.1.0

--- a/public/celestia-app.sh
+++ b/public/celestia-app.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# ASCII art
+echo "          __        __  _                       "
+echo " _______ / /__ ___ / /_(_)__ ________ ____  ___ "
+echo "/ __/ -_) / -_|_-</ __/ / _ \`/___/ _ \`/ _ \/ _ \\"
+echo "\\__/\\__/_/\\__/___/\\__/_/\\_,_/    \\_,_/ .__/ .__/"
+echo "                                    /_/  /_/    "
+
+# Rest of your script...
+echo ""
+
+# Create a log file to capture detailed logs
+LOGFILE="$HOME/celestia-temp/logfile.log"
+TEMP_DIR="$HOME/celestia-temp"
+
+# Check if the directory exists
+if [ -d "$TEMP_DIR" ]; then
+    read -p "Directory $TEMP_DIR exists. Do you want to clear it out? (y/n) " -n 1 -r
+    echo    # move to a new line
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        rm -rf "$TEMP_DIR"
+        echo "Directory $TEMP_DIR has been removed."
+    fi
+fi
+
+mkdir -p "$TEMP_DIR"
+touch "$LOGFILE"
+
+# Log and print the log file location
+echo "Log file is located at: $LOGFILE" | tee -a "$LOGFILE"
+
+# Create a temporary directory to work from
+TEMP_DIR="$HOME/celestia-temp"
+mkdir -p "$TEMP_DIR"
+cd "$TEMP_DIR"
+
+# Log and print a message
+echo "Working from temporary directory: $TEMP_DIR" | tee -a "$LOGFILE"
+
+# Comment out once all releases haev prebuilt binaries
+# Set the version manually, until all releases have prebuilt
+# binaries attached to them
+VERSION=v1.1.0
+
+# # Uncomment this once all releases have prebuilt binaries
+# # Fetch the latest release tag from GitHub
+# VERSION=$(curl -s "https://api.github.com/repos/celestiaorg/celestia-app/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+# Log and print a message
+echo "Latest version detected: $VERSION" | tee -a "$LOGFILE"
+
+# Detect the operating system and architecture
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+# Translate architecture to expected format
+case $ARCH in
+    x86_64)
+        ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        ARCH="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture." | tee -a "$LOGFILE"
+        exit 1
+        ;;
+esac
+
+# Translate OS to expected format
+case $OS in
+    Linux|Darwin)
+        ;;
+    *)
+        echo "Unsupported operating system." | tee -a "$LOGFILE"
+        exit 1
+        ;;
+esac
+
+# Construct the download URL
+PLATFORM="${OS}_${ARCH}"
+URL="https://github.com/celestiaorg/celestia-app/releases/download/$VERSION/celestia-app_$PLATFORM.tar.gz"
+
+# Log and print a message
+echo "Downloading from: $URL" | tee -a "$LOGFILE"
+
+# Download the tarball
+if ! wget "$URL" >> "$LOGFILE" 2>&1; then
+    echo "Download failed. Exiting." | tee -a "$LOGFILE"
+    exit 1
+fi
+
+# Detect if running on macOS and use appropriate command for checksum
+if [ "$OS" = "Darwin" ]; then
+    CALCULATED_CHECKSUM=$(shasum -a 256 "celestia-app_$PLATFORM.tar.gz" | awk '{print $1}')
+else
+    CALCULATED_CHECKSUM=$(sha256sum "celestia-app_$PLATFORM.tar.gz" | awk '{print $1}')
+fi
+
+# Download checksums.txt
+if ! wget "https://github.com/celestiaorg/celestia-app/releases/download/$VERSION/checksums.txt" >> "$LOGFILE" 2>&1; then
+    echo "Failed to download checksums. Exiting." | tee -a "$LOGFILE"
+    exit 1
+fi
+
+# Find the expected checksum in checksums.txt
+EXPECTED_CHECKSUM=$(grep "celestia-app_$PLATFORM.tar.gz" checksums.txt | awk '{print $1}')
+
+# Verify the checksum
+if [ "$CALCULATED_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
+    echo "Checksum verification failed. Exiting." | tee -a "$LOGFILE"
+    exit 1
+else
+    echo "Checksum verification successful." | tee -a "$LOGFILE"
+fi
+
+# Extract the tarball to the temporary directory
+if ! tar -xzf "celestia-app_$PLATFORM.tar.gz" >> "$LOGFILE" 2>&1; then
+    echo "Extraction failed. Exiting." | tee -a "$LOGFILE"
+    exit 1
+fi
+
+# Log and print a message
+echo "Binary extracted to: $TEMP_DIR" | tee -a "$LOGFILE"
+
+# Remove the tarball to clean up
+rm "celestia-app_$PLATFORM.tar.gz"
+
+# Log and print a message
+echo "Temporary files cleaned up." | tee -a "$LOGFILE"
+
+# Provide final instructions to the user
+echo "You can navigate to $TEMP_DIR to find and run celestia-appd." | tee -a "$LOGFILE"
+echo "To run the app and check its version, you may execute the following commands:" | tee -a "$LOGFILE"
+echo ""
+echo "cd $TEMP_DIR" | tee -a "$LOGFILE"
+echo "chmod +x celestia-appd" | tee -a "$LOGFILE"
+echo "./celestia-appd version" | tee -a "$LOGFILE"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves #1134
Resolves #1201
adding a prebuilt binary script to documentation for celestia-app, to allow users to download the binary instead of building it on their own.

- [x] use curl to set latest version once celestia-app consistently has binaries in the release
- [x] change URL path to script before this PR is merged
- [x] also, update curl to:

```bash
curl -L -s https://docs.celestia.org/celestia-app.sh | bash
```

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
