### PR TITLE
Persistent Docker Node Instructions for Windows Users

### DIFF
--- a/nodes/docker-images.md
+++ b/nodes/docker-images.md
@@ -122,11 +122,13 @@ If you delete a container that you started above, all data will be lost.
 To avoid this, you can mount a volume to the container.
 This will allow you to persist data even after the container is deleted.
 
-For security purposes Celestia expects to interact with the your node's keys in a read-only manner.
-This is enforced using linux style permissions on the filesystem.
-Windows NTFS does not support these types of permissions.
-As a result the recommended path for Windows users to mount a persisted volume is to do so within WSL.
-You can find [instructions for installing WSL here](https://learn.microsoft.com/en-us/windows/wsl/install).
+For security purposes Celestia expects to interact with the your node's
+keys in a read-only manner. This is enforced using linux style permissions
+on the filesystem. Windows NTFS does not support these types of permissions.
+As a result the recommended path for Windows users to mount a persisted
+volume is to do so within WSL.
+You can find
+[instructions for installing WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 
 First, you will need to create a directory on your host machine.
 This directory will be used to store the data for the container.

--- a/nodes/docker-images.md
+++ b/nodes/docker-images.md
@@ -122,6 +122,12 @@ If you delete a container that you started above, all data will be lost.
 To avoid this, you can mount a volume to the container.
 This will allow you to persist data even after the container is deleted.
 
+For security purposes Celestia expects to interact with the your node's keys in a read-only manner.
+This is enforced using linux style permissions on the filesystem.
+Windows NTFS does not support these types of permissions.
+As a result the recommended path for Windows users to mount a persisted volume is to do so within WSL.
+You can find [instructions for installing WSL here](https://learn.microsoft.com/en-us/windows/wsl/install).
+
 First, you will need to create a directory on your host machine.
 This directory will be used to store the data for the container.
 Create a directory on your host machine and give it a name.

--- a/nodes/docker-images.md
+++ b/nodes/docker-images.md
@@ -122,14 +122,6 @@ If you delete a container that you started above, all data will be lost.
 To avoid this, you can mount a volume to the container.
 This will allow you to persist data even after the container is deleted.
 
-For security purposes Celestia expects to interact with the your node's
-keys in a read-only manner. This is enforced using linux style permissions
-on the filesystem. Windows NTFS does not support these types of permissions.
-As a result the recommended path for Windows users to mount a persisted
-volume is to do so within WSL.
-You can find
-[instructions for installing WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
-
 First, you will need to create a directory on your host machine.
 This directory will be used to store the data for the container.
 Create a directory on your host machine and give it a name.
@@ -249,3 +241,13 @@ Congratulations! You now have a node running with persistent storage.
     allowfullscreen
   ></iframe>
 </div>
+
+## Troubleshooting
+
+For security purposes Celestia expects to interact with the your node's
+keys in a read-only manner. This is enforced using linux style permissions
+on the filesystem. Windows NTFS does not support these types of permissions.
+As a result the recommended path for Windows users to mount a persisted
+volume is to do so within WSL.
+You can find
+[instructions for installing WSL](https://learn.microsoft.com/en-us/windows/wsl/install).


### PR DESCRIPTION
## Overview

This PR provides some information necessary for Windows users to be able to successfully run a persistent docker node. NTFS does not support linux style permissions so when a docker node is started the first time it creates the desired files to store the node, but afterwards will refuse to run indicating that the file containing the keys has permissions of 777 instead of 600. In order to avoid these issues it is recommended that Windows users install and run WSL and then run the docker container with the celestia node storage mounted within the WSL filesystem which obviously supports linux permissions.

Associated issue can be found here #1228 .

## Checklist

- [X] New and updated code has appropriate documentation
- [X] New and updated code has new and/or updated testing
- [X] Required CI checks are passing
- [X] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
