### PR TITLE
Fix incorrect variable name in deployment instructions

### DIFF
--- a/developers/deploy-on-bubs.md
+++ b/developers/deploy-on-bubs.md
@@ -221,7 +221,7 @@ To write to the contract, we'll use the `cast send` command:
 <!-- markdownlint-disable MD013 -->
 
 ```bash
-cast send $CONTRACT_ADDRESS "setNumber(uint256)" 10 --rpc-url $BUBS_RPC_URL --private-key $PRIVATE_KEY
+cast send $CONTRACT_ADDRESS "setNumber(uint256)" 10 --rpc-url $BUBS_RPC_URL --private-key $BUBS_PRIVATE_KEY
 ```
 
 <!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
## Overview

This pull request fixes an incorrect variable name in the smart contract deployment instructions. The variable `$PRIVATE_KEY` is referenced in the `cast send` command, but it should be `$BUBS_PRIVATE_KEY` as defined earlier in the document. This change ensures consistency and prevents potential confusion for users following the deployment steps.

## Checklist

- Replaced `$PRIVATE_KEY` with `$BUBS_PRIVATE_KEY` in the command for sending a transaction to the smart contract.
