### PR TITLE
eth-fallback: rewrite for release-v1.0.0

### DIFF
--- a/developers/eth-fallback.md
+++ b/developers/eth-fallback.md
@@ -5,8 +5,8 @@ description: The DA fallback mechanism to Ethereum for rollups.
 # ETH fallback
 
 ETH fallback is
-[a fallback mechanism](https://github.com/celestiaorg/optimism/commit/1215c15fda540a1f19b81588de98e2e7b546e517)
-that enables Ethereum L2s (or L3s) to “fall back” to posting Ethereum
+[a fallback mechanism](https://github.com/celestiaorg/optimism/pull/266)
+that enables Ethereum L2s (or L3s) to “fall back” to using Ethereum
 calldata for data availability in the event of downtime on Celestia
 Mainnet Beta. This feature is currently supported by Celestia integrations
 with:
@@ -27,9 +27,6 @@ triggered due to a congested mempool or nonce error and can be simulated
 with an error such as low balance or incorrect sequence. Fallback
 can also be triggered in the event Blobstream stops relaying attestations.
 
-The integration is still a work in progress, and the
-[most up-to-date version can be found on the `tux/frame-ref-version` branch](https://github.com/celestiaorg/optimism/tree/tux/frame-ref-version).
-
 ![ETH fallback](/img/Celestia_ETH-fallback.jpg
 )
 
@@ -47,40 +44,38 @@ The [@celestiaorg/nitro](https://github.com/celestiaorg/nitro) integration
 
 ## OP Stack
 
-The ETH fallback mechanism is set up in the
-[celestiaorg/optimism integration](https://github.com/celestiaorg/optimism/tree/tux/rebase-frame-ref-version).
+The ETH fallback mechanism is implemented in the
+[celestiaorg/optimism](https://github.com/celestiaorg/optimism/tree/release-v1.0.0) v1.0.0 release.
 
 The `op-batcher/batcher/driver.go` and
 `op-node/rollup/derive/calldata_source.go` files are part of the ETH
-fallback mechanism in the op-batcher and op-noderespectively.
+fallback mechanism in the `op-batcher` and `op-node` respectively.
 
-In [`driver.go`, the `sendTransaction` function is responsible for the write path](https://github.com/celestiaorg/optimism/blob/1215c15fda540a1f19b81588de98e2e7b546e517/op-batcher/batcher/driver.go#L351-L395)
+In [`driver.go`, the `sendTransaction` function is responsible for the write path](https://github.com/celestiaorg/optimism/blob/release-v1.0.0/op-batcher/batcher/driver.go#L400-L406)
 of the ETH fallback. This function creates and submits a transaction to the
 batch inbox address with the given data. It uses the underlying `txmgr` to
-handle transaction sending and price management. If the transaction data
-can be published to Celestia, it creates a `FrameCelestiaStdRef` and sends
-the transaction with this data. If it cannot be published to Celestia, it
-falls back to Ethereum by creating a `FrameEthereumStdRef` and sends the
-transaction with this data.
+handle transaction sending and gas price management.
 
-That the transaction data includes a version prefix, which determines how
-the data will be parsed.
+If the transaction data can be published as a blob to Celestia,
+it replaces the calldata with a blob identifier and sends the
+transaction with this data. If it cannot be published to Celestia,
+it falls back to Ethereum without any change to the transaction.
+
+The blob identifer starts with the special prefix `0xce`, which was chosen a
+mnemonic for Celestia, and indicates that the remaining data has to
+interpreted as a little-endian encoded Block Height (8 bytes) and
+Blob Commitment (32 bytes). The combination of these can later be used to
+retrieve the original calldata from Celestia.
 
 <!-- markdownlint-disable MD013 -->
-| Version | Prefix | Frame type            | Description                                                                                     |
-|---------|--------|-----------------------|-------------------------------------------------------------------------------------------------|
-| v0      | 0x00   | `FrameCelestiaLegacyRef`| Legacy celestia - 8 bytes block height, 4 bytes tx index                   |
-| v1      | 0x01   | `FrameEthereumStdRef`   | Eth calldata fallback - all remaining bytes are interpreted as Frame       |
-| v2      | 0x02   | `FrameCelestiaStdRef`   | Standard celestia - 8 bytes block height, 32 byte tx commitment            |
+| Prefix | 8 bytes       | 32 bytes        |
+|--------|---------------|-----------------|
+| 0xce   | Block Height  | Blob Commitment |
 <!-- markdownlint-enable MD013 -->
-
-In other words, the first byte of the calldata is interpreted as
-the version prefix which determines how to parse the remaining data.
-
 ```go
 func (l *BatchSubmitter) sendTransaction(
-    txdata txData, 
-    queue *txmgr.Queue[txData], 
+    txdata txData,
+    queue *txmgr.Queue[txData],
     receiptsCh chan txmgr.TxReceipt[txData],
 ) {
     // ...
@@ -88,18 +83,19 @@ func (l *BatchSubmitter) sendTransaction(
 ```
 
 In `calldata_source.go`,
-[the `DataFromEVMTransactions` function defines the read path](https://github.com/celestiaorg/optimism/blob/1215c15fda540a1f19b81588de98e2e7b546e517/op-node/rollup/derive/calldata_source.go#L131-L180)
-of the ETH fallback. This function filters all of the transactions and returns
-the calldata from transactions that are sent to the batch inbox address from
-the batch sender address. It checks the type of the frame by reading the version
-prefix and retrieves the data accordingly. If the frame is `FrameCelestiaLegacy`
-or `FrameCelestiaStd`, it requests the data from Celestia. If the frame is
-`FrameEthereumStd`, it directly uses the calldata from the frame.
+[the `DataFromEVMTransactions` function defines the read path](https://github.com/celestiaorg/optimism/blob/release-v1.0.0/op-node/rollup/derive/calldata_source.go#L138-L163)
+of the ETH fallback. This function filters all of the transactions
+and returns the calldata from transactions that are sent to the batch
+inbox address from the batch sender address.
+
+If the calldata matches the version prefix `0xce`, it is decoded as a
+blob identifier, the original calldata is retrieved from Celestia
+and returned for derivation. If the calldata does not match the prefix,
+the entire calldata is returned for derivation.
 
 ```go
 func DataFromEVMTransactions(
     config *rollup.Config,
-    daClient *rollup.DAClient,
     batcherAddr common.Address,
     txs types.Transactions,
     log log.Logger
@@ -109,6 +105,6 @@ func DataFromEVMTransactions(
 ```
 
 These two functions work together to ensure that the ETH
-fallback mechanism operates correctly, allowing the system
+fallback mechanism operates correctly, allowing the rollup
 to continue functioning even during periods of downtime on
 Celestia.


### PR DESCRIPTION
## Overview

This PR updates the `eth-fallback` page OP stack section to reflect the changes in the `v1.0.0` release of OP stack integration.

## Checklist


- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
