### PR TITLE
op stack: fix deploy guide

### DIFF
--- a/developers/optimism.md
+++ b/developers/optimism.md
@@ -140,7 +140,7 @@ da:
   image: ghcr.io/rollkit/celestia-da:v0.12.1-rc0 // [!code ++]
   command: > // [!code ++]
     celestia-da light start // [!code ++]
-    --p2p.network=$P2P_NETWORK // [!code ++]
+    --p2p.network=<network> // [!code ++]
     --da.grpc.namespace=000008e5f679bf7116cb // [!code ++]
     --da.grpc.listen=0.0.0.0:26650 // [!code ++]
     --core.ip rpc.celestia.pops.one // [!code ++]
@@ -153,7 +153,7 @@ da:
     - "26658:26658"
     - "26659:26659"
   volumes: // [!code ++]
-    - $HOME/.celestia-light-<network>/:/home/celestia/.celestia-light.<network>/ // [!code ++]
+    - $HOME/.celestia-light-<network>/:/home/celestia/.celestia-light-<network>/ // [!code ++]
   healthcheck:
     test: ["CMD", "curl", "-f", "http://localhost:26659/header/1"]
     interval: 10s

--- a/developers/optimism.md
+++ b/developers/optimism.md
@@ -149,7 +149,7 @@ da:
       - NODE_TYPE=light // [!code ++]
       - P2P_NETWORK=<network> // [!code ++]
   ports:
-    - "26650:26650" // [!code --]
+    - "26650:26650"
     - "26658:26658"
     - "26659:26659"
   volumes: // [!code ++]


### PR DESCRIPTION
## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Minor fixes to OP stack deployment guide. The port `26650` is required and should be retained. Also fixes network flag and node store location.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
