### PR TITLE
feat: generalize rpc flag

### DIFF
--- a/developers/optimism.md
+++ b/developers/optimism.md
@@ -131,7 +131,8 @@ a DA server on port 26650.
 
 For the `P2P_NETWORK` variable, you'll need to supply the network of choice, either
 `celestia`, `mocha`, or `arabica`. Using `celestia`, the volume path will be just
-`.celestia-light` instead of `.celestia-light-<network>`.
+`.celestia-light` instead of `.celestia-light-<network>`. You will also need
+to provide a core.ip RPC URL for the network you are using.
 
 <!-- markdownlint-disable MD013 -->
 ```yaml
@@ -143,7 +144,7 @@ da:
     --p2p.network=<network> // [!code ++]
     --da.grpc.namespace=000008e5f679bf7116cb // [!code ++]
     --da.grpc.listen=0.0.0.0:26650 // [!code ++]
-    --core.ip rpc.celestia.pops.one // [!code ++]
+    --core.ip <rpc-url> // [!code ++]
     --gateway // [!code ++]
   environment: // [!code ++]
       - NODE_TYPE=light // [!code ++]


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Generalizes the `--core.ip string` flag to use `<rpc-url>` instead of a hardcoded endpoint that was for mainnet.
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
