### PR TITLE
chore: run yarn lint

### DIFF
--- a/developers/blobstream.md
+++ b/developers/blobstream.md
@@ -99,11 +99,13 @@ You can interact with the Blobstream contracts today on testnet. The Blobstream 
 smart contracts are currently deployed on the following Ethereum testnets:
 
 <!-- markdownlint-disable MD013 -->
-| Contract | EVM network | Contract address | Attested data |
-| --- | --- | --- | --- |
-| Blobstream | Sepolia | [`0x3a5cbB6EF4756DA0b3f6DAE7aB6430fD8c46d247`](https://sepolia.etherscan.io/address/0x3a5cbB6EF4756DA0b3f6DAE7aB6430fD8c46d247) | Mocha testnet |
-| Blobstream | Arbitrum Sepolia | [`0x040769edbca5218e616c8eb16e4faea49ced5e33`](https://sepolia.arbiscan.io/address/0x040769edbca5218e616c8eb16e4faea49ced5e33) | Mocha testnet |
-| Blobstream X | Goerli | [`0x67ea962864cdad3f2202118dc6f65ff510f7bb4d`](https://goerli.etherscan.io/address/0x67ea962864cdad3f2202118dc6f65ff510f7bb4d) | Mocha testnet |
+
+| Contract     | EVM network      | Contract address                                                                                                                | Attested data |
+| ------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| Blobstream   | Sepolia          | [`0x3a5cbB6EF4756DA0b3f6DAE7aB6430fD8c46d247`](https://sepolia.etherscan.io/address/0x3a5cbB6EF4756DA0b3f6DAE7aB6430fD8c46d247) | Mocha testnet |
+| Blobstream   | Arbitrum Sepolia | [`0x040769edbca5218e616c8eb16e4faea49ced5e33`](https://sepolia.arbiscan.io/address/0x040769edbca5218e616c8eb16e4faea49ced5e33)  | Mocha testnet |
+| Blobstream X | Goerli           | [`0x67ea962864cdad3f2202118dc6f65ff510f7bb4d`](https://goerli.etherscan.io/address/0x67ea962864cdad3f2202118dc6f65ff510f7bb4d)  | Mocha testnet |
+
 <!-- markdownlint-enable MD013 -->
 
 ## Blobstream vs. data availability committees (DACs)

--- a/developers/ethereum-fallback.md
+++ b/developers/ethereum-fallback.md
@@ -56,10 +56,13 @@ Blob Commitment (32 bytes). The combination of these can later be used to
 retrieve the original calldata from Celestia.
 
 <!-- markdownlint-disable MD013 -->
-| Prefix | 8 bytes       | 32 bytes        |
-|--------|---------------|-----------------|
-| 0xce   | Block Height  | Blob Commitment |
+
+| Prefix | 8 bytes      | 32 bytes        |
+| ------ | ------------ | --------------- |
+| 0xce   | Block Height | Blob Commitment |
+
 <!-- markdownlint-enable MD013 -->
+
 ```go
 func (l *BatchSubmitter) sendTransaction(
     txdata txData,

--- a/developers/optimism.md
+++ b/developers/optimism.md
@@ -135,6 +135,7 @@ For the `P2P_NETWORK` variable, you'll need to supply the network of choice, eit
 to provide a core.ip RPC URL for the network you are using.
 
 <!-- markdownlint-disable MD013 -->
+
 ```yaml
 da:
   image: ghcr.io/rollkit/local-celestia-devnet:v0.12.1 // [!code --]

--- a/nodes/blobstream-orchestrator.md
+++ b/nodes/blobstream-orchestrator.md
@@ -155,7 +155,7 @@ To start the orchestrator in the default home directory, run the following:
 blobstream orchestrator start --evm.account 0x966e6f22781EF6a6A82BBB4DB3df8E225DfD9488
 ```
 
-> **_NOTE:_** The above command assumes that the necessary configuration is specified in the  `<orchestrator_home>/config/config.toml` file.
+> **_NOTE:_** The above command assumes that the necessary configuration is specified in the `<orchestrator_home>/config/config.toml` file.
 
 Then, you will be prompted to enter your EVM key passphrase so that the orchestrator can use it to sign attestations. Make sure that it's the EVM address that was provided when creating the validator. If not, then the orchestrator will not sign, and you will keep seeing a "validator not part of valset" warning message. If you see such message, first verify that your validator is part of the active validator set. If so, then probably the EVM address provided to the orchestrator is not the right one, and you should check which EVM address is registered to your validator. Check the [Register EVM Address](#register-evm-address) section for more information.
 
@@ -166,7 +166,7 @@ If you no longer have access to your EVM address, you could always edit your val
 #### `transport: authentication handshake failed`
 
 ```text
-rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake" 
+rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"
 ```
 
 Seeing this error means that the orchestrator/relayer is trying to connect to a gRPC endpoint that is not secure. To bypass this, use the `--grpc.insecure` flag. However, we recommend using secure gRPC connections.

--- a/nodes/blobstream-relayer.md
+++ b/nodes/blobstream-relayer.md
@@ -118,6 +118,6 @@ To start the relayer using the default home directory, run the following:
 /bin/blobstream relayer start --evm.account=0x35a1F8CE94187E4b043f4D57548EF2348Ed556c8
 ```
 
-> **_NOTE:_** The above command assumes that the necessary configuration is specified in the  `<relayer_home>/config/config.toml` file.
+> **_NOTE:_** The above command assumes that the necessary configuration is specified in the `<relayer_home>/config/config.toml` file.
 
 Then, you will be prompted to enter your EVM key passphrase for the EVM address passed using the `--evm.account` flag, so that the relayer can use it to send transactions to the target Blobstream smart contract. Make sure that it's funded.


### PR DESCRIPTION
While working on a different PR, the commit pre-hook failed because `yarn lint` resulted in a diff. Since these changes are unrelated to my PR, I included them here. 

Note: I wonder why CI lint didn't catch these? Do we want an issue to investigate the discrepancy between local lint and CI lint?