### PR TITLE
feat: add direct links to gov params for `blob.GasPerBlobByte` and `auth.TxSizeCostPerByte`

### DIFF
--- a/developers/submit-data.md
+++ b/developers/submit-data.md
@@ -60,7 +60,9 @@ how many shares are needed to store the blob size. Then, it computes the product
 of the number of shares, the number of bytes per share, and the `gasPerByte`
 parameter. Finally, it adds a static amount per blob.
 
-The `GasCostPerBlobByte` and `GasCostPerTransactionByte` are parameters that
+The [`blob.GasPerBlobByte`](https://github.com/celestiaorg/celestia-app/blob/ad91a5b2ca2d562f0b8c9c2e1ed6b4d3098a2e8e/specs/src/specs/params.md?plain=1#L27)
+and [`auth.TxSizeCostPerByte`](https://github.com/celestiaorg/celestia-app/blob/ad91a5b2ca2d562f0b8c9c2e1ed6b4d3098a2e8e/specs/src/specs/params.md?plain=1#L25C11-L25C11)
+are parameters that
 could potentially be adjusted through the system's governance mechanisms. Hence,
 actual costs may vary depending on the current state of these parameters.
 

--- a/developers/submit-data.md
+++ b/developers/submit-data.md
@@ -61,7 +61,7 @@ of the number of shares, the number of bytes per share, and the `gasPerByte`
 parameter. Finally, it adds a static amount per blob.
 
 The [`blob.GasPerBlobByte`](https://github.com/celestiaorg/celestia-app/blob/ad91a5b2ca2d562f0b8c9c2e1ed6b4d3098a2e8e/specs/src/specs/params.md?plain=1#L27)
-and [`auth.TxSizeCostPerByte`](https://github.com/celestiaorg/celestia-app/blob/ad91a5b2ca2d562f0b8c9c2e1ed6b4d3098a2e8e/specs/src/specs/params.md?plain=1#L25C11-L25C11)
+and [`auth.TxSizeCostPerByte`](https://github.com/celestiaorg/celestia-app/blob/ad91a5b2ca2d562f0b8c9c2e1ed6b4d3098a2e8e/specs/src/specs/params.md?plain=1#L25)
 are parameters that
 could potentially be adjusted through the system's governance mechanisms. Hence,
 actual costs may vary depending on the current state of these parameters.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

### Problem
Variables are not accurate, based on governance params.

| Currently | Should be |
| --------- | ---------- |
| `GasCostPerBlobByte` | `blob.GasPerBlobByte` |
| `GasCostPerTransactionByte ` | `auth.TxSizeCostPerByte` |

### Solution

Edit documentation to match `blob.GasPerBlobByte` and `auth.TxSizeCostPerByte` to be more accurate.

### [PREVIEW](https://celestiaorg.github.io/docs/pr-preview/pr-1363/developers/submit-data#estimating-pfb-gas)

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
