### PR TITLE
Fix Image Referencing in Markdown Files

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -1,10 +1,23 @@
 import { HeadConfig } from "vitepress";
+import { defineConfig } from "vitepress";
+import { createLogger } from "vite";
 
 const telegramSVG = ` <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12ZM12.43 8.85893C11.2628 9.3444 8.93014 10.3492 5.43189 11.8733C4.86383 12.0992 4.56626 12.3202 4.53917 12.5363C4.49339 12.9015 4.95071 13.0453 5.57347 13.2411C5.65818 13.2678 5.74595 13.2954 5.83594 13.3246C6.44864 13.5238 7.27283 13.7568 7.70129 13.766C8.08994 13.7744 8.52373 13.6142 9.00264 13.2853C12.2712 11.079 13.9584 9.96381 14.0643 9.93977C14.139 9.92281 14.2426 9.90148 14.3128 9.96385C14.3829 10.0262 14.376 10.1443 14.3686 10.176C14.3233 10.3691 12.5281 12.0381 11.5991 12.9018C11.3095 13.171 11.1041 13.362 11.0621 13.4056C10.968 13.5033 10.8721 13.5958 10.78 13.6846C10.2108 14.2333 9.78391 14.6448 10.8036 15.3168C11.2936 15.6397 11.6858 15.9067 12.077 16.1731C12.5042 16.4641 12.9303 16.7543 13.4816 17.1157C13.6221 17.2077 13.7562 17.3034 13.8869 17.3965C14.3841 17.751 14.8307 18.0694 15.3826 18.0186C15.7032 17.9891 16.0345 17.6876 16.2027 16.7884C16.6002 14.6631 17.3816 10.0585 17.5622 8.16097C17.578 7.99473 17.5581 7.78197 17.5422 7.68857C17.5262 7.59518 17.4928 7.46211 17.3714 7.3636C17.2276 7.24694 17.0056 7.22234 16.9064 7.22408C16.455 7.23203 15.7626 7.47282 12.43 8.85893Z" fill="currentColor"/>
 </svg>`;
 
 const { BASE: base = "/" } = process.env;
+
+const logger = createLogger();
+const originalWarning = logger.warn;
+
+logger.warn = (msg, options) => {
+  if (
+    msg.includes("Files in the public directory are served at the root path.")
+  )
+    return;
+  originalWarning(msg, options);
+};
 
 // https://vitepress.dev/concepts/site-config
 export default {
@@ -138,6 +151,10 @@ export default {
       },
     ],
   ],
+
+  vite: {
+    customLogger: logger,
+  },
 
   themeConfig: {
     // https://vitepress.dev/concepts/default-theme-config

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -1,5 +1,4 @@
 import { HeadConfig } from "vitepress";
-import { defineConfig } from "vitepress";
 import { createLogger } from "vite";
 
 const telegramSVG = ` <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/community/modular-fellows.md
+++ b/community/modular-fellows.md
@@ -4,7 +4,7 @@ description: A program designed to support the future of scalable and sovereign 
 
 # Modular Fellows
 
-![Modular Fellows](https://github.com/celestiaorg/docs/raw/main/public/img/modular_fellows.jpg)
+![Modular Fellows](/public/img/modular_fellows.jpg)
 
 Modular Fellows is a program designed to empower modular builders with the
 right resources to build the future of scalable and sovereign blockchain networks.

--- a/community/modular-fellows.md
+++ b/community/modular-fellows.md
@@ -4,7 +4,7 @@ description: A program designed to support the future of scalable and sovereign 
 
 # Modular Fellows
 
-![Modular Fellows](/img/modular_fellows.jpg)
+![Modular Fellows](/public/img/modular_fellows.jpg)
 
 Modular Fellows is a program designed to empower modular builders with the
 right resources to build the future of scalable and sovereign blockchain networks.

--- a/community/modular-fellows.md
+++ b/community/modular-fellows.md
@@ -4,7 +4,7 @@ description: A program designed to support the future of scalable and sovereign 
 
 # Modular Fellows
 
-![Modular Fellows](/public/img/modular_fellows.jpg)
+![Modular Fellows](https://github.com/celestiaorg/docs/raw/main/public/img/modular_fellows.jpg)
 
 Modular Fellows is a program designed to empower modular builders with the
 right resources to build the future of scalable and sovereign blockchain networks.

--- a/community/modular-meetup-intro.md
+++ b/community/modular-meetup-intro.md
@@ -4,7 +4,7 @@ description: The ultimate guide for Modular Meetup organizers!
 
 # Celestia Modular Meetup program
 
-![Modular Meetup Banner](/public/img/Celestia_Modular_meetup2.jpg)
+![Modular Meetup Banner](https://github.com/celestiaorg/docs/raw/main/public/img/Celestia_Modular_meetup2.jpg)
 
 Welcome to the ultimate guide for Modular Meetup organizers!
 This collection of resources is designed for those enthusiastic

--- a/community/modular-meetup-intro.md
+++ b/community/modular-meetup-intro.md
@@ -4,7 +4,7 @@ description: The ultimate guide for Modular Meetup organizers!
 
 # Celestia Modular Meetup program
 
-![Modular Meetup Banner](https://github.com/celestiaorg/docs/raw/main/public/img/Celestia_Modular_meetup2.jpg)
+![Modular Meetup Banner](/public/img/Celestia_Modular_meetup2.jpg)
 
 Welcome to the ultimate guide for Modular Meetup organizers!
 This collection of resources is designed for those enthusiastic

--- a/community/modular-meetup-intro.md
+++ b/community/modular-meetup-intro.md
@@ -4,7 +4,7 @@ description: The ultimate guide for Modular Meetup organizers!
 
 # Celestia Modular Meetup program
 
-![Modular Meetup Banner](/img/Celestia_Modular_meetup2.jpg)
+![Modular Meetup Banner](/public/img/Celestia_Modular_meetup2.jpg)
 
 Welcome to the ultimate guide for Modular Meetup organizers!
 This collection of resources is designed for those enthusiastic

--- a/developers/arbitrum-dapp-deploy.md
+++ b/developers/arbitrum-dapp-deploy.md
@@ -114,4 +114,4 @@ cp dev/gm-portal/contracts/out/GmPortal.sol/GmPortal.json dev/gm-portal/frontend
 
 Now, login with your wallet that you funded, and post a GM on your GM portal!
 
-![gm-arb](https://github.com/celestiaorg/docs/raw/main/public/img/gm-arb.png)
+![gm-arb](/public/img/gm-arb.png)

--- a/developers/arbitrum-dapp-deploy.md
+++ b/developers/arbitrum-dapp-deploy.md
@@ -114,4 +114,4 @@ cp dev/gm-portal/contracts/out/GmPortal.sol/GmPortal.json dev/gm-portal/frontend
 
 Now, login with your wallet that you funded, and post a GM on your GM portal!
 
-![gm-arb](/public/img/gm-arb.png)
+![gm-arb](https://github.com/celestiaorg/docs/raw/main/public/img/gm-arb.png)

--- a/developers/arbitrum-dapp-deploy.md
+++ b/developers/arbitrum-dapp-deploy.md
@@ -114,4 +114,4 @@ cp dev/gm-portal/contracts/out/GmPortal.sol/GmPortal.json dev/gm-portal/frontend
 
 Now, login with your wallet that you funded, and post a GM on your GM portal!
 
-![gm-arb](/img/gm-arb.png)
+![gm-arb](/public/img/gm-arb.png)

--- a/developers/arbitrum-deploy.md
+++ b/developers/arbitrum-deploy.md
@@ -4,7 +4,7 @@ description: A guide on how to install Arbitrum Nitro and deploy an instance on 
 
 # Deploy an Arbitrum rollup devnet
 
-![nitro-vroom](/public/img/nitro-vroom-devnet.png)
+![nitro-vroom](https://github.com/celestiaorg/docs/raw/main/public/img/nitro-vroom-devnet.png)
 
 We will go over installation of Arbitrum Nitro and deploying an instance on an
 Ubuntu AMD machine. This section covers all necessary dependencies needed to be

--- a/developers/arbitrum-deploy.md
+++ b/developers/arbitrum-deploy.md
@@ -4,7 +4,7 @@ description: A guide on how to install Arbitrum Nitro and deploy an instance on 
 
 # Deploy an Arbitrum rollup devnet
 
-![nitro-vroom](/img/nitro-vroom-devnet.png)
+![nitro-vroom](/public/img/nitro-vroom-devnet.png)
 
 We will go over installation of Arbitrum Nitro and deploying an instance on an
 Ubuntu AMD machine. This section covers all necessary dependencies needed to be

--- a/developers/arbitrum-deploy.md
+++ b/developers/arbitrum-deploy.md
@@ -4,7 +4,7 @@ description: A guide on how to install Arbitrum Nitro and deploy an instance on 
 
 # Deploy an Arbitrum rollup devnet
 
-![nitro-vroom](https://github.com/celestiaorg/docs/raw/main/public/img/nitro-vroom-devnet.png)
+![nitro-vroom](/public/img/nitro-vroom-devnet.png)
 
 We will go over installation of Arbitrum Nitro and deploying an instance on an
 Ubuntu AMD machine. This section covers all necessary dependencies needed to be

--- a/developers/arbitrum-integration.md
+++ b/developers/arbitrum-integration.md
@@ -4,7 +4,7 @@ description: An overview of the integration of Arbitrum Nitro with Celestia, det
 
 # Introduction to Arbitrum rollups with Celestia as DA
 
-![Celestia_Arbitrum](/img/Celestia-Arbitrum.png)
+![Celestia_Arbitrum](/public/img/Celestia-Arbitrum.png)
 
 ## Overview
 

--- a/developers/arbitrum-integration.md
+++ b/developers/arbitrum-integration.md
@@ -4,7 +4,7 @@ description: An overview of the integration of Arbitrum Nitro with Celestia, det
 
 # Introduction to Arbitrum rollups with Celestia as DA
 
-![Celestia_Arbitrum](https://github.com/celestiaorg/docs/raw/main/public/img/Celestia-Arbitrum.png)
+![Celestia_Arbitrum](/public/img/Celestia-Arbitrum.png)
 
 ## Overview
 

--- a/developers/arbitrum-integration.md
+++ b/developers/arbitrum-integration.md
@@ -4,7 +4,7 @@ description: An overview of the integration of Arbitrum Nitro with Celestia, det
 
 # Introduction to Arbitrum rollups with Celestia as DA
 
-![Celestia_Arbitrum](/public/img/Celestia-Arbitrum.png)
+![Celestia_Arbitrum](https://github.com/celestiaorg/docs/raw/main/public/img/Celestia-Arbitrum.png)
 
 ## Overview
 

--- a/developers/arbitrum-mocha.md
+++ b/developers/arbitrum-mocha.md
@@ -4,7 +4,7 @@ description: An overview of the deploying Arbitrum Nitro and Celestia rollup to 
 
 # Deploy an Arbitrum rollup to Mocha testnet
 
-![nitro-vroom](https://github.com/celestiaorg/docs/raw/main/public/img/nitro-vroom.png)
+![nitro-vroom](/public/img/nitro-vroom.png)
 
 <!-- markdownlint-disable MD033 -->
 <script setup>

--- a/developers/arbitrum-mocha.md
+++ b/developers/arbitrum-mocha.md
@@ -4,7 +4,7 @@ description: An overview of the deploying Arbitrum Nitro and Celestia rollup to 
 
 # Deploy an Arbitrum rollup to Mocha testnet
 
-![nitro-vroom](/public/img/nitro-vroom.png)
+![nitro-vroom](https://github.com/celestiaorg/docs/raw/main/public/img/nitro-vroom.png)
 
 <!-- markdownlint-disable MD033 -->
 <script setup>

--- a/developers/arbitrum-mocha.md
+++ b/developers/arbitrum-mocha.md
@@ -4,7 +4,7 @@ description: An overview of the deploying Arbitrum Nitro and Celestia rollup to 
 
 # Deploy an Arbitrum rollup to Mocha testnet
 
-![nitro-vroom](/img/nitro-vroom.png)
+![nitro-vroom](/public/img/nitro-vroom.png)
 
 <!-- markdownlint-disable MD033 -->
 <script setup>

--- a/developers/blobstream-proof-queries.md
+++ b/developers/blobstream-proof-queries.md
@@ -451,11 +451,11 @@ portion of the specs.
 
 ### The Celestia square
 
-![Square](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/blobstream-square.png)
+![Square](/public/img/blobstream/blobstream-square.png)
 
 ### The commitment scheme
 
-![Blobstream Commitment Diagram](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/blobstream-commitment-diagram.png)
+![Blobstream Commitment Diagram](/public/img/blobstream/blobstream-commitment-diagram.png)
 
 ## Conclusion
 

--- a/developers/blobstream-proof-queries.md
+++ b/developers/blobstream-proof-queries.md
@@ -451,11 +451,11 @@ portion of the specs.
 
 ### The Celestia square
 
-![Square](/public/img/blobstream/blobstream-square.png)
+![Square](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/blobstream-square.png)
 
 ### The commitment scheme
 
-![Blobstream Commitment Diagram](/public/img/blobstream/blobstream-commitment-diagram.png)
+![Blobstream Commitment Diagram](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/blobstream-commitment-diagram.png)
 
 ## Conclusion
 

--- a/developers/blobstream-proof-queries.md
+++ b/developers/blobstream-proof-queries.md
@@ -451,11 +451,11 @@ portion of the specs.
 
 ### The Celestia square
 
-![Square](/img/blobstream/blobstream-square.png)
+![Square](/public/img/blobstream/blobstream-square.png)
 
 ### The commitment scheme
 
-![Blobstream Commitment Diagram](/img/blobstream/blobstream-commitment-diagram.png)
+![Blobstream Commitment Diagram](/public/img/blobstream/blobstream-commitment-diagram.png)
 
 ## Conclusion
 

--- a/developers/blobstream.md
+++ b/developers/blobstream.md
@@ -4,7 +4,7 @@ description: Learn how to integrate your L2 with Blobstream
 
 # Integrate with Blobstream
 
-![Blobstream logo](/public/img/blobstream/blobstream_logo.png)
+![Blobstream logo](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/blobstream_logo.png)
 
 [Blobstream](https://blog.celestia.org/introducing-blobstream/)
 is the first data availability solution for Ethereum that securely
@@ -28,7 +28,7 @@ and a [relayer](../nodes/blobstream-relayer.md).
 In the following diagram, we show how a layer 2 (L2) would post data to
 Celestia and then verify that it was published in the target EVM chain.
 
-![Blobstream-Architecture](/public/img/blobstream/Blobstream.png)
+![Blobstream-Architecture](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/Blobstream.png)
 
 Data will first be attested to by the Celestia validator set, _i.e._
 signing commitments committing to the data. Then, these signatures will be
@@ -70,7 +70,7 @@ each tuple representing a single
 [data root (i.e. block header)](https://celestiaorg.github.io/celestia-app/specs/data_structures.html#header).
 Relayed tuples are in the same order as Celestia block headers.
 
-![Blobstream attestation flow](/public/img/blobstream/Celestia_Blobstream_attestation_flow.jpg)
+![Blobstream attestation flow](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/Celestia_Blobstream_attestation_flow.jpg)
 
 ### Events and messages relayed
 

--- a/developers/blobstream.md
+++ b/developers/blobstream.md
@@ -4,7 +4,7 @@ description: Learn how to integrate your L2 with Blobstream
 
 # Integrate with Blobstream
 
-![Blobstream logo](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/blobstream_logo.png)
+![Blobstream logo](/public/img/blobstream/blobstream_logo.png)
 
 [Blobstream](https://blog.celestia.org/introducing-blobstream/)
 is the first data availability solution for Ethereum that securely
@@ -28,7 +28,7 @@ and a [relayer](../nodes/blobstream-relayer.md).
 In the following diagram, we show how a layer 2 (L2) would post data to
 Celestia and then verify that it was published in the target EVM chain.
 
-![Blobstream-Architecture](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/Blobstream.png)
+![Blobstream-Architecture](/public/img/blobstream/Blobstream.png)
 
 Data will first be attested to by the Celestia validator set, _i.e._
 signing commitments committing to the data. Then, these signatures will be
@@ -70,7 +70,7 @@ each tuple representing a single
 [data root (i.e. block header)](https://celestiaorg.github.io/celestia-app/specs/data_structures.html#header).
 Relayed tuples are in the same order as Celestia block headers.
 
-![Blobstream attestation flow](https://github.com/celestiaorg/docs/raw/main/public/img/blobstream/Celestia_Blobstream_attestation_flow.jpg)
+![Blobstream attestation flow](/public/img/blobstream/Celestia_Blobstream_attestation_flow.jpg)
 
 ### Events and messages relayed
 

--- a/developers/blobstream.md
+++ b/developers/blobstream.md
@@ -4,7 +4,7 @@ description: Learn how to integrate your L2 with Blobstream
 
 # Integrate with Blobstream
 
-![Blobstream logo](/img/blobstream/blobstream_logo.png)
+![Blobstream logo](/public/img/blobstream/blobstream_logo.png)
 
 [Blobstream](https://blog.celestia.org/introducing-blobstream/)
 is the first data availability solution for Ethereum that securely
@@ -28,7 +28,7 @@ and a [relayer](../nodes/blobstream-relayer.md).
 In the following diagram, we show how a layer 2 (L2) would post data to
 Celestia and then verify that it was published in the target EVM chain.
 
-![Blobstream-Architecture](/img/blobstream/Blobstream.png)
+![Blobstream-Architecture](/public/img/blobstream/Blobstream.png)
 
 Data will first be attested to by the Celestia validator set, _i.e._
 signing commitments committing to the data. Then, these signatures will be
@@ -70,7 +70,7 @@ each tuple representing a single
 [data root (i.e. block header)](https://celestiaorg.github.io/celestia-app/specs/data_structures.html#header).
 Relayed tuples are in the same order as Celestia block headers.
 
-![Blobstream attestation flow](/img/blobstream/Celestia_Blobstream_attestation_flow.jpg)
+![Blobstream attestation flow](/public/img/blobstream/Celestia_Blobstream_attestation_flow.jpg)
 
 ### Events and messages relayed
 

--- a/developers/bubs-testnet.md
+++ b/developers/bubs-testnet.md
@@ -4,7 +4,7 @@ description: The first testnet built with OP Stack and Celestia.
 
 # Bubs testnet
 
-![Bubs testnet](/img/Celestia_Bubs_Testnet.jpg)
+![Bubs testnet](/public/img/Celestia_Bubs_Testnet.jpg)
 
 [Bubs Testnet](https://bubstestnet.com) is a fresh offering from
 [Caldera](https://caldera.xyz) with support from Celestia Labs,

--- a/developers/bubs-testnet.md
+++ b/developers/bubs-testnet.md
@@ -4,7 +4,7 @@ description: The first testnet built with OP Stack and Celestia.
 
 # Bubs testnet
 
-![Bubs testnet](https://github.com/celestiaorg/docs/raw/main/public/img/Celestia_Bubs_Testnet.jpg)
+![Bubs testnet](/public/img/Celestia_Bubs_Testnet.jpg)
 
 [Bubs Testnet](https://bubstestnet.com) is a fresh offering from
 [Caldera](https://caldera.xyz) with support from Celestia Labs,

--- a/developers/bubs-testnet.md
+++ b/developers/bubs-testnet.md
@@ -4,7 +4,7 @@ description: The first testnet built with OP Stack and Celestia.
 
 # Bubs testnet
 
-![Bubs testnet](/public/img/Celestia_Bubs_Testnet.jpg)
+![Bubs testnet](https://github.com/celestiaorg/docs/raw/main/public/img/Celestia_Bubs_Testnet.jpg)
 
 [Bubs Testnet](https://bubstestnet.com) is a fresh offering from
 [Caldera](https://caldera.xyz) with support from Celestia Labs,

--- a/developers/build-modular.md
+++ b/developers/build-modular.md
@@ -69,7 +69,7 @@ technologies that can help us get there.
   This means rollups don’t require every node in the network to re-execute
   every transaction.
 
-![image](/img/da-and-validity.png)
+![image](/public/img/da-and-validity.png)
 
 - **Decoupling execution from consensus** lets developers define the VM
   that best fits the scaling needs of their application.

--- a/developers/build-modular.md
+++ b/developers/build-modular.md
@@ -69,7 +69,7 @@ technologies that can help us get there.
   This means rollups don’t require every node in the network to re-execute
   every transaction.
 
-![image](/public/img/da-and-validity.png)
+![image](https://github.com/celestiaorg/docs/raw/main/public/img/da-and-validity.png)
 
 - **Decoupling execution from consensus** lets developers define the VM
   that best fits the scaling needs of their application.

--- a/developers/build-modular.md
+++ b/developers/build-modular.md
@@ -69,7 +69,7 @@ technologies that can help us get there.
   This means rollups don’t require every node in the network to re-execute
   every transaction.
 
-![image](https://github.com/celestiaorg/docs/raw/main/public/img/da-and-validity.png)
+![image](/public/img/da-and-validity.png)
 
 - **Decoupling execution from consensus** lets developers define the VM
   that best fits the scaling needs of their application.

--- a/developers/ethereum-fallback.md
+++ b/developers/ethereum-fallback.md
@@ -27,4 +27,4 @@ triggered due to a congested mempool or nonce error and can be simulated
 with an error such as low balance or incorrect sequence. Fallback
 can also be triggered in the event Blobstream stops relaying attestations.
 
-![Ethereum fallback](/public/img/Celestia_ethereum-fallback.jpg)
+![Ethereum fallback](https://github.com/celestiaorg/docs/raw/main/public/img/Celestia_ethereum-fallback.jpg)

--- a/developers/ethereum-fallback.md
+++ b/developers/ethereum-fallback.md
@@ -27,4 +27,4 @@ triggered due to a congested mempool or nonce error and can be simulated
 with an error such as low balance or incorrect sequence. Fallback
 can also be triggered in the event Blobstream stops relaying attestations.
 
-![Ethereum fallback](/img/Celestia_ethereum-fallback.jpg)
+![Ethereum fallback](/public/img/Celestia_ethereum-fallback.jpg)

--- a/developers/ethereum-fallback.md
+++ b/developers/ethereum-fallback.md
@@ -27,4 +27,4 @@ triggered due to a congested mempool or nonce error and can be simulated
 with an error such as low balance or incorrect sequence. Fallback
 can also be triggered in the event Blobstream stops relaying attestations.
 
-![Ethereum fallback](https://github.com/celestiaorg/docs/raw/main/public/img/Celestia_ethereum-fallback.jpg)
+![Ethereum fallback](/public/img/Celestia_ethereum-fallback.jpg)

--- a/developers/gm-portal-bubs.md
+++ b/developers/gm-portal-bubs.md
@@ -38,7 +38,7 @@ forge script script/GmPortal.s.sol:GmPortalScript --rpc-url $BUBS_RPC_URL --priv
 
 <!-- markdownlint-enable MD013 -->
 
-![gm-contract](https://github.com/celestiaorg/docs/raw/main/public/img/gm_contract.png)
+![gm-contract](/public/img/gm_contract.png)
 
 In the output of the deployment, find the contract address and set it as a variable:
 
@@ -105,7 +105,7 @@ cp dev/gm-portal/contracts/out/GmPortal.sol/GmPortal.json dev/gm-portal/frontend
 
 Now, login with your wallet that you funded, and post a GM on your GM portal!
 
-![gm-bubs](https://github.com/celestiaorg/docs/raw/main/public/img/gm_bubs.png)
+![gm-bubs](/public/img/gm_bubs.png)
 
 ## Next steps
 

--- a/developers/gm-portal-bubs.md
+++ b/developers/gm-portal-bubs.md
@@ -38,7 +38,7 @@ forge script script/GmPortal.s.sol:GmPortalScript --rpc-url $BUBS_RPC_URL --priv
 
 <!-- markdownlint-enable MD013 -->
 
-![gm-contract](/public/img/gm_contract.png)
+![gm-contract](https://github.com/celestiaorg/docs/raw/main/public/img/gm_contract.png)
 
 In the output of the deployment, find the contract address and set it as a variable:
 
@@ -105,7 +105,7 @@ cp dev/gm-portal/contracts/out/GmPortal.sol/GmPortal.json dev/gm-portal/frontend
 
 Now, login with your wallet that you funded, and post a GM on your GM portal!
 
-![gm-bubs](/public/img/gm_bubs.png)
+![gm-bubs](https://github.com/celestiaorg/docs/raw/main/public/img/gm_bubs.png)
 
 ## Next steps
 

--- a/developers/gm-portal-bubs.md
+++ b/developers/gm-portal-bubs.md
@@ -38,7 +38,7 @@ forge script script/GmPortal.s.sol:GmPortalScript --rpc-url $BUBS_RPC_URL --priv
 
 <!-- markdownlint-enable MD013 -->
 
-![gm-contract](/img/gm_contract.png)
+![gm-contract](/public/img/gm_contract.png)
 
 In the output of the deployment, find the contract address and set it as a variable:
 
@@ -105,7 +105,7 @@ cp dev/gm-portal/contracts/out/GmPortal.sol/GmPortal.json dev/gm-portal/frontend
 
 Now, login with your wallet that you funded, and post a GM on your GM portal!
 
-![gm-bubs](/img/gm_bubs.png)
+![gm-bubs](/public/img/gm_bubs.png)
 
 ## Next steps
 

--- a/developers/how-to-stake-tia.md
+++ b/developers/how-to-stake-tia.md
@@ -20,13 +20,13 @@ wallets.
 <!-- markdownlint-disable MD033 -->
 <div style="display: inline-block;">
     <a href="#stake-tia-with-keplr-wallet">
-    <img src="/public/img/keplr.png" alt="Keplr">
+    <img src="/img/keplr.png" alt="Keplr">
     </a>
 </div>
 
 <div style="display: inline-block;">
     <a href="#stake-tia-with-leap-wallet">
-    <img src="/public/img/leap.png" alt="Leap">
+    <img src="/img/leap.png" alt="Leap">
     </a>
 </div>
 
@@ -38,14 +38,14 @@ Navigate to `Staked` and select `Stake with Keplr Dashboard`.
 
 This will open the Keplr dashboard in a new browser page.
 
-![Keplr1](/public/img/keplr/keplr1.gif)
+![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/keplr/keplr1.gif)
 
 ### :two: Select Celestia network and search for a validator
 
 In the Keplr dashboard, select the `Celestia` network and pick a
 validator of your choice.
 
-![Keplr1](/public/img/keplr/keplr2.gif)
+![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/keplr/keplr2.gif)
 
 ### :three: Stake your TIA tokens
 
@@ -54,7 +54,7 @@ On the following screen enter amount of TIA tokens and select `Stake`.
 A Keplr popup will appear, requesting your approval for the
 transaction. Select `Approve`.
 
-![Keplr1](/public/img/keplr/keplr3.gif)
+![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/keplr/keplr3.gif)
 
 ### :four: Confirm and manage your TIA
 
@@ -62,7 +62,7 @@ After the transaction is confirmed, you will see the following
 overview dashboard where you can claim rewards, unstake, redelegate,
 or stake additional tokens.
 
-![Keplr1](/public/img/keplr/keplr4.gif)
+![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/keplr/keplr4.gif)
 
 ## Stake TIA with Leap wallet
 
@@ -72,7 +72,7 @@ In top right select `Celestia` network and navigate to `Stake`.
 
 Similarly to previous step, select the `+Stake` button.
 
-![Keplr1](/public/img/leap/leap1.gif)
+![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/leap/leap1.gif)
 
 ### :two: Select a validator and stake TIA
 
@@ -82,7 +82,7 @@ the desired amount, and click `Review`.
 Following that, review the transaction details and select `Stake`,
 then wait for the transaction to finalize.
 
-![Keplr1](/public/img/leap/leap2.gif)
+![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/leap/leap2.gif)
 
 ### :three: Confirm and manage your TIA
 
@@ -90,4 +90,4 @@ After the transaction is confirmed, you will see the following
 overview dashboard where you can claim rewards, unstake, redelegate,
 or stake additional tokens.
 
-![Keplr1](/public/img/leap/leap3.gif)
+![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/leap/leap3.gif)

--- a/developers/how-to-stake-tia.md
+++ b/developers/how-to-stake-tia.md
@@ -20,13 +20,13 @@ wallets.
 <!-- markdownlint-disable MD033 -->
 <div style="display: inline-block;">
     <a href="#stake-tia-with-keplr-wallet">
-    <img src="/img/keplr.png" alt="Keplr">
+    <img src="/public/img/keplr.png" alt="Keplr">
     </a>
 </div>
 
 <div style="display: inline-block;">
     <a href="#stake-tia-with-leap-wallet">
-    <img src="/img/leap.png" alt="Leap">
+    <img src="/public/img/leap.png" alt="Leap">
     </a>
 </div>
 
@@ -38,14 +38,14 @@ Navigate to `Staked` and select `Stake with Keplr Dashboard`.
 
 This will open the Keplr dashboard in a new browser page.
 
-![Keplr1](/img/keplr/keplr1.gif)
+![Keplr1](/public/img/keplr/keplr1.gif)
 
 ### :two: Select Celestia network and search for a validator
 
 In the Keplr dashboard, select the `Celestia` network and pick a
 validator of your choice.
 
-![Keplr1](/img/keplr/keplr2.gif)
+![Keplr1](/public/img/keplr/keplr2.gif)
 
 ### :three: Stake your TIA tokens
 
@@ -54,7 +54,7 @@ On the following screen enter amount of TIA tokens and select `Stake`.
 A Keplr popup will appear, requesting your approval for the
 transaction. Select `Approve`.
 
-![Keplr1](/img/keplr/keplr3.gif)
+![Keplr1](/public/img/keplr/keplr3.gif)
 
 ### :four: Confirm and manage your TIA
 
@@ -62,7 +62,7 @@ After the transaction is confirmed, you will see the following
 overview dashboard where you can claim rewards, unstake, redelegate,
 or stake additional tokens.
 
-![Keplr1](/img/keplr/keplr4.gif)
+![Keplr1](/public/img/keplr/keplr4.gif)
 
 ## Stake TIA with Leap wallet
 
@@ -72,7 +72,7 @@ In top right select `Celestia` network and navigate to `Stake`.
 
 Similarly to previous step, select the `+Stake` button.
 
-![Keplr1](/img/leap/leap1.gif)
+![Keplr1](/public/img/leap/leap1.gif)
 
 ### :two: Select a validator and stake TIA
 
@@ -82,7 +82,7 @@ the desired amount, and click `Review`.
 Following that, review the transaction details and select `Stake`,
 then wait for the transaction to finalize.
 
-![Keplr1](/img/leap/leap2.gif)
+![Keplr1](/public/img/leap/leap2.gif)
 
 ### :three: Confirm and manage your TIA
 
@@ -90,4 +90,4 @@ After the transaction is confirmed, you will see the following
 overview dashboard where you can claim rewards, unstake, redelegate,
 or stake additional tokens.
 
-![Keplr1](/img/leap/leap3.gif)
+![Keplr1](/public/img/leap/leap3.gif)

--- a/developers/how-to-stake-tia.md
+++ b/developers/how-to-stake-tia.md
@@ -20,13 +20,13 @@ wallets.
 <!-- markdownlint-disable MD033 -->
 <div style="display: inline-block;">
     <a href="#stake-tia-with-keplr-wallet">
-    <img src="/img/keplr.png" alt="Keplr">
+    <img src="/public/img/keplr.png" alt="Keplr">
     </a>
 </div>
 
 <div style="display: inline-block;">
     <a href="#stake-tia-with-leap-wallet">
-    <img src="/img/leap.png" alt="Leap">
+    <img src="/public/img/leap.png" alt="Leap">
     </a>
 </div>
 
@@ -38,14 +38,14 @@ Navigate to `Staked` and select `Stake with Keplr Dashboard`.
 
 This will open the Keplr dashboard in a new browser page.
 
-![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/keplr/keplr1.gif)
+![Keplr1](/public/img/keplr/keplr1.gif)
 
 ### :two: Select Celestia network and search for a validator
 
 In the Keplr dashboard, select the `Celestia` network and pick a
 validator of your choice.
 
-![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/keplr/keplr2.gif)
+![Keplr1](/public/img/keplr/keplr2.gif)
 
 ### :three: Stake your TIA tokens
 
@@ -54,7 +54,7 @@ On the following screen enter amount of TIA tokens and select `Stake`.
 A Keplr popup will appear, requesting your approval for the
 transaction. Select `Approve`.
 
-![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/keplr/keplr3.gif)
+![Keplr1](/public/img/keplr/keplr3.gif)
 
 ### :four: Confirm and manage your TIA
 
@@ -62,7 +62,7 @@ After the transaction is confirmed, you will see the following
 overview dashboard where you can claim rewards, unstake, redelegate,
 or stake additional tokens.
 
-![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/keplr/keplr4.gif)
+![Keplr1](/public/img/keplr/keplr4.gif)
 
 ## Stake TIA with Leap wallet
 
@@ -72,7 +72,7 @@ In top right select `Celestia` network and navigate to `Stake`.
 
 Similarly to previous step, select the `+Stake` button.
 
-![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/leap/leap1.gif)
+![Keplr1](/public/img/leap/leap1.gif)
 
 ### :two: Select a validator and stake TIA
 
@@ -82,7 +82,7 @@ the desired amount, and click `Review`.
 Following that, review the transaction details and select `Stake`,
 then wait for the transaction to finalize.
 
-![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/leap/leap2.gif)
+![Keplr1](/public/img/leap/leap2.gif)
 
 ### :three: Confirm and manage your TIA
 
@@ -90,4 +90,4 @@ After the transaction is confirmed, you will see the following
 overview dashboard where you can claim rewards, unstake, redelegate,
 or stake additional tokens.
 
-![Keplr1](https://github.com/celestiaorg/docs/raw/main/public/img/leap/leap3.gif)
+![Keplr1](/public/img/leap/leap3.gif)

--- a/developers/nitrogen.md
+++ b/developers/nitrogen.md
@@ -1,6 +1,6 @@
 # Nitrogen testnet
 
-![nitrogen-testnet](/public/img/nitrogen-testnet.jpg)
+![nitrogen-testnet](https://github.com/celestiaorg/docs/raw/main/public/img/nitrogen-testnet.jpg)
 
 [Nitrogen](https://rollup-info.altlayer.io/public/nitrogen)
 is the first testnet and L3 made with

--- a/developers/nitrogen.md
+++ b/developers/nitrogen.md
@@ -1,6 +1,6 @@
 # Nitrogen testnet
 
-![nitrogen-testnet](/img/nitrogen-testnet.jpg)
+![nitrogen-testnet](/public/img/nitrogen-testnet.jpg)
 
 [Nitrogen](https://rollup-info.altlayer.io/public/nitrogen)
 is the first testnet and L3 made with

--- a/developers/nitrogen.md
+++ b/developers/nitrogen.md
@@ -1,6 +1,6 @@
 # Nitrogen testnet
 
-![nitrogen-testnet](https://github.com/celestiaorg/docs/raw/main/public/img/nitrogen-testnet.jpg)
+![nitrogen-testnet](/public/img/nitrogen-testnet.jpg)
 
 [Nitrogen](https://rollup-info.altlayer.io/public/nitrogen)
 is the first testnet and L3 made with

--- a/developers/rollkit.md
+++ b/developers/rollkit.md
@@ -6,7 +6,7 @@ description: Learn how to build Cosmos-SDK applications that connect to Celestia
 
 Validator nodes allow you to participate in consensus in the Celestia network.
 
-![rollkit](https://github.com/celestiaorg/docs/raw/main/public/img/rollkit.png)
+![rollkit](/public/img/rollkit.png)
 
 [Rollkit](https://rollkit.dev) is an ABCI
 (Application Blockchain Interface) implementation for sovereign

--- a/developers/rollkit.md
+++ b/developers/rollkit.md
@@ -6,7 +6,7 @@ description: Learn how to build Cosmos-SDK applications that connect to Celestia
 
 Validator nodes allow you to participate in consensus in the Celestia network.
 
-![rollkit](/img/rollkit.png)
+![rollkit](/public/img/rollkit.png)
 
 [Rollkit](https://rollkit.dev) is an ABCI
 (Application Blockchain Interface) implementation for sovereign

--- a/developers/rollkit.md
+++ b/developers/rollkit.md
@@ -6,7 +6,7 @@ description: Learn how to build Cosmos-SDK applications that connect to Celestia
 
 Validator nodes allow you to participate in consensus in the Celestia network.
 
-![rollkit](/public/img/rollkit.png)
+![rollkit](https://github.com/celestiaorg/docs/raw/main/public/img/rollkit.png)
 
 [Rollkit](https://rollkit.dev) is an ABCI
 (Application Blockchain Interface) implementation for sovereign

--- a/learn/how-celestia-works/data-availability-faq.md
+++ b/learn/how-celestia-works/data-availability-faq.md
@@ -17,7 +17,7 @@ If the node can download all the transaction data, then it successfully
 verified data availability, proving that the block data was actually
 published to the network.
 
-![Modular VS Monolithic](https://github.com/celestiaorg/docs/raw/main/public/img/learn/data-availability-faq/Data-availability.png)
+![Modular VS Monolithic](/public/img/learn/data-availability-faq/Data-availability.png)
 
 As you’ll see, modular blockchains like Celestia employ other primitives
 that allow nodes to verify data availability more efficiently. Data
@@ -99,7 +99,7 @@ able to generate a bad encoding fraud proof.
 
 Data storage is concerned with the ability to store and access past transaction data.
 
-![Modular VS Monolithic](https://github.com/celestiaorg/docs/raw/main/public/img/learn/data-availability-faq/Data-storage.png)
+![Modular VS Monolithic](/public/img/learn/data-availability-faq/Data-storage.png)
 
 Data storage and retrieval is needed for multiple purposes, such as:
 

--- a/learn/how-celestia-works/data-availability-faq.md
+++ b/learn/how-celestia-works/data-availability-faq.md
@@ -17,7 +17,7 @@ If the node can download all the transaction data, then it successfully
 verified data availability, proving that the block data was actually
 published to the network.
 
-![Modular VS Monolithic](/img/learn/data-availability-faq/Data-availability.png)
+![Modular VS Monolithic](/public/img/learn/data-availability-faq/Data-availability.png)
 
 As you’ll see, modular blockchains like Celestia employ other primitives
 that allow nodes to verify data availability more efficiently. Data
@@ -99,7 +99,7 @@ able to generate a bad encoding fraud proof.
 
 Data storage is concerned with the ability to store and access past transaction data.
 
-![Modular VS Monolithic](/img/learn/data-availability-faq/Data-storage.png)
+![Modular VS Monolithic](/public/img/learn/data-availability-faq/Data-storage.png)
 
 Data storage and retrieval is needed for multiple purposes, such as:
 

--- a/learn/how-celestia-works/data-availability-faq.md
+++ b/learn/how-celestia-works/data-availability-faq.md
@@ -17,7 +17,7 @@ If the node can download all the transaction data, then it successfully
 verified data availability, proving that the block data was actually
 published to the network.
 
-![Modular VS Monolithic](/public/img/learn/data-availability-faq/Data-availability.png)
+![Modular VS Monolithic](https://github.com/celestiaorg/docs/raw/main/public/img/learn/data-availability-faq/Data-availability.png)
 
 As you’ll see, modular blockchains like Celestia employ other primitives
 that allow nodes to verify data availability more efficiently. Data
@@ -99,7 +99,7 @@ able to generate a bad encoding fraud proof.
 
 Data storage is concerned with the ability to store and access past transaction data.
 
-![Modular VS Monolithic](/public/img/learn/data-availability-faq/Data-storage.png)
+![Modular VS Monolithic](https://github.com/celestiaorg/docs/raw/main/public/img/learn/data-availability-faq/Data-storage.png)
 
 Data storage and retrieval is needed for multiple purposes, such as:
 

--- a/learn/how-celestia-works/data-availability-layer.md
+++ b/learn/how-celestia-works/data-availability-layer.md
@@ -32,7 +32,7 @@ Then, $4k$ separate Merkle roots are computed for the rows and columns
 of the extended matrix; the Merkle root of these Merkle roots is used
 as the block data commitment in the block header.
 
-![2D Reed-Soloman (RS) Encoding](/img/learn/reed-solomon-encoding.png)
+![2D Reed-Soloman (RS) Encoding](/public/img/learn/reed-solomon-encoding.png)
 
 To verify that the data is available, Celestia light nodes are sampling
 the $2k \times 2k$ data chunks.
@@ -115,7 +115,7 @@ range of namespaces of all its descendants. The following figure shows an
 example of an NMT with height three (_i.e._, eight data chunks). The data is
 partitioned into three namespaces.
 
-![Namespaced Merkle Tree](/img/learn/nmt.png)
+![Namespaced Merkle Tree](/public/img/learn/nmt.png)
 
 When an application requests the data for namespace 2, the DA layer must
 provide the data chunks `D3`, `D4`, `D5`, and `D6` and the nodes `N2`, `N8`
@@ -142,7 +142,7 @@ an application that provides transactions to facilitate the DA layer and is buil
 using [Cosmos SDK](https://docs.cosmos.network/main). The following figure
 shows the main components of celestia-app.
 
-![Main components of celestia-app](/img/learn/celestia-app.png)
+![Main components of celestia-app](/public/img/learn/celestia-app.png)
 
 celestia-app is built on top of [celestia-core](https://github.com/celestiaorg/celestia-core),
 a modified version of the [Tendermint consensus algorithm](https://arxiv.org/abs/1807.04938).

--- a/learn/how-celestia-works/data-availability-layer.md
+++ b/learn/how-celestia-works/data-availability-layer.md
@@ -115,7 +115,7 @@ range of namespaces of all its descendants. The following figure shows an
 example of an NMT with height three (_i.e._, eight data chunks). The data is
 partitioned into three namespaces.
 
-![Namespaced Merkle Tree](https://github.com/celestiaorg/docs/raw/main/public/img/learn/nmt.png)
+![Namespaced Merkle Tree](/public/img/learn/nmt.png)
 
 When an application requests the data for namespace 2, the DA layer must
 provide the data chunks `D3`, `D4`, `D5`, and `D6` and the nodes `N2`, `N8`
@@ -142,7 +142,7 @@ an application that provides transactions to facilitate the DA layer and is buil
 using [Cosmos SDK](https://docs.cosmos.network/main). The following figure
 shows the main components of celestia-app.
 
-![Main components of celestia-app](https://github.com/celestiaorg/docs/raw/main/public/img/learn/celestia-app.png)
+![Main components of celestia-app](/public/img/learn/celestia-app.png)
 
 celestia-app is built on top of [celestia-core](https://github.com/celestiaorg/celestia-core),
 a modified version of the [Tendermint consensus algorithm](https://arxiv.org/abs/1807.04938).

--- a/learn/how-celestia-works/data-availability-layer.md
+++ b/learn/how-celestia-works/data-availability-layer.md
@@ -115,7 +115,7 @@ range of namespaces of all its descendants. The following figure shows an
 example of an NMT with height three (_i.e._, eight data chunks). The data is
 partitioned into three namespaces.
 
-![Namespaced Merkle Tree](/public/img/learn/nmt.png)
+![Namespaced Merkle Tree](https://github.com/celestiaorg/docs/raw/main/public/img/learn/nmt.png)
 
 When an application requests the data for namespace 2, the DA layer must
 provide the data chunks `D3`, `D4`, `D5`, and `D6` and the nodes `N2`, `N8`
@@ -142,7 +142,7 @@ an application that provides transactions to facilitate the DA layer and is buil
 using [Cosmos SDK](https://docs.cosmos.network/main). The following figure
 shows the main components of celestia-app.
 
-![Main components of celestia-app](/public/img/learn/celestia-app.png)
+![Main components of celestia-app](https://github.com/celestiaorg/docs/raw/main/public/img/learn/celestia-app.png)
 
 celestia-app is built on top of [celestia-core](https://github.com/celestiaorg/celestia-core),
 a modified version of the [Tendermint consensus algorithm](https://arxiv.org/abs/1807.04938).

--- a/learn/how-celestia-works/monolithic-vs-modular.md
+++ b/learn/how-celestia-works/monolithic-vs-modular.md
@@ -34,7 +34,7 @@ monolithic blockchains is that the consensus layer must perform a lot of
 different tasks and it cannot be optimized for only one of these functions.
 As a result, the monolithic paradigm limits the throughput of the system.
 
-![Modular VS Monolithic](/img/learn/monolithic-modular.png)
+![Modular VS Monolithic](/public/img/learn/monolithic-modular.png)
 
 As a solution, modular blockchains decouple these functions among
 multiple specialized layers as part of a modular stack. Due to the

--- a/learn/how-celestia-works/monolithic-vs-modular.md
+++ b/learn/how-celestia-works/monolithic-vs-modular.md
@@ -34,7 +34,7 @@ monolithic blockchains is that the consensus layer must perform a lot of
 different tasks and it cannot be optimized for only one of these functions.
 As a result, the monolithic paradigm limits the throughput of the system.
 
-![Modular VS Monolithic](https://github.com/celestiaorg/docs/raw/main/public/img/learn/monolithic-modular.png)
+![Modular VS Monolithic](/public/img/learn/monolithic-modular.png)
 
 As a solution, modular blockchains decouple these functions among
 multiple specialized layers as part of a modular stack. Due to the

--- a/learn/how-celestia-works/monolithic-vs-modular.md
+++ b/learn/how-celestia-works/monolithic-vs-modular.md
@@ -34,7 +34,7 @@ monolithic blockchains is that the consensus layer must perform a lot of
 different tasks and it cannot be optimized for only one of these functions.
 As a result, the monolithic paradigm limits the throughput of the system.
 
-![Modular VS Monolithic](/public/img/learn/monolithic-modular.png)
+![Modular VS Monolithic](https://github.com/celestiaorg/docs/raw/main/public/img/learn/monolithic-modular.png)
 
 As a solution, modular blockchains decouple these functions among
 multiple specialized layers as part of a modular stack. Due to the

--- a/learn/how-celestia-works/transaction-lifecycle.md
+++ b/learn/how-celestia-works/transaction-lifecycle.md
@@ -23,7 +23,7 @@ Thus, the block data consists of data partitioned into namespaces
 and executable transactions. Note that only these transactions are
 executed by the Celestia state machine once the block is committed.
 
-![Lifecycle of a celestia-app Transaction](/img/learn/tx-lifecycle.png)
+![Lifecycle of a celestia-app Transaction](/public/img/learn/tx-lifecycle.png)
 
 Next, the block producer adds to the block header a commitment
 of the block data. As
@@ -52,7 +52,7 @@ one for every row and column of the extended matrix.
 
 ## Checking data availability
 
-![DA network](/img/learn/consensus-da.png)
+![DA network](/public/img/learn/consensus-da.png)
 
 To enhance connectivity, the celestia-node augments the celestia-app
 with a separate libp2p network, _i.e._, the so-called _DA network_,

--- a/learn/how-celestia-works/transaction-lifecycle.md
+++ b/learn/how-celestia-works/transaction-lifecycle.md
@@ -23,7 +23,7 @@ Thus, the block data consists of data partitioned into namespaces
 and executable transactions. Note that only these transactions are
 executed by the Celestia state machine once the block is committed.
 
-![Lifecycle of a celestia-app Transaction](https://github.com/celestiaorg/docs/raw/main/public/img/learn/tx-lifecycle.png)
+![Lifecycle of a celestia-app Transaction](/public/img/learn/tx-lifecycle.png)
 
 Next, the block producer adds to the block header a commitment
 of the block data. As
@@ -52,7 +52,7 @@ one for every row and column of the extended matrix.
 
 ## Checking data availability
 
-![DA network](https://github.com/celestiaorg/docs/raw/main/public/img/learn/consensus-da.png)
+![DA network](/public/img/learn/consensus-da.png)
 
 To enhance connectivity, the celestia-node augments the celestia-app
 with a separate libp2p network, _i.e._, the so-called _DA network_,

--- a/learn/how-celestia-works/transaction-lifecycle.md
+++ b/learn/how-celestia-works/transaction-lifecycle.md
@@ -23,7 +23,7 @@ Thus, the block data consists of data partitioned into namespaces
 and executable transactions. Note that only these transactions are
 executed by the Celestia state machine once the block is committed.
 
-![Lifecycle of a celestia-app Transaction](/public/img/learn/tx-lifecycle.png)
+![Lifecycle of a celestia-app Transaction](https://github.com/celestiaorg/docs/raw/main/public/img/learn/tx-lifecycle.png)
 
 Next, the block producer adds to the block header a commitment
 of the block data. As
@@ -52,7 +52,7 @@ one for every row and column of the extended matrix.
 
 ## Checking data availability
 
-![DA network](/public/img/learn/consensus-da.png)
+![DA network](https://github.com/celestiaorg/docs/raw/main/public/img/learn/consensus-da.png)
 
 To enhance connectivity, the celestia-node augments the celestia-app
 with a separate libp2p network, _i.e._, the so-called _DA network_,

--- a/learn/paying-for-blobspace.md
+++ b/learn/paying-for-blobspace.md
@@ -14,7 +14,7 @@ Both the blobs and executable payment transactions are put into the block within
 the appropriate namespace. The block data is extended using erasure coding and then
 Merkelized into a data root commitment included in the block header.
 
-![Lifecycle of a celestia-app Transaction](/public/img/learn/tx-lifecycle.png)
+![Lifecycle of a celestia-app Transaction](https://github.com/celestiaorg/docs/raw/main/public/img/learn/tx-lifecycle.png)
 
 See
 [the detailed life cycle of a Celestia transaction](./how-celestia-works/transaction-lifecycle.md).

--- a/learn/paying-for-blobspace.md
+++ b/learn/paying-for-blobspace.md
@@ -14,7 +14,7 @@ Both the blobs and executable payment transactions are put into the block within
 the appropriate namespace. The block data is extended using erasure coding and then
 Merkelized into a data root commitment included in the block header.
 
-![Lifecycle of a celestia-app Transaction](https://github.com/celestiaorg/docs/raw/main/public/img/learn/tx-lifecycle.png)
+![Lifecycle of a celestia-app Transaction](/public/img/learn/tx-lifecycle.png)
 
 See
 [the detailed life cycle of a Celestia transaction](./how-celestia-works/transaction-lifecycle.md).

--- a/learn/paying-for-blobspace.md
+++ b/learn/paying-for-blobspace.md
@@ -14,7 +14,7 @@ Both the blobs and executable payment transactions are put into the block within
 the appropriate namespace. The block data is extended using erasure coding and then
 Merkelized into a data root commitment included in the block header.
 
-![Lifecycle of a celestia-app Transaction](/img/learn/tx-lifecycle.png)
+![Lifecycle of a celestia-app Transaction](/public/img/learn/tx-lifecycle.png)
 
 See
 [the detailed life cycle of a Celestia transaction](./how-celestia-works/transaction-lifecycle.md).

--- a/learn/staking-governance-supply.md
+++ b/learn/staking-governance-supply.md
@@ -35,7 +35,7 @@ TIA inflation starts at 8% annually and decreases by 10% every year until it
 reaches the long term issuance rate of 1.5%. Exact annual inflation rates can be
 found in the diagram below.
 
-![inflation diagram](https://github.com/celestiaorg/docs/raw/main/public/img/learn/Celestia_TIA_Inflation.png)
+![inflation diagram](/public/img/learn/Celestia_TIA_Inflation.png)
 
 The annual provisions for inflation are calculated based on the total supply of
 TIA at the beginning of each year. To calculate how many TIA to issue per block,
@@ -71,7 +71,7 @@ Learn how to
 Celestia will have a total supply of 1,000,000,000 TIA at genesis,
 split across five categories described in the chart and table below.
 
-![allocation diagram](https://github.com/celestiaorg/docs/raw/main/public/img/learn/Celestia_TIA_Allocation_at_Genesis.png)
+![allocation diagram](/public/img/learn/Celestia_TIA_Allocation_at_Genesis.png)
 
 | Category                  | Description                                                                                                                                                                                                                                   | %     |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
@@ -98,7 +98,7 @@ of the R&D & Ecosystem tokens and the tokens set aside for future initiatives.
 _The definitions for circulating and available supply were adapted from
 [Optimism’s definitions](https://community.optimism.io/docs/governance/allocations/#token-distribution-details)._
 
-![supply diagram](https://github.com/celestiaorg/docs/raw/main/public/img/learn/Celestia_TIA_Available_Supply.png)
+![supply diagram](/public/img/learn/Celestia_TIA_Available_Supply.png)
 
 Unlock schedule by category is described in the table below.
 

--- a/learn/staking-governance-supply.md
+++ b/learn/staking-governance-supply.md
@@ -35,7 +35,7 @@ TIA inflation starts at 8% annually and decreases by 10% every year until it
 reaches the long term issuance rate of 1.5%. Exact annual inflation rates can be
 found in the diagram below.
 
-![inflation diagram](/img/learn/Celestia_TIA_Inflation.png)
+![inflation diagram](/public/img/learn/Celestia_TIA_Inflation.png)
 
 The annual provisions for inflation are calculated based on the total supply of
 TIA at the beginning of each year. To calculate how many TIA to issue per block,
@@ -71,7 +71,7 @@ Learn how to
 Celestia will have a total supply of 1,000,000,000 TIA at genesis,
 split across five categories described in the chart and table below.
 
-![allocation diagram](/img/learn/Celestia_TIA_Allocation_at_Genesis.png)
+![allocation diagram](/public/img/learn/Celestia_TIA_Allocation_at_Genesis.png)
 
 | Category                  | Description                                                                                                                                                                                                                                   | %     |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
@@ -98,7 +98,7 @@ of the R&D & Ecosystem tokens and the tokens set aside for future initiatives.
 _The definitions for circulating and available supply were adapted from
 [Optimism’s definitions](https://community.optimism.io/docs/governance/allocations/#token-distribution-details)._
 
-![supply diagram](/img/learn/Celestia_TIA_Available_Supply.png)
+![supply diagram](/public/img/learn/Celestia_TIA_Available_Supply.png)
 
 Unlock schedule by category is described in the table below.
 

--- a/learn/staking-governance-supply.md
+++ b/learn/staking-governance-supply.md
@@ -35,7 +35,7 @@ TIA inflation starts at 8% annually and decreases by 10% every year until it
 reaches the long term issuance rate of 1.5%. Exact annual inflation rates can be
 found in the diagram below.
 
-![inflation diagram](/public/img/learn/Celestia_TIA_Inflation.png)
+![inflation diagram](https://github.com/celestiaorg/docs/raw/main/public/img/learn/Celestia_TIA_Inflation.png)
 
 The annual provisions for inflation are calculated based on the total supply of
 TIA at the beginning of each year. To calculate how many TIA to issue per block,
@@ -71,7 +71,7 @@ Learn how to
 Celestia will have a total supply of 1,000,000,000 TIA at genesis,
 split across five categories described in the chart and table below.
 
-![allocation diagram](/public/img/learn/Celestia_TIA_Allocation_at_Genesis.png)
+![allocation diagram](https://github.com/celestiaorg/docs/raw/main/public/img/learn/Celestia_TIA_Allocation_at_Genesis.png)
 
 | Category                  | Description                                                                                                                                                                                                                                   | %     |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
@@ -98,7 +98,7 @@ of the R&D & Ecosystem tokens and the tokens set aside for future initiatives.
 _The definitions for circulating and available supply were adapted from
 [Optimism’s definitions](https://community.optimism.io/docs/governance/allocations/#token-distribution-details)._
 
-![supply diagram](/public/img/learn/Celestia_TIA_Available_Supply.png)
+![supply diagram](https://github.com/celestiaorg/docs/raw/main/public/img/learn/Celestia_TIA_Available_Supply.png)
 
 Unlock schedule by category is described in the table below.
 

--- a/nodes/arabica-devnet.md
+++ b/nodes/arabica-devnet.md
@@ -4,7 +4,7 @@ description: A guide to Arabica devnet.
 
 # Arabica devnet
 
-![arabica-devnet](https://github.com/celestiaorg/docs/raw/main/public/img/arabica-devnet.png)
+![arabica-devnet](/public/img/arabica-devnet.png)
 
 Arabica devnet is a testnet from Celestia Labs that is focused
 exclusively on providing developers with enhanced performance and

--- a/nodes/arabica-devnet.md
+++ b/nodes/arabica-devnet.md
@@ -4,7 +4,7 @@ description: A guide to Arabica devnet.
 
 # Arabica devnet
 
-![arabica-devnet](/public/img/arabica-devnet.png)
+![arabica-devnet](https://github.com/celestiaorg/docs/raw/main/public/img/arabica-devnet.png)
 
 Arabica devnet is a testnet from Celestia Labs that is focused
 exclusively on providing developers with enhanced performance and

--- a/nodes/arabica-devnet.md
+++ b/nodes/arabica-devnet.md
@@ -4,7 +4,7 @@ description: A guide to Arabica devnet.
 
 # Arabica devnet
 
-![arabica-devnet](/img/arabica-devnet.png)
+![arabica-devnet](/public/img/arabica-devnet.png)
 
 Arabica devnet is a testnet from Celestia Labs that is focused
 exclusively on providing developers with enhanced performance and

--- a/nodes/bridge-node.md
+++ b/nodes/bridge-node.md
@@ -20,7 +20,7 @@ A Celestia bridge node has the following properties:
 2. Validate and erasure code the “raw” blocks
 3. Supply block shares with data availability headers to light nodes in the DA network.
 
-![bridge-node-diagram](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/BridgeNodes.png)
+![bridge-node-diagram](/public/img/nodes/BridgeNodes.png)
 
 From an implementation perspective, Bridge nodes run two separate processes:
 

--- a/nodes/bridge-node.md
+++ b/nodes/bridge-node.md
@@ -20,7 +20,7 @@ A Celestia bridge node has the following properties:
 2. Validate and erasure code the “raw” blocks
 3. Supply block shares with data availability headers to light nodes in the DA network.
 
-![bridge-node-diagram](/public/img/nodes/BridgeNodes.png)
+![bridge-node-diagram](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/BridgeNodes.png)
 
 From an implementation perspective, Bridge nodes run two separate processes:
 

--- a/nodes/bridge-node.md
+++ b/nodes/bridge-node.md
@@ -20,7 +20,7 @@ A Celestia bridge node has the following properties:
 2. Validate and erasure code the “raw” blocks
 3. Supply block shares with data availability headers to light nodes in the DA network.
 
-![bridge-node-diagram](/img/nodes/BridgeNodes.png)
+![bridge-node-diagram](/public/img/nodes/BridgeNodes.png)
 
 From an implementation perspective, Bridge nodes run two separate processes:
 

--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -16,7 +16,7 @@ Celestia.
 Full consensus nodes allow you to sync blockchain history in the Celestia
 consensus layer.
 
-![full consensus node](/public/img/nodes/full-consensus-node.png)
+![full consensus node](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/full-consensus-node.png)
 
 [[toc]]
 
@@ -325,7 +325,7 @@ for information on which ports are required to be open on your machine.
 
 Validator nodes allow you to participate in consensus in the Celestia network.
 
-![validator node](/public/img/nodes/validator.png)
+![validator node](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/validator.png)
 
 #### Validator hardware requirements
 

--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -16,7 +16,7 @@ Celestia.
 Full consensus nodes allow you to sync blockchain history in the Celestia
 consensus layer.
 
-![full consensus node](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/full-consensus-node.png)
+![full consensus node](/public/img/nodes/full-consensus-node.png)
 
 [[toc]]
 
@@ -325,7 +325,7 @@ for information on which ports are required to be open on your machine.
 
 Validator nodes allow you to participate in consensus in the Celestia network.
 
-![validator node](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/validator.png)
+![validator node](/public/img/nodes/validator.png)
 
 #### Validator hardware requirements
 

--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -16,7 +16,7 @@ Celestia.
 Full consensus nodes allow you to sync blockchain history in the Celestia
 consensus layer.
 
-![full consensus node](/img/nodes/full-consensus-node.png)
+![full consensus node](/public/img/nodes/full-consensus-node.png)
 
 [[toc]]
 
@@ -325,7 +325,7 @@ for information on which ports are required to be open on your machine.
 
 Validator nodes allow you to participate in consensus in the Celestia network.
 
-![validator node](/img/nodes/validator.png)
+![validator node](/public/img/nodes/validator.png)
 
 #### Validator hardware requirements
 

--- a/nodes/full-storage-node.md
+++ b/nodes/full-storage-node.md
@@ -15,7 +15,7 @@ storage nodes send block shares, headers, and fraud proofs to light nodes.
 The light nodes gossip headers, fraud proofs, and sometimes block shares,
 between one another.
 
-![Full storage node](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/full-storage-node.png)
+![Full storage node](/public/img/nodes/full-storage-node.png)
 
 ## Hardware requirements
 

--- a/nodes/full-storage-node.md
+++ b/nodes/full-storage-node.md
@@ -15,7 +15,7 @@ storage nodes send block shares, headers, and fraud proofs to light nodes.
 The light nodes gossip headers, fraud proofs, and sometimes block shares,
 between one another.
 
-![Full storage node](/public/img/nodes/full-storage-node.png)
+![Full storage node](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/full-storage-node.png)
 
 ## Hardware requirements
 

--- a/nodes/full-storage-node.md
+++ b/nodes/full-storage-node.md
@@ -15,7 +15,7 @@ storage nodes send block shares, headers, and fraud proofs to light nodes.
 The light nodes gossip headers, fraud proofs, and sometimes block shares,
 between one another.
 
-![Full storage node](/img/nodes/full-storage-node.png)
+![Full storage node](/public/img/nodes/full-storage-node.png)
 
 ## Hardware requirements
 

--- a/nodes/light-node.md
+++ b/nodes/light-node.md
@@ -14,7 +14,7 @@ availability (DA) network.
 Light nodes ensure data availability. This is the most common
 way to interact with Celestia networks.
 
-![light-node](/public/img/nodes/LightNodes.png)
+![light-node](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/LightNodes.png)
 
 Light nodes have the following behavior:
 

--- a/nodes/light-node.md
+++ b/nodes/light-node.md
@@ -14,7 +14,7 @@ availability (DA) network.
 Light nodes ensure data availability. This is the most common
 way to interact with Celestia networks.
 
-![light-node](https://github.com/celestiaorg/docs/raw/main/public/img/nodes/LightNodes.png)
+![light-node](/public/img/nodes/LightNodes.png)
 
 Light nodes have the following behavior:
 

--- a/nodes/light-node.md
+++ b/nodes/light-node.md
@@ -14,7 +14,7 @@ availability (DA) network.
 Light nodes ensure data availability. This is the most common
 way to interact with Celestia networks.
 
-![light-node](/img/nodes/LightNodes.png)
+![light-node](/public/img/nodes/LightNodes.png)
 
 Light nodes have the following behavior:
 

--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -6,7 +6,7 @@
 import MainnetVersionTags from '../.vitepress/components/MainnetVersionTags.vue'
 </script>
 
-![Mainnet Beta](/img/Mainnet-Beta.png)
+![Mainnet Beta](/public/img/Mainnet-Beta.png)
 
 Welcome to the guide for Celestia’s Mainnet Beta, the production
 network that marks the pinnacle of Celestia’s evolution since its

--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -6,7 +6,7 @@
 import MainnetVersionTags from '../.vitepress/components/MainnetVersionTags.vue'
 </script>
 
-![Mainnet Beta](https://github.com/celestiaorg/docs/raw/main/public/img/Mainnet-Beta.png)
+![Mainnet Beta](/public/img/Mainnet-Beta.png)
 
 Welcome to the guide for Celestia’s Mainnet Beta, the production
 network that marks the pinnacle of Celestia’s evolution since its

--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -6,7 +6,7 @@
 import MainnetVersionTags from '../.vitepress/components/MainnetVersionTags.vue'
 </script>
 
-![Mainnet Beta](/public/img/Mainnet-Beta.png)
+![Mainnet Beta](https://github.com/celestiaorg/docs/raw/main/public/img/Mainnet-Beta.png)
 
 Welcome to the guide for Celestia’s Mainnet Beta, the production
 network that marks the pinnacle of Celestia’s evolution since its

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -4,7 +4,7 @@ description: Learn how to connect to the Mocha network.
 
 # Mocha testnet
 
-![mocha-testnet](https://github.com/celestiaorg/docs/raw/main/public/img/mocha.jpg)
+![mocha-testnet](/public/img/mocha.jpg)
 
 This guide contains the relevant sections for how to connect to Mocha,
 depending on the type of node you are running. Mocha testnet is designed

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -4,7 +4,7 @@ description: Learn how to connect to the Mocha network.
 
 # Mocha testnet
 
-![mocha-testnet](/public/img/mocha.jpg)
+![mocha-testnet](https://github.com/celestiaorg/docs/raw/main/public/img/mocha.jpg)
 
 This guide contains the relevant sections for how to connect to Mocha,
 depending on the type of node you are running. Mocha testnet is designed

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -4,7 +4,7 @@ description: Learn how to connect to the Mocha network.
 
 # Mocha testnet
 
-![mocha-testnet](/img/mocha.jpg)
+![mocha-testnet](/public/img/mocha.jpg)
 
 This guide contains the relevant sections for how to connect to Mocha,
 depending on the type of node you are running. Mocha testnet is designed

--- a/nodes/overview.md
+++ b/nodes/overview.md
@@ -29,7 +29,7 @@ Data Availability:
 You can learn more about how to setup each different node by going through
 each tutorial guide.
 
-![Banner](https://github.com/celestiaorg/docs/raw/main/public/img/node-requirements.jpg)
+![Banner](/public/img/node-requirements.jpg)
 
 Please provide any feedback on the tutorials and guides. If you notice
 a bug or issue, feel free to make a pull request or write up a Github

--- a/nodes/overview.md
+++ b/nodes/overview.md
@@ -29,7 +29,7 @@ Data Availability:
 You can learn more about how to setup each different node by going through
 each tutorial guide.
 
-![Banner](/img/node-requirements.jpg)
+![Banner](/public/img/node-requirements.jpg)
 
 Please provide any feedback on the tutorials and guides. If you notice
 a bug or issue, feel free to make a pull request or write up a Github

--- a/nodes/overview.md
+++ b/nodes/overview.md
@@ -29,7 +29,7 @@ Data Availability:
 You can learn more about how to setup each different node by going through
 each tutorial guide.
 
-![Banner](/public/img/node-requirements.jpg)
+![Banner](https://github.com/celestiaorg/docs/raw/main/public/img/node-requirements.jpg)
 
 Please provide any feedback on the tutorials and guides. If you notice
 a bug or issue, feel free to make a pull request or write up a Github


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This Pull Request fixes image referencings in the markdown files of `/learn` and `/learn/how-celestia-works` directories. The changes made include:

- Updating image references to ensure accuracy.

### Before and After

**Before:**
![image](https://github.com/celestiaorg/docs/assets/44838743/0ab272bf-8fc4-4c93-98b7-c1ee8fb5e026)

![image](https://github.com/celestiaorg/docs/assets/44838743/ff7a7d9f-6693-41fe-a84b-f3b9037b185d)


**After:**
![image](https://github.com/celestiaorg/docs/assets/44838743/1f78c4fc-7a45-49c6-827f-ae508e9e8a94)

![image](https://github.com/celestiaorg/docs/assets/44838743/ee30d6fd-3474-4450-9bad-aefb8fe4a0c3)


## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated image paths in various documentation pages to improve access and loading times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->