### PR TITLE
feat: Update arbitrum-mocha.md to celestia-node v0.12.4

### DIFF
--- a/developers/arbitrum-mocha.md
+++ b/developers/arbitrum-mocha.md
@@ -39,8 +39,8 @@ This guide covers deploying an Arbitrum Nitro rollup to
        container_name: 'celestia-da' // [!code ++]
        user: root // [!code ++]
        platform: linux/x86_64
-       image: "ghcr.io/rollkit/local-celestia-devnet:v0.12.1" // [!code --]
-       image: "ghcr.io/celestiaorg/celestia-node:v0.12.1" // [!code ++]
+       image: "ghcr.io/rollkit/local-celestia-devnet:v0.12.4" // [!code --]
+       image: "ghcr.io/celestiaorg/celestia-node:v0.12.4" // [!code ++]
        command: > // [!code ++]
                celestia light start // [!code ++]
                --core.ip rpc-mocha.pops.one // [!code ++]

--- a/developers/arbitrum-mocha.md
+++ b/developers/arbitrum-mocha.md
@@ -75,7 +75,7 @@ This guide covers deploying an Arbitrum Nitro rollup to
    NODE_PATH="/home/celestia/bridge/" // [!code --]
    NODE_PATH="/home/celestia/.celestia-light-{{constants.mochaChainId}}/" // [!code ++]
 
-   # Line 287
+   # Line 322
    # NOTE: depending on the version you're using, you may have a different
    # container name to start. Change yours accordingly to `celestia-da`.
    export CELESTIA_NODE_AUTH_TOKEN="$(docker exec nitro-testnode-da-1 celestia bridge auth admin --node.store  ${NODE_PATH})" // [!code --]


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Docker image references in the Arbitrum Nitro rollup deployment guide from `v0.12.1` to `v0.12.4`, enhancing the deployment process with the latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->