### PR TITLE
Update arbitrum-integration.md

### DIFF
--- a/developers/arbitrum-integration.md
+++ b/developers/arbitrum-integration.md
@@ -57,7 +57,7 @@ Arbitrum `SequencerInbox.sol` contract.
 In the `SequencerInbox.sol` contract, the `validateBatchData`
 modifier has been designed to authenticate that the data root is
 on Celestia when reading a batch of data. This is achieved by the
-[following code by @Ferret-san]([https://arbnode/sequencer_inbox.go](https://github.com/celestiaorg/nitro/blob/4dac70821b5bbb7c48b6e5c2460663dc0c07e011/arbnode/sequencer_inbox.go)):
+[following code in `arbnode/sequencer_inbox.go`](https://github.com/celestiaorg/nitro/blob/v2.2.2-no-blobstream/arbnode/sequencer_inbox.go):
 
 Note that the data above is the bytes serialized version of this struct in Go:
 

--- a/developers/arbitrum-integration.md
+++ b/developers/arbitrum-integration.md
@@ -51,13 +51,13 @@ which relays commitments to Celestia’s data root to an onchain light client
 on Ethereum. This allows L2 solutions that settle on Ethereum to benefit
 from the scalability Celestia’s data availability layer can provide.
 
-As part of this integration, Blobstream has been incorporated into the
+As part of this integration, Blobstream is being called from the
 Arbitrum `SequencerInbox.sol` contract.
 
 In the `SequencerInbox.sol` contract, the `validateBatchData`
 modifier has been designed to authenticate that the data root is
 on Celestia when reading a batch of data. This is achieved by the
-[following code by @Ferret-san](https://gist.github.com/Ferret-san/3d3fc1b5738ee8d77ad112c0eb8bbe5f):
+[following code by @Ferret-san]([https://arbnode/sequencer_inbox.go](https://github.com/celestiaorg/nitro/blob/4dac70821b5bbb7c48b6e5c2460663dc0c07e011/arbnode/sequencer_inbox.go)):
 
 Note that the data above is the bytes serialized version of this struct in Go:
 
@@ -101,8 +101,8 @@ The [@celestiaorg/nitro](https://github.com/celestiaorg/nitro) integration
 [uses the same fallback mechanism](https://github.com/celestiaorg/nitro/blob/f01968eb3d4e19329e9c92b050e98a8e5772f1f2/arbnode/batch_poster.go#L845-L857).
 
 The fallback logic for Celestia DA is configurable, providing an alternative
-to the previous default fallback mechanism. Additionally, a method has been
-added to the Arbitrum node software. This method allows the sequencer to call
+to the previous default fallback mechanism. Additionally, an ability has been
+added to the Arbitrum node software which allows the sequencer to call
 `VerifyAttestation` to check if a data root has been posted on Blobstream or
 not, before it sends the sequencer message (data pointer) to the underlying
 chain.

--- a/developers/arbitrum-integration.md
+++ b/developers/arbitrum-integration.md
@@ -57,7 +57,7 @@ Arbitrum `SequencerInbox.sol` contract.
 In the `SequencerInbox.sol` contract, the `validateBatchData`
 modifier has been designed to authenticate that the data root is
 on Celestia when reading a batch of data. This is achieved by the
-[following code in `arbnode/sequencer_inbox.go`](https://github.com/celestiaorg/nitro/blob/v2.2.2-no-blobstream/arbnode/sequencer_inbox.go):
+[following code in `arbnode/sequencer_inbox.go`](https://github.com/celestiaorg/nitro-contracts/blob/celestia/blobstream/src/bridge/SequencerInbox.sol#L334-L360):
 
 Note that the data above is the bytes serialized version of this struct in Go:
 


### PR DESCRIPTION
change in fall back on method to ability
change in link to sequencer_inbox.go

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the Arbitrum integration guide including:
		- New method for calling Blobstream from the Arbitrum `SequencerInbox.sol` contract.
		- Revised code references for more accurate information.
		- Added configurable fallback logic for Celestia DA and a method for sequencer attestation verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->