### PR TITLE
Update TrustedPoint archive node domain (RPC, gRPC, API) on mocha & mainnet.md

### DIFF
--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -112,6 +112,7 @@ to participate in Mainnet Beta:
 - `celestia-rpc.easy2stake.com`
 - `celestia.rpc.kjnodes.com`
 - `celestia-rpc.0xcryptovestor.com`
+- `rpc-celestia-mainnet.trusted-point.com`
 
 #### API endpoints
 
@@ -131,6 +132,7 @@ to participate in Mainnet Beta:
 - `api-celestia-full.avril14th.org`
 - `celestia-lcd.easy2stake.com`
 - `celestia.api.kjnodes.com`
+- `api-celestia-mainnet.trusted-point.com`
 
 #### gRPC endpoints
 
@@ -149,6 +151,7 @@ to participate in Mainnet Beta:
 - `rpc-celestia.alphab.ai:9090`
 - `grpc-celestia-full.avril14th.org`
 - `celestia.grpc.kjnodes.com:443`
+- `grpc-celestia-mainnet.trusted-point.com:9095`
 
 ### Data availability nodes
 

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -80,7 +80,7 @@ Celestia network. The default port is 26657.
 - `celestia-rpc.f5nodes.com`
 - `celestia-testnet.brightlystake.com`
 - `rpc-celestia-mocha.architectnodes.com`
-- `rpc-celestia-mocha.testnet-pride.com`
+- `rpc-celestia-mocha.trusted-point.com`
 - `rpc-celestia-testnet-01.stakeflow.io`
 - `mocha.celestia.rpc.cumulo.me`
 - `rpc-mocha-4.spidey.services`
@@ -99,7 +99,7 @@ The default port is 1317.
 - [https://celestia-api.f5nodes.com](https://celestia-api.f5nodes.com)
 - [https://celestia-testnet.brightlystake.com/api](https://celestia-testnet.brightlystake.com/api)
 - [https://rest-celestia-mocha.architectnodes.com](https://rest-celestia-mocha.architectnodes.com)
-- [https://api-celestia-mocha.testnet-pride.com/](https://api-celestia-mocha.testnet-pride.com/)
+- [https://api-celestia-mocha.trusted-point.com](https://api-celestia-mocha.trusted-point.com)
 - [https://api-celestia-testnet-01.stakeflow.io/](https://api-celestia-testnet-01.stakeflow.io/)
 - [https://mocha.api.cumulo.me/](https://mocha.api.cumulo.me/)
 - [http://api-mocha-4.spidey.services](http://api-mocha-4.spidey.services)
@@ -119,7 +119,7 @@ broadcast transactions.
 - `celestia-grpc.f5nodes.com`
 - `celestia-testnet.brightlystake.com:9390`
 - `grpc-celestia-mocha.architectnodes.com:1443`
-- `grpc-celestia-mocha.testnet-pride.com:9099`
+- `grpc-celestia-mocha.trusted-point.com:9099`
 - `grpc-celestia-testnet-01.stakeflow.io:16002`
 - `mocha.grpc.cumulo.me:443`
 - `grpc-mocha-4.spidey.services`


### PR DESCRIPTION
Hello!
We made a rebranding some time ago and migrating to a different domain names. So we would like to update our services on mocha.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated RPC and API endpoints for the Celestia network in the documentation.
	- Added a new RPC endpoint and corresponding API and gRPC endpoints for Mainnet Beta participation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->