### PR TITLE
docs: 15s -> 12s block times

### DIFF
--- a/developers/integrate-celestia.md
+++ b/developers/integrate-celestia.md
@@ -72,7 +72,7 @@ fast-sync, state sync, and quick sync.
 ### Notable exceptions relative to other blockchains
 
 Relative to other Tendermint based chains, Celestia will have significantly
-longer blocktimes of around 12\* seconds. The reason behind this block time is to
+longer blocktimes of roughly 12\* seconds. The reason behind this block time is to
 optimize the bandwidth used by light clients that are sampling the chain, and
 is not because we have modified Tendermint consensus in any meaningful way.
 Validators will likely download/upload relatively large blocks. It should be

--- a/developers/integrate-celestia.md
+++ b/developers/integrate-celestia.md
@@ -72,7 +72,7 @@ fast-sync, state sync, and quick sync.
 ### Notable exceptions relative to other blockchains
 
 Relative to other Tendermint based chains, Celestia will have significantly
-longer blocktimes of around 15\* seconds. The reason behind this block time is to
+longer blocktimes of around 12\* seconds. The reason behind this block time is to
 optimize the bandwidth used by light clients that are sampling the chain, and
 is not because we have modified Tendermint consensus in any meaningful way.
 Validators will likely download/upload relatively large blocks. It should be


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This updates block time from ~15 to ~12 seconds.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Celestia integration guide to include the adjustment of block time from 15 seconds to approximately 12 seconds, optimizing bandwidth for light clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->