### PR TITLE
feat: update pruning info

### DIFF
--- a/learn/retrievability.md
+++ b/learn/retrievability.md
@@ -21,7 +21,8 @@ order to ensure that syncing new rollup nodes is possible.
 As of version v0.13.0, celestia-node has implemented a light node
 sampling window of 30 days, as specified in
 [CIP-4](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-4.md).
-This means that light nodes will now only sample blocks within a 30-day
+This means that once pruning is implemented,
+light nodes will now only sample blocks within a 30-day
 window instead of sampling all blocks from genesis. This change
 introduces the concept of pruning to celestia-node, where data
 outside of the 30-day window may not be stored by light nodes,
@@ -29,12 +30,12 @@ marking a significant update in how data retrievability and
 storage are managed within the network
 ([v0.13.0 release notes](https://github.com/celestiaorg/celestia-node/releases/tag/v0.13.0)).
 
-Data blobs older than the recency window are pruned by default on light nodes, but
-will continue to be stored by archival nodes that do not prune data. Light
+Data blobs older than the recency window will be pruned by default on light nodes, after pruning is implemented,
+but will continue to be stored by archival nodes that do not prune data. Light
 nodes will be able to query historic blob data in namespaces from archival
 nodes, as long as archival nodes exist on the public network.
 
-Light nodes will only perform data
+Once pruning is implemented, light nodes will only perform data
 availability sampling for blocks within the data recency window of 30 days.
 
 ## Suggested practices for rollups

--- a/learn/retrievability.md
+++ b/learn/retrievability.md
@@ -30,7 +30,7 @@ marking a significant update in how data retrievability and
 storage are managed within the network
 ([v0.13.0 release notes](https://github.com/celestiaorg/celestia-node/releases/tag/v0.13.0)).
 
-Data blobs older than the recency window will be pruned by default on light nodes, after pruning is implemented,
+Data blobs older than the recency window will be pruned by default on light nodes, after pruning is fully implemented,
 but will continue to be stored by archival nodes that do not prune data. Light
 nodes will be able to query historic blob data in namespaces from archival
 nodes, as long as archival nodes exist on the public network.

--- a/learn/retrievability.md
+++ b/learn/retrievability.md
@@ -30,7 +30,8 @@ marking a significant update in how data retrievability and
 storage are managed within the network
 ([v0.13.0 release notes](https://github.com/celestiaorg/celestia-node/releases/tag/v0.13.0)).
 
-Data blobs older than the recency window will be pruned by default on light nodes, after pruning is fully implemented,
+Data blobs older than the recency window will be pruned by default
+on light nodes, after pruning is fully implemented,
 but will continue to be stored by archival nodes that do not prune data. Light
 nodes will be able to query historic blob data in namespaces from archival
 nodes, as long as archival nodes exist on the public network.

--- a/learn/retrievability.md
+++ b/learn/retrievability.md
@@ -36,7 +36,7 @@ but will continue to be stored by archival nodes that do not prune data. Light
 nodes will be able to query historic blob data in namespaces from archival
 nodes, as long as archival nodes exist on the public network.
 
-Once pruning is implemented, light nodes will only perform data
+Once pruning is fully implemented, light nodes will only perform data
 availability sampling for blocks within the data recency window of 30 days.
 
 ## Suggested practices for rollups


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

From [comment](https://github.com/celestiaorg/docs/pull/1424#issuecomment-1953738851):
> likely need to revert this as it appears the window was the only thing introduced, and that the release notes say "Light nodes will now only sample blocks within a 30 day window instead of sampling all blocks from genesis." but it does not work this way.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Implemented a 30-day light node sampling window and introduced pruning for enhanced data retrievability and storage management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->