### PR TITLE
docs: update celestia-node troubleshooting

### DIFF
--- a/nodes/celestia-node-troubleshooting.md
+++ b/nodes/celestia-node-troubleshooting.md
@@ -187,13 +187,17 @@ celestia bridge init --p2p.network private
 
 ## Error: "too many open files"
 
-When running a Celestia Bridge node, you may encounter an error in the logs similar to this:
+When running a Celestia bridge node, you may encounter an error in the
+logs similar to this:
 
 ```bash
 Error while creating log file in valueLog.open error: while opening file: /opt/celestia/.celestia-bridge/data/003442.vlog error: open /opt/celestia/.celestia-bridge/data/003442.vlog: too many open files
 ```
 
-This error indicates that the Celestia application is trying to open more files than the operating system's limit allows. To fix this, you will need to edit the Celestia Bridge service file to increase the number of file descriptors that the service can open.
+This error indicates that the Celestia application is trying to open more
+files than the operating system's limit allows. To fix this, you will need
+to edit the Celestia bridge service file to increase the number of file
+descriptors that the service can open.
 
 1. Open the service file for editing:
 
@@ -203,7 +207,8 @@ nano /etc/systemd/system/celestia-bridge.service
 
 2. Modify the `LimitNOFILE` parameter:
 
-In the service file, find the `LimitNOFILE` parameter under the [Service] section and set its value to `1400000`. It should look like this:
+In the service file, find the `LimitNOFILE` parameter under the
+`[Service]` section and set its value to `1400000`. It should look like this:
 
 ```ini
 [Service]
@@ -213,10 +218,12 @@ LimitNOFILE=1400000
 ```
 
 :::tip NOTE
-Be cautious when increasing file descriptor limits. Setting this value too high might affect system performance. Ensure the value is appropriate for your system's capabilities.
+Be cautious when increasing file descriptor limits. Setting this value too
+high might affect system performance. Ensure the value is appropriate
+for your system's capabilities.
 :::
 
-3. Reload daemon and restart Bridge service:
+3. Reload daemon and restart bridge service:
 
 ```bash
 sudo systemctl daemon-reload

--- a/nodes/celestia-node-troubleshooting.md
+++ b/nodes/celestia-node-troubleshooting.md
@@ -184,3 +184,44 @@ rm -rf ~/.celestia-bridge-private
 # celestia <node-type> init --p2p.network <network>
 celestia bridge init --p2p.network private
 ```
+
+## Error: "too many open files"
+
+When running a Celestia Bridge node, you may encounter an error in the logs similar to this:
+
+```bash
+Error while creating log file in valueLog.open error: while opening file: /opt/celestia/.celestia-bridge/data/003442.vlog error: open /opt/celestia/.celestia-bridge/data/003442.vlog: too many open files
+```
+
+This error indicates that the Celestia application is trying to open more files than the operating system's limit allows. To fix this, you will need to edit the Celestia Bridge service file to increase the number of file descriptors that the service can open.
+
+1. Open the service file for editing:
+
+```bash
+nano /etc/systemd/system/celestia-bridge.service
+```
+
+2. Modify the `LimitNOFILE` parameter:
+
+In the service file, find the `LimitNOFILE` parameter under the [Service] section and set its value to `1400000`. It should look like this:
+
+```ini
+[Service]
+...
+LimitNOFILE=1400000
+...
+```
+
+:::tip NOTE
+Be cautious when increasing file descriptor limits. Setting this value too high might affect system performance. Ensure the value is appropriate for your system's capabilities.
+:::
+
+3. Reload daemon and restart Bridge service:
+
+```bash
+sudo systemctl daemon-reload
+```
+
+```bash
+sudo systemctl restart celestia-bridge
+```

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -77,7 +77,7 @@ Celestia network. The default port is 26657.
 
 - `rpc.celestia-mocha.com`
 - `rpc-2.celestia-mocha.com`
-- `celestia-rpc.f5nodes.com`
+- `celestia-testnet-rpc.f5nodes.com`
 - `celestia-testnet.brightlystake.com`
 - `rpc-celestia-mocha.architectnodes.com`
 - `rpc-celestia-mocha.trusted-point.com`
@@ -98,7 +98,7 @@ The default port is 1317.
 - [https://api-mocha.pops.one](https://api-mocha.pops.one)
 - [https://api.celestia-mocha.com/](https://api.celestia-mocha.com/)
 - [https://api-2.celestia-mocha.com/](https://api-2.celestia-mocha.com/)
-- [https://celestia-api.f5nodes.com](https://celestia-api.f5nodes.com)
+- [https://celestia-testnet-api.f5nodes.com](https://celestia-testnet-api.f5nodes.com)
 - [https://celestia-testnet.brightlystake.com/api](https://celestia-testnet.brightlystake.com/api)
 - [https://rest-celestia-mocha.architectnodes.com](https://rest-celestia-mocha.architectnodes.com)
 - [https://api-celestia-mocha.trusted-point.com](https://api-celestia-mocha.trusted-point.com)
@@ -120,7 +120,7 @@ broadcast transactions.
 - `grpc-2.celestia-mocha.com:443`
 - `full.consensus.mocha-4.celestia-mocha.com:9090`
 - `consensus-full-mocha-4.celestia-mocha.com:9090`
-- `celestia-grpc.f5nodes.com`
+- `celestia-testnet-grpc.f5nodes.com`
 - `celestia-testnet.brightlystake.com:9390`
 - `grpc-celestia-mocha.architectnodes.com:1443`
 - `grpc-celestia-mocha.trusted-point.com:9099`


### PR DESCRIPTION
## Overview

This PR addresses a common issue faced by Celestia Bridge node operators, specifically the "too many open files" error: 

```bash 
Error while creating log file in valueLog.open error: while opening file: /opt/celestia/.celestia-bridge/data/003442.vlog error: open /opt/celestia/.celestia-bridge/data/003442.vlog: too many open files
```

I have proposed an addition to the [celestia-node troubleshooting section](https://docs.celestia.org/nodes/celestia-node-troubleshooting) of the docs. The addition describes steps to increase the `LimitNOFILE` parameter in the `celestia-bridge.service` file. 

While the `celestia-bridge.service` file example in the [documentation](https://docs.celestia.org/nodes/systemd#celestia-bridge-node) already specifies `LimitNOFILE=1400000`, it's important to address this in the troubleshooting section, because node operators often set this value to a lower default, such as `65535`, which can lead to the above error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Added troubleshooting instructions for the "too many open files" error in Celestia Bridge nodes.
	- Updated RPC, API, and GRPC endpoints for the Celestia testnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->