### PR TITLE
refactor: chunk -> share

### DIFF
--- a/developers/blobstream-offchain.md
+++ b/developers/blobstream-offchain.md
@@ -51,7 +51,7 @@ that data's inclusion via Blobstream if needed. Read more in the
 [namespace specifications](https://celestiaorg.github.io/celestia-app/specs/namespace.html),
 and you can think of this like a chain ID. Learn more
 [information about `shares`](https://celestiaorg.github.io/celestia-app/specs/shares.html),
-which are small chunks of the encoded Celestia block. We use the same encoding
+which are small pieces of the encoded Celestia block. We use the same encoding
 here so that the commitments to the rollup block match those committed to by
 validators in the Celestia data root.
 

--- a/learn/how-celestia-works/overview.md
+++ b/learn/how-celestia-works/overview.md
@@ -18,7 +18,7 @@ similar to [reducing consensus to atomic broadcast](https://en.wikipedia.org/wik
 The latter provides an efficient solution to the
 [data availability problem](https://coinmarketcap.com/alexandria/article/what-is-data-availability)
 by only requiring resource-limited light nodes to sample a
-small number of random chunks from each block to verify data availability.
+small number of random shares from each block to verify data availability.
 
 Interestingly, more light nodes that participate in sampling
 increases the amount of data that the network can safely handle,

--- a/learn/how-celestia-works/transaction-lifecycle.md
+++ b/learn/how-celestia-works/transaction-lifecycle.md
@@ -61,7 +61,7 @@ that serves DAS requests.
 Light nodes connect to a celestia-node in the DA network, listen to
 extended block headers (i.e., the block headers together with the
 relevant DA metadata, such as the $4k$ intermediate Merkle roots), and
-perform DAS on the received headers (i.e., ask for random data chunks).
+perform DAS on the received headers (i.e., ask for random data shares).
 
 Note that although it is recommended, performing DAS is optional -- light
 nodes could just trust that the data corresponding to the commitments in
@@ -70,11 +70,11 @@ In addition, light nodes can also submit transactions to the celestia-app,
 i.e., `PayForBlobs` transactions.
 
 While performing DAS for a block header, every light node queries Celestia
-Nodes for a number of random data chunks from the extended matrix and the
+Nodes for a number of random data shares from the extended matrix and the
 corresponding Merkle proofs. If all the queries are successful, then the
 light node accepts the block header as valid (from a DA perspective).
 
-If at least one of the queries fails (i.e., either the data chunk is not
+If at least one of the queries fails (i.e., either the data share is not
 received or the Merkle proof is invalid), then the light node rejects the
 block header and tries again later. The retrial is necessary to deal with
 false negatives, i.e., block headers being rejected although the block
@@ -87,6 +87,6 @@ then at least one honest full node will eventually have the entire block data)
 is probabilistically guaranteed (for more details, take a look at the
 [original paper](https://arxiv.org/abs/1809.09044)).
 
-By fine tuning Celestia's parameters (e.g., the number of data chunks sampled
+By fine tuning Celestia's parameters (e.g., the number of data shares sampled
 by each light node) the likelihood of false positives can be sufficiently
 reduced such that block producers have no incentive to withhold the block data.


### PR DESCRIPTION
## Description

Rename instances of `chunk` to `share`.

## Motivation

The rsmt2d repo uses chunks and shares interchangeably and it would help new comers if we used one term consistently. A few people have expressed favor for share over chunk because of it's broader usage in celestia-node and celestia-app.

See https://github.com/celestiaorg/rsmt2d/issues/215