### PR TITLE
fix: match menu in overview document for modular meetups

### DIFF
--- a/community/modular-meetup-intro.md
+++ b/community/modular-meetup-intro.md
@@ -81,6 +81,6 @@ companion in organizing events. Drawing upon the wisdom of seasoned event
 organizers, this resource is available for you and your co-organizers
 to explore and learn.
 
+- [Meetup Guide](./modular-meetup-guide.md)
 - [Modular Meetup Toolkit](./modular-meetup-toolkit.md)
 - [Speaker List](./speaker-list.md)
-- [Meetup Guide](./modular-meetup-guide.md)


### PR DESCRIPTION
This matches the overview bullet list to the menu format, where the order is:

1. guide
2. toolkit
3. speaker list

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Documentation**
	- Removed a duplicate link to the "Meetup Guide" in the community modular meetup introduction document.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->