### PR TITLE
docs: download-genesis command

### DIFF
--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -80,23 +80,20 @@ celestia-appd init "node-name" --chain-id {{constants.arabicaChainId}}
 
 :::
 
-Copy the `genesis.json` file:
+Download the `genesis.json` file:
 
 ::: code-group
 
 ```bash-vue [Mainnet Beta]
-cp $HOME/networks/{{constants.mainnetChainId}}/genesis.json \
-    $HOME/.celestia-app/config
+celestia-appd download-genesis {{constants.mainnetChainId}}
 ```
 
 ```bash-vue [Mocha]
-cp $HOME/networks/{{constants.mochaChainId}}/genesis.json \
-    $HOME/.celestia-app/config
+celestia-appd download-genesis {{constants.mochaChainId}}
 ```
 
 ```bash-vue [Arabica]
-cp $HOME/networks/{{constants.arabicaChainId}}/genesis.json \
-    $HOME/.celestia-app/config
+celestia-appd download-genesis {{constants.arabicaChainId}}
 ```
 
 :::


### PR DESCRIPTION
celestia-appd has had a `download-genesis` command since [1.4.0](https://github.com/celestiaorg/celestia-app/releases/tag/v1.4.0) so I think it's safe to suggest doing that instead of manually `curl`ing the genesis file and copying it over.

## Screenshot

<img width="715" alt="Screenshot 2024-03-06 at 9 08 36 PM" src="https://github.com/celestiaorg/docs/assets/3699047/158048bc-24f4-4fc0-beec-7294227646b1">

and it works on my machine

```
$ celestia-appd download-genesis celestia
Downloading genesis file for celestia to /Users/rootulp/.celestia-app/config/genesis.json
Downloaded genesis file for celestia to /Users/rootulp/.celestia-app/config/genesis.json
SHA-256 hash verified for celestia
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the process for downloading the `genesis.json` file for different chain IDs, enhancing clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->