### PR TITLE
fix: remove unecessary `head -c -1` command

### DIFF
--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -132,6 +132,22 @@ the following commands:
 
 Setting persistent peers is advised only if you are running a sentry node.
 
+:::tip
+Mac users' built-in `head` command does not accept negative numbers for `-c` flag.
+Solution is to install `coreutils` package and use `ghead` command from it.
+
+```bash
+brew install coreutils
+```
+
+and optionally set alias from `head` to `ghead` in shell config (`~/.bashrc`, `~/.zshrc` etc):
+
+```sh
+alias head=ghead
+```
+
+:::
+
 ::: code-group
 
 ```bash-vue [Mainnet Beta]
@@ -150,22 +166,6 @@ sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"
 PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.arabicaChainId}}/peers.txt | head -c -1 | tr '\n' ',')
 echo $PERSISTENT_PEERS
 sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/.celestia-app/config/config.toml
-```
-
-:::
-
-:::tip
-Mac users' built-in `head` command does not accept negative numbers for `-c` flag.
-Solution is to install `coreutils` package and use `ghead` command from it.
-
-```bash
-brew install coreutils
-```
-
-and optionally set alias from `head` to `ghead` in shell config (`~/.bashrc`, `~/.zshrc` etc):
-
-```sh
-alias head=ghead
 ```
 
 :::

--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -106,13 +106,13 @@ Set seeds in the `$HOME/.celestia-app/config/config.toml` file:
 ::: code-group
 
 ```bash-vue [Mainnet Beta]
-SEEDS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.mainnetChainId}}/seeds.txt | head -c -1 | tr '\n' ',')
+SEEDS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.mainnetChainId}}/seeds.txt | tr '\n' ',')
 echo $SEEDS
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/" $HOME/.celestia-app/config/config.toml
 ```
 
 ```bash-vue [Mocha]
-SEEDS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.mochaChainId}}/seeds.txt | head -c -1 | tr '\n' ',')
+SEEDS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.mochaChainId}}/seeds.txt | tr '\n' ',')
 echo $SEEDS
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/" $HOME/.celestia-app/config/config.toml
 ```
@@ -132,38 +132,22 @@ the following commands:
 
 Setting persistent peers is advised only if you are running a sentry node.
 
-:::tip
-Mac users' built-in `head` command does not accept negative numbers for `-c` flag.
-Solution is to install `coreutils` package and use `ghead` command from it.
-
-```bash
-brew install coreutils
-```
-
-and optionally set alias from `head` to `ghead` in shell config (`~/.bashrc`, `~/.zshrc` etc):
-
-```sh
-alias head=ghead
-```
-
-:::
-
 ::: code-group
 
 ```bash-vue [Mainnet Beta]
-PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.mainnetChainId}}/peers.txt | head -c -1 | tr '\n' ',')
+PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.mainnetChainId}}/peers.txt | tr '\n' ',')
 echo $PERSISTENT_PEERS
 sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/.celestia-app/config/config.toml
 ```
 
 ```bash-vue [Mocha]
-PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.mochaChainId}}/peers.txt | head -c -1 | tr '\n' ',')
+PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.mochaChainId}}/peers.txt | tr '\n' ',')
 echo $PERSISTENT_PEERS
 sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/.celestia-app/config/config.toml
 ```
 
 ```bash-vue [Arabica]
-PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.arabicaChainId}}/peers.txt | head -c -1 | tr '\n' ',')
+PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants.arabicaChainId}}/peers.txt | tr '\n' ',')
 echo $PERSISTENT_PEERS
 sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/.celestia-app/config/config.toml
 ```


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
    - Updated the tip for Mac users on using the `head` command with installation instructions for `coreutils` and setting up an alias for `ghead`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->