### PR TITLE
fix: use v1.7.0 instead of rc

### DIFF
--- a/.vitepress/constants/arabica_versions.js
+++ b/.vitepress/constants/arabica_versions.js
@@ -1,5 +1,5 @@
 const arabicaVersions = Object.freeze({
-  "app-latest-tag": "v1.7.0-rc0",
+  "app-latest-tag": "v1.7.0",
   "app-latest-sha": "915847191e80d836f862eea2664949d9a240abea",
   "core-latest-tag": "v1.35.0-tm-v0.34.29",
   "core-latest-sha": "f95a434e674610b3a2c5e7d26bd87da69ccaa213",


### PR DESCRIPTION
they are the same commit. the automation picked up the rc instead of release. the rc had no issues, which is why release is the same commit.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
