### PR TITLE
fix: update contract addresses to gateway contract for Blobstream X

### DIFF
--- a/developers/blobstream.md
+++ b/developers/blobstream.md
@@ -165,7 +165,7 @@ the following Ethereum testnets:
 | Blobstream X  | Ethereum Mainnet          | [`Not yet deployed`](https://etherscan.io/address/0xTODO) | [Mainnet Beta](../nodes/mainnet.md) |
 | Blobstream X | Arbitrum One | [`Not yet deployed`](https://arbiscan.io/address/0xTODO)  | [Mainnet Beta](../nodes/mainnet.md) |
 | Blobstream X | Base           | [`Not yet deployed`](https://goerli.etherscan.io/address/0xTODO)  | [Mainnet Beta](../nodes/mainnet.md) |
-| Blobstream X | Ethereum Sepolia           | [`0x6c7a05e0AE641c6559fD76ac56641778B6eCd776`](https://sepolia.etherscan.io/address/0x6c7a05e0AE641c6559fD76ac56641778B6eCd776)  | [Mainnet Beta](../nodes/mainnet.md) |
-| Blobstream X | Arbitrum Sepolia           | [`0x6c7a05e0AE641c6559fD76ac56641778B6eCd776`](https://sepolia.arbiscan.io/address/0x6c7a05e0AE641c6559fD76ac56641778B6eCd776)  | [Mocha testnet](../nodes/mocha-testnet.md) |
+| Blobstream X | Ethereum Sepolia           | [`0x48B257EC1610d04191cC2c528d0c940AdbE1E439`](https://sepolia.etherscan.io/address/0x48B257EC1610d04191cC2c528d0c940AdbE1E439#events)  | [Mainnet Beta](../nodes/mainnet.md) |
+| Blobstream X | Arbitrum Sepolia           | [`0xf6b3239143d33aefc893fa5411cdc056f8080418`](https://sepolia.arbiscan.io/address/0xf6b3239143d33aefc893fa5411cdc056f8080418#events)  | [Mocha testnet](../nodes/mocha-testnet.md) |
 
 <!-- markdownlint-enable MD013 -->

--- a/developers/blobstream.md
+++ b/developers/blobstream.md
@@ -165,7 +165,7 @@ the following Ethereum testnets:
 | Blobstream X  | Ethereum Mainnet          | [`Not yet deployed`](https://etherscan.io/address/0xTODO) | [Mainnet Beta](../nodes/mainnet.md) |
 | Blobstream X | Arbitrum One | [`Not yet deployed`](https://arbiscan.io/address/0xTODO)  | [Mainnet Beta](../nodes/mainnet.md) |
 | Blobstream X | Base           | [`Not yet deployed`](https://goerli.etherscan.io/address/0xTODO)  | [Mainnet Beta](../nodes/mainnet.md) |
-| Blobstream X | Ethereum Sepolia           | [`0x48B257EC1610d04191cC2c528d0c940AdbE1E439`](https://sepolia.etherscan.io/address/0x48B257EC1610d04191cC2c528d0c940AdbE1E439)  | [Mainnet Beta](../nodes/mainnet.md) |
-| Blobstream X | Arbitrum Sepolia           | [`0xf6b3239143d33aeFC893fa5411cdc056F8080418`](https://sepolia.arbiscan.io/address/0xf6b3239143d33aeFC893fa5411cdc056F8080418)  | [Mocha testnet](../nodes/mocha-testnet.md) |
+| Blobstream X | Ethereum Sepolia           | [`0x6c7a05e0AE641c6559fD76ac56641778B6eCd776`](https://sepolia.etherscan.io/address/0x6c7a05e0AE641c6559fD76ac56641778B6eCd776)  | [Mainnet Beta](../nodes/mainnet.md) |
+| Blobstream X | Arbitrum Sepolia           | [`0x6c7a05e0AE641c6559fD76ac56641778B6eCd776`](https://sepolia.arbiscan.io/address/0x6c7a05e0AE641c6559fD76ac56641778B6eCd776)  | [Mocha testnet](../nodes/mocha-testnet.md) |
 
 <!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
Uses `0x6c7a05e0AE641c6559fD76ac56641778B6eCd776` for both examples: 
1. mocha -> arbitrum sepolia: https://sepolia.arbiscan.io/address/0x6c7a05e0ae641c6559fd76ac56641778b6ecd776
2. mainnet -> ethereum sepolia: https://sepolia.etherscan.io/address/0x6c7a05e0ae641c6559fd76ac56641778b6ecd776

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated Ethereum and Arbitrum Sepolia addresses for Blobstream X in the developer documentation, now including event links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->