### PR TITLE
docs: update bubs testnet informations

### DIFF
--- a/developers/bubs-testnet.md
+++ b/developers/bubs-testnet.md
@@ -73,6 +73,11 @@ contracts you deploy there.
 
 Remember, Bubs Testnet is a testing environment!
 
+### Bridge
+
+To bridge from Ethereum Sepolia to Bubs Testnet, visit the
+[Bubs Testnet bridge](https://bubs-sepolia.bridge.caldera.xyz/).
+
 ### Faucet
 
 To visit the Bubs testnet faucet, go to
@@ -83,6 +88,11 @@ and click the "Faucet" tab.
 
 To visit the explorer, go to
 [`https://bubs-sepolia.explorer.caldera.xyz/`](https://bubs-sepolia.explorer.caldera.xyz/).
+
+### Status
+
+To see the status and uptime information for Bubs,
+[visit the status page](https://bubs-sepolia.betteruptime.com/).
 
 ## Next steps
 

--- a/developers/bubs-testnet.md
+++ b/developers/bubs-testnet.md
@@ -76,8 +76,11 @@ Remember, Bubs Testnet is a testing environment!
 
 ### Bridge
 
-To bridge from Ethereum Sepolia to Bubs Testnet, visit the
-[Bubs Testnet bridge](https://bubs-sepolia.bridge.caldera.xyz/).
+Bridging is a process that enables the transfer of assets between
+different blockchains.
+
+To bridge between Ethereum Sepolia and Bubs Testnet,
+visit the [Bubs Testnet bridge](https://bubs-sepolia.bridge.caldera.xyz/).
 
 ### Faucet
 

--- a/developers/bubs-testnet.md
+++ b/developers/bubs-testnet.md
@@ -102,4 +102,4 @@ capabilities:
 
 - [Deploy a smart contract on Bubs testnet](./deploy-on-bubs.md)
 - [Deploy a GM Portal dapp on Bubs testnet](./gm-portal-bubs.md)
-- [Deploy a smart contract with Thirdweb](https://thirdweb.com/bubs-testnet)
+<!-- - [Deploy a smart contract with Thirdweb](https://thirdweb.com/bubs-testnet) -->

--- a/developers/bubs-testnet.md
+++ b/developers/bubs-testnet.md
@@ -22,12 +22,13 @@ who makes it easy to launch rollups with no code required.
 
 In this setup, data handling is accomplished in two ways. Firstly, data is
 written to the DA layer, in this case, Celestia
-(on the [Arabica devnet](../nodes/arabica-devnet.md)). Then, the data
+(on the [Mocha testnet](../nodes/mocha-testnet.md)). Then, the data
 commitment is written to the `op-batcher`. When reading, the `op-node`
 retrieves the data back from the DA layer by first reading the data commitment
 from the `op-batcher`, then reading the data from the DA layer using the data
 commitment. Hence, while previously `op-node` was reading from `calldata` on
 Ethereum, it now reads data from Celestia.
+[View the namespace for Bubs on Celestia's Mocha testnet](https://mocha-4.celenium.io/namespace/000000000000000000000000000000000000ca1de12ad45362e77e87).
 
 The tools involved in the data handling process include `op-batcher`,
 which batches up rollup blocks and posts them to Ethereum, `op-geth`

--- a/developers/bubs-testnet.md
+++ b/developers/bubs-testnet.md
@@ -6,7 +6,7 @@ description: The first testnet built with OP Stack and Celestia.
 
 ![Bubs testnet](/img/Celestia_Bubs_Testnet.jpg)
 
-[Bubs Testnet](https://bubstestnet.com) is a fresh offering from
+[Bubs Testnet](https://bubs-sepolia.hub.caldera.xyz/) is a fresh offering from
 [Caldera](https://caldera.xyz) with support from Celestia Labs,
 built with OP Stack and Celestia, and is dedicated to providing developers with
 an EVM-compatible execution layer to deploy their EVM applications on.
@@ -48,7 +48,7 @@ execution layer, making it an ideal platform for developers looking to
 build and test applications in a setting that closely mirrors an OP Stack
 rollup on Celestia.
 
-Learn more at [bubstestnet.com](https://bubstestnet.com).
+Learn more at [https://bubs-sepolia.hub.caldera.xyz/](https://bubs-sepolia.hub.caldera.xyz/).
 
 ### RPC URLs
 
@@ -61,11 +61,11 @@ For the Bubs Testnet, you can connect to the following RPC URLs:
 
 #### HTTPS
 
-- `https://bubs.calderachain.xyz/http`
+- `https://bubs-sepolia.rpc.caldera.xyz/http`
 
 #### WSS
 
-- `wss://bubs.calderachain.xyz/ws`
+- `wss://bubs-sepolia.rpc.caldera.xyz/ws`
 
 This URL serves as the entry point to the Bubs Testnet. You can use it
 in your applications to connect to the testnet and interact with the smart
@@ -76,12 +76,13 @@ Remember, Bubs Testnet is a testing environment!
 ### Faucet
 
 To visit the Bubs testnet faucet, go to
-[`https://bubstestnet.com`](https://bubstestnet.com).
+[`https://bubs-sepolia.hub.caldera.xyz/`](https://bubs-sepolia.hub.caldera.xyz/)
+and click the "Faucet" tab.
 
 ### Explorer
 
 To visit the explorer, go to
-[`https://explorer.bubstestnet.com/`](https://explorer.bubstestnet.com/).
+[`https://bubs-sepolia.explorer.caldera.xyz/`](https://bubs-sepolia.explorer.caldera.xyz/).
 
 ## Next steps
 

--- a/developers/deploy-on-bubs.md
+++ b/developers/deploy-on-bubs.md
@@ -9,7 +9,8 @@ Bubs testnet.
 - [Node.js](https://nodejs.org/en)
 - Basic understanding of Ethereum
 - Basic understanding of Solidity and Node.js
-- Bubs ETH from the [Bubs faucet](https://bubstestnet.com)
+- Bubs ETH from the [Bubs faucet](https://bubs-sepolia.hub.caldera.xyz/) or
+[Bubs bridge](https://bubs-sepolia.bridge.caldera.xyz/)
 - A Bubs RPC URL from the [Bubs testnet page](./bubs-testnet.md)
 
 ## Setup
@@ -182,7 +183,7 @@ set the `BUBS_RPC_URL` variable with an
 
 ```bash
 export BUBS_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-export BUBS_RPC_URL=https://bubs.calderachain.xyz/http
+export BUBS_RPC_URL=https://bubs-sepolia.rpc.caldera.xyz/http
 ```
 
 Now that we're ready to deploy the smart contract onto Bubs, we will run

--- a/developers/gm-portal-bubs.md
+++ b/developers/gm-portal-bubs.md
@@ -23,7 +23,7 @@ faucet as a variable and the RPC URL you're using:
 
 ```bash
 export PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-export BUBS_RPC_URL=https://bubs.calderachain.xyz/http
+export BUBS_RPC_URL=https://bubs-sepolia.rpc.caldera.xyz/http
 ```
 
 Now, change into the `gm-portal/contracts` directory in the same terminal and deploy


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

- [x] Updates bubs-testnet.md https://github.com/celestiaorg/docs/pull/1496/commits/fa516ffdf0e015016c035965d5780ba0424f1566
- [x] Updates deploy-on-bubs.md
- [x] Updates gm-portal-bubs.md

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated Bubs Testnet documentation with new URLs for RPC connections, faucet, explorer links, and added a bridge feature, pointing to the domain `bubs-sepolia.hub.caldera.xyz`.
	- Updated deployment guide for Bubs ETH acquisition source to include Bubs bridge option and adjust RPC URL for Bubs testnet deployment.
	- Updated RPC URL for BUBS to `https://bubs-sepolia.rpc.caldera.xyz/http` in the GM portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->