### PR TITLE
docs: update to make install for all types of machines

### DIFF
--- a/developers/node-tutorial.md
+++ b/developers/node-tutorial.md
@@ -254,17 +254,9 @@ commands:
 
 4. Install the binary:
 
-   ::: code-group
-
-   ```bash [Ubuntu]
+   ```bash
    make install
    ```
-
-   ```bash [Mac]
-   make go-install
-   ```
-
-   :::
 
 5. Build the `cel-key` utility:
 

--- a/nodes/celestia-node.md
+++ b/nodes/celestia-node.md
@@ -73,17 +73,9 @@ commands:
 
 4. Install the binary:
 
-   ::: code-group
-
-   ```bash [Ubuntu]
+   ```bash
    make install
    ```
-
-   ```bash [Mac]
-   make go-install
-   ```
-
-   :::
 
 5. Build the `cel-key` utility:
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves #1451 

Makes the default `make install` and removes `make go-install` from docs for macs. Live in v0.13.2
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Simplified the installation process in the documentation by replacing platform-specific commands with a single generic command for both Ubuntu and Mac users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->