### PR TITLE
docs: Fix proof query example errors

### DIFF
--- a/developers/blobstream-proof-queries.md
+++ b/developers/blobstream-proof-queries.md
@@ -1075,6 +1075,7 @@ func toRowProofs(proofs []*merkle.Proof) []client.BinaryMerkleProof {
 			NumLeaves: big.NewInt(proof.Total),
 		}
 	}
+	return rowProofs
 }
 
 func toNamespaceMerkleMultiProofs(proofs []*tmproto.NMTProof) []client.NamespaceMerkleMultiproof {

--- a/developers/blobstream-proof-queries.md
+++ b/developers/blobstream-proof-queries.md
@@ -663,6 +663,7 @@ func toRowProofs(proofs []*merkle.Proof) []client.BinaryMerkleProof {
 			NumLeaves: big.NewInt(proof.Total),
 		}
 	}
+	return rowProofs
 }
 ```
 

--- a/developers/blobstream-proof-queries.md
+++ b/developers/blobstream-proof-queries.md
@@ -1000,9 +1000,7 @@ func submitFraudProof(
 	dataRoot []byte,
 ) error {
 	var blockDataRoot [32]byte
-	for i, b := range dataRoot[58:] {
-		blockDataRoot[i] = b
-	}
+	copy(blockDataRoot[:], dataRoot)
 	tx, err := simpleRollup.SubmitFraudProof(
 		&bind.TransactOpts{
 			Context: ctx,


### PR DESCRIPTION
## Overview

This PR fixes two errors/typos in the "Proof Queries" example code, making it easier to for readers to follow. 

1. `toRowProofs` missing return statement. This code cannot compile.
2.  Incorrect handling of `dataRoot` in `submitFraudProof` always leading to a `slice bounds out of range` error.
     - The example provides `blockRes.Block.DataHash` – which is always 32 bytes long, as the dataRoot to the submitFraudProof function. The `submitFraudProof` function then attempts to get slice that is out of bounds `for i, b := range dataRoot[58:]`.
     
### Missing return statement:

The function signature for toRowProofs claims it should return []client.BinaryMerkleProof, but there is no return statement.  

```go
func toRowProofs(proofs []*merkle.Proof) []client.BinaryMerkleProof {
	rowProofs := make([]client.BinaryMerkleProof, len(proofs))
	for i, proof := range proofs {
		sideNodes := make( [][32]byte, len(proof.Aunts))
		for j, sideNode :=  range proof.Aunts {
			var bzSideNode [32]byte
			for k, b := range sideNode {
				bzSideNode[k] = b
			}
			sideNodes[j] = bzSideNode
		}
 		rowProofs[i] = client.BinaryMerkleProof{
			SideNodes: sideNodes,
			Key:       big.NewInt(proof.Index),
			NumLeaves: big.NewInt(proof.Total),
		}
	}
	// missing return statement. 
	// this function must return type []client.BinaryMerkleProof
}
```

### DataRoot slice bounds out of range

The example calls submitFraudProof, providing a 32 byte dataHash as the dataRoot, the called function then attempts to create a slice starting at the 58th byte, which is out of bounds. 

```go
func verify() error {
        // ...
	err = submitFraudProof(
		ctx,
		simpleRollupWrapper,
		sharesProof,
		event.ProofNonce.Uint64(),
		uint64(tx.Height),
		dcProof.Proof,
		blockRes.Block.DataHash, // DataHash is always 32 bytes
	)

	return nil
}

func submitFraudProof(
	ctx context.Context,
	simpleRollup *client.Wrappers,
	sharesProof types.ShareProof,
	nonce uint64,
	height uint64,
	dataRootInclusionProof merkle.Proof,
	dataRoot []byte,
) error {
	var blockDataRoot [32]byte
	for i, b := range dataRoot[58:] {  // slice out of bounds as dataRoot/dataHash is always 32 bytes
		blockDataRoot[i] = b
	}
```

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `copy` operation for more efficient data handling in fraud proof submissions.
- **Refactor**
	- Improved clarity in the fraud proof process by explicitly returning `rowProofs` from a function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->