### PR TITLE
fix typo in arabica-devnet page

### DIFF
--- a/nodes/arabica-devnet.md
+++ b/nodes/arabica-devnet.md
@@ -106,7 +106,7 @@ As an example, this command will work to start a light node with
 state access, using default ports:
 
 ```bash
-celestia light start --p2p.netowrk arabica \
+celestia light start --p2p.network arabica \
   --core.ip validator-1.celestia-arabica-11.com
 ```
 


### PR DESCRIPTION
`network` was misspelt



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the command for starting a light node with state access, ensuring accurate command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->