### PR TITLE
feat: add celestia-node.sh script

### DIFF
--- a/nodes/celestia-app.md
+++ b/nodes/celestia-app.md
@@ -80,7 +80,7 @@ The steps below will download a binary file named `celestia-appd`.
 Depending on the setup that you choose during installation, the `celestia-appd`
 binary will be available at either:
 
-- `$HOME/celestia-temp/celestia-appd`
+- `$HOME/celestia-app-temp/celestia-appd`
 - `/usr/local/bin/celestia-appd`
 
 Pre-built binaries are available for:

--- a/nodes/celestia-node.md
+++ b/nodes/celestia-node.md
@@ -14,7 +14,7 @@ import mainnetVersions from '/.vitepress/constants/mainnet_versions.js'
 
 ## Installing from source
 
-This tutorial goes over building and installing celestia-node. This
+This section goes over building and installing celestia-node. This
 tutorial assumes you completed the steps in
 [setting up your development environment](./environment.md).
 

--- a/nodes/celestia-node.md
+++ b/nodes/celestia-node.md
@@ -12,6 +12,8 @@ import mochaVersions from '/.vitepress/constants/mocha_versions.js'
 import mainnetVersions from '/.vitepress/constants/mainnet_versions.js'
 </script>
 
+## Installing from source
+
 This tutorial goes over building and installing celestia-node. This
 tutorial assumes you completed the steps in
 [setting up your development environment](./environment.md).
@@ -91,6 +93,39 @@ commands:
 
 The output will show the semantic version of celestia-node,
 commit hash, build date, system version, and Golang version.
+
+## Installing a pre-built binary
+
+Installing a pre-built binary is the fastest way to get started with your
+Celestia data availability node. Releases after celestia-node v0.13.3 should have
+these binaries available.
+
+The steps below will download a binary file named `celestia`.
+Depending on the setup that you choose during installation, the `celestia`
+binary will be available at either:
+
+- `$HOME/celestia-node-temp/celestia`
+- `/usr/local/bin/celestia`
+
+Pre-built binaries are available for:
+
+- Operating systems: Darwin (Apple), Linux
+- Architectures: x86_64 (amd64), arm64
+
+To install the latest pre-built binary you can run this command in your
+terminal:
+
+```bash
+bash -c "$(curl -sL https://docs.celestia.org/celestia-node.sh)"
+```
+
+Follow the instructions in the terminal output to choose your installation
+preferences.
+
+You will see an output with the menu for `celestia`.
+
+View [the script](https://github.com/celestiaorg/docs/tree/main/public/celestia-node.sh)
+to learn more about what it is doing.
 
 ## Next steps
 

--- a/public/celestia-app.sh
+++ b/public/celestia-app.sh
@@ -31,7 +31,7 @@ touch "$LOGFILE"
 echo "Log file is located at: $LOGFILE" | tee -a "$LOGFILE"
 
 # Change to $TEMP_DIR and print a message
-cd "$TEMP_DIR"
+cd "$TEMP_DIR" || exit 1
 echo "Working from temporary directory: $TEMP_DIR" | tee -a "$LOGFILE"
 
 # Fetch the latest release tag from GitHub

--- a/public/celestia-node.sh
+++ b/public/celestia-node.sh
@@ -30,7 +30,7 @@ touch "$LOGFILE"
 echo "Log file is located at: $LOGFILE" | tee -a "$LOGFILE"
 
 # Change to $TEMP_DIR and print a message
-cd "$TEMP_DIR"
+cd "$TEMP_DIR" || exit 1
 echo "Working from temporary directory: $TEMP_DIR" | tee -a "$LOGFILE"
 
 # Fetch the latest release tag from GitHub

--- a/public/celestia-node.sh
+++ b/public/celestia-node.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
 # ASCII art
-echo "          __        __  _                       "
-echo " _______ / /__ ___ / /_(_)__ ________ ____  ___ "
-echo "/ __/ -_) / -_|_-</ __/ / _ \`/___/ _ \`/ _ \/ _ \\"
-echo "\\__/\\__/_/\\__/___/\\__/_/\\_,_/    \\_,_/ .__/ .__/"
-echo "                                    /_/  /_/    "
-echo ""
+echo "        _        _   _                       _     "
+echo " __ ___| |___ __| |_(_)__ _ ___ _ _  ___  __| |___ "
+echo "/ _/ -_) / -_|_-<  _| / _\` |___| ' \\/ _ \\/ _\` / -_)"
+echo "\\__\\___|_\\___/__/\__|_\\__,_|   |_||_\\___/\\__,_\\___|"
+echo "                                                    "
 
-# Declare a log file to capture detailed logs and a temp directory
-LOGFILE="$HOME/celestia-app-temp/logfile.log"
-TEMP_DIR="$HOME/celestia-app-temp"
+# Declare a log file and a temp directory
+LOGFILE="$HOME/celestia-node-temp/logfile.log"
+TEMP_DIR="$HOME/celestia-node-temp"
 
 # Check if the directory exists
 if [ -d "$TEMP_DIR" ]; then
@@ -35,7 +34,7 @@ cd "$TEMP_DIR"
 echo "Working from temporary directory: $TEMP_DIR" | tee -a "$LOGFILE"
 
 # Fetch the latest release tag from GitHub
-VERSION=$(curl -s "https://api.github.com/repos/celestiaorg/celestia-app/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+VERSION=$(curl -s "https://api.github.com/repos/celestiaorg/celestia-node/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
 # Check if VERSION is empty
 if [ -z "$VERSION" ]; then
@@ -76,10 +75,10 @@ esac
 
 # Construct the download URL
 PLATFORM="${OS}_${ARCH}"
-URL="https://github.com/celestiaorg/celestia-app/releases/download/$VERSION/celestia-app_$PLATFORM.tar.gz"
+URL="https://github.com/celestiaorg/celestia-node/releases/download/$VERSION/celestia-node_$PLATFORM.tar.gz"
 
 # Check if URL is valid
-if [[ ! $URL =~ ^https://github.com/celestiaorg/celestia-app/releases/download/[^/]+/celestia-app_[^/]+.tar.gz$ ]]; then
+if [[ ! $URL =~ ^https://github.com/celestiaorg/celestia-node/releases/download/[^/]+/celestia-node_[^/]+.tar.gz$ ]]; then
     echo "Invalid URL: $URL. Exiting." | tee -a "$LOGFILE"
     exit 1
 fi
@@ -95,19 +94,19 @@ fi
 
 # Detect if running on macOS and use appropriate command for checksum
 if [ "$OS" = "Darwin" ]; then
-    CALCULATED_CHECKSUM=$(shasum -a 256 "celestia-app_$PLATFORM.tar.gz" | awk '{print $1}')
+    CALCULATED_CHECKSUM=$(shasum -a 256 "celestia-node_$PLATFORM.tar.gz" | awk '{print $1}')
 else
-    CALCULATED_CHECKSUM=$(sha256sum "celestia-app_$PLATFORM.tar.gz" | awk '{print $1}')
+    CALCULATED_CHECKSUM=$(sha256sum "celestia-node_$PLATFORM.tar.gz" | awk '{print $1}')
 fi
 
 # Download checksums.txt
-if ! wget "https://github.com/celestiaorg/celestia-app/releases/download/$VERSION/checksums.txt" >> "$LOGFILE" 2>&1; then
+if ! wget "https://github.com/celestiaorg/celestia-node/releases/download/$VERSION/checksums.txt" >> "$LOGFILE" 2>&1; then
     echo "Failed to download checksums. Exiting." | tee -a "$LOGFILE"
     exit 1
 fi
 
 # Find the expected checksum in checksums.txt
-EXPECTED_CHECKSUM=$(grep "celestia-app_$PLATFORM.tar.gz" checksums.txt | awk '{print $1}')
+EXPECTED_CHECKSUM=$(grep "celestia-node_$PLATFORM.tar.gz" checksums.txt | awk '{print $1}')
 
 # Verify the checksum
 if [ "$CALCULATED_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
@@ -118,7 +117,7 @@ else
 fi
 
 # Extract the tarball to the temporary directory
-if ! tar -xzf "celestia-app_$PLATFORM.tar.gz" >> "$LOGFILE" 2>&1; then
+if ! tar -xzf "celestia-node_$PLATFORM.tar.gz" >> "$LOGFILE" 2>&1; then
     echo "Extraction failed. Exiting." | tee -a "$LOGFILE"
     exit 1
 fi
@@ -127,7 +126,7 @@ fi
 echo "Binary extracted to: $TEMP_DIR" | tee -a "$LOGFILE"
 
 # Remove the tarball to clean up
-rm "celestia-app_$PLATFORM.tar.gz"
+rm "celestia-node_$PLATFORM.tar.gz"
 
 # Log and print a message
 echo "Temporary files cleaned up." | tee -a "$LOGFILE"
@@ -137,24 +136,24 @@ read -p "Do you want to move the binary to /usr/local/bin? This will require sud
 echo    # move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    sudo mv "$TEMP_DIR/celestia-appd" /usr/local/bin/
+    sudo mv "$TEMP_DIR/celestia" /usr/local/bin/
     echo "Binary moved to /usr/local/bin" | tee -a "$LOGFILE"
     # Create a symbolic link in the temporary directory
-    ln -s /usr/local/bin/celestia-appd "$TEMP_DIR/celestia-appd"
+    ln -s /usr/local/bin/celestia "$TEMP_DIR/celestia"
     echo "Symbolic link created in $TEMP_DIR" | tee -a "$LOGFILE"
     echo ""
-    echo "You can now run celestia-appd from anywhere." | tee -a "$LOGFILE"
+    echo "You can now run celestia from anywhere." | tee -a "$LOGFILE"
     echo ""
     echo "To check its version and see the menu, execute the following command:" | tee -a "$LOGFILE"
     echo ""
-    echo "celestia-appd version && celestia-appd --help" | tee -a "$LOGFILE"
+    echo "celestia version && celestia --help" | tee -a "$LOGFILE"
 else
     echo ""
-    echo "You can navigate to $TEMP_DIR to find and run celestia-appd." | tee -a "$LOGFILE"
+    echo "You can navigate to $TEMP_DIR to find and run celestia." | tee -a "$LOGFILE"
     echo ""
     echo "To check its version and see the menu, execute the following commands:" | tee -a "$LOGFILE"
     echo ""
     echo "cd $TEMP_DIR" | tee -a "$LOGFILE"
-    echo "chmod +x celestia-appd" | tee -a "$LOGFILE"
-    echo "./celestia-appd version && ./celestia-appd --help" | tee -a "$LOGFILE"
+    echo "chmod +x celestia" | tee -a "$LOGFILE"
+    echo "./celestia version && ./celestia --help" | tee -a "$LOGFILE"
 fi


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves #1481

Also modifies celestia-app.sh to name the directories `celestia-app-temp` and `celestia-node-temp`, respectively.

Provides a simple way to install a celestia-node:

![image](https://github.com/celestiaorg/docs/assets/46639943/bfd400e1-068b-449d-a513-499ccfbd46e3)

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated installation paths for the `celestia-appd` binary, log files, and temporary directories.
	- Added automated download and installation script for Celestia Node binary with detailed instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->