### PR TITLE
feat: redirect for rollup-overview

### DIFF
--- a/developers/rollup-overview.md
+++ b/developers/rollup-overview.md
@@ -1,0 +1,12 @@
+# Rollup overview
+
+<!-- markdownlint-disable MD033 -->
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; URL=build-whatever">
+</head>
+<body>
+    <p>This page has moved. If you are not redirected, <a href="build-whatever">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR adds a redirect for `developers/rollup-overview` that forwards visitors to `developers/build-whatever`. `rollup-overview` was removed in #1515 in a restructuring.

Potential blocker for this PR: the page `rollup-overview` will still be indexed. Unfortunately, there is no good way to handle redirects in Vitepress out-of-the-box.

[Try the redirect on the PR preview link
](https://celestiaorg.github.io/docs-preview/pr-1542/developers/rollup-overview)
[See a demo walkthrough on Loom](https://www.loom.com/share/6c3eee9758dd4139b9fd93ed8d82243f?sid=97d94690-88c2-4870-9f5a-cde866db7f43)

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Introduced a new `rollup-overview.md` file to guide users with redirection instructions when accessed directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->