### PR TITLE
cleanup: consistent formatting of mainnet node hosts

### DIFF
--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -123,8 +123,8 @@ to participate in Mainnet Beta:
 - `rpc-archive.celestia.bitszn.com`
 - `celestia-rpc.f5nodes.com`
 - `celestia-rpc.chainode.tech:33373`
-- `https://rpc-celestia.staker.space/`
-- `https://celestia-rpc.noders.services/`
+- `rpc-celestia.staker.space`
+- `celestia-rpc.noders.services`
 
 #### API endpoints
 
@@ -148,9 +148,9 @@ to participate in Mainnet Beta:
 - `celestia.rest.archives.validao.xyz`
 - `api-archive.celestia.bitszn.com`
 - `celestia-api.f5nodes.com`
-- `https://celestia-api.chainode.tech`
-- `https://api-celestia.staker.space/`
-- `https://celestia-api.noders.services/`
+- `celestia-api.chainode.tech`
+- `api-celestia.staker.space`
+- `celestia-api.noders.services`
 
 #### gRPC endpoints
 
@@ -174,7 +174,7 @@ to participate in Mainnet Beta:
 - `gprc-archive.celestia.bitszn.com`
 - `celestia-grpc.f5nodes.com:9390`
 - `celestia-grpc.chainode.tech:443`
-- `https://grpc-celestia.staker.space/`
+- `grpc-celestia.staker.space`
 - `celestia-grpc.noders.services:11090`
 
 #### WebSocket endpoints


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

I noticed some inconsistency in how nodes were listed. some with a trailing slash, some with the scheme. I've unified these for the `nodes/mainnet.md` list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated URLs for Mainnet Beta participation endpoints, including RPC, API, gRPC, and WebSocket, by removing `https://` prefixes and adjusting domain names for improved accessibility and compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->