### PR TITLE
developers: clarify why grpc endpoint needed for light node

### DIFF
--- a/developers/node-tutorial.md
+++ b/developers/node-tutorial.md
@@ -305,9 +305,9 @@ your keys will be stored.
 ### Connect to a public core endpoint
 
 Let's now run the Celestia Light node with a gRPC connection
-to an example public core endpoint. Connecting to a public core endpoint 
-provides the light node with access to state queries (reading balances, submitting 
-transactions, and other state-related queries). 
+to an example public core endpoint. Connecting to a public core endpoint
+provides the light node with access to state queries (reading balances, submitting
+transactions, and other state-related queries).
 
 Note: You are also encouraged to find a community-run API endpoint
 and there are several in the Discord. This one is used for demonstration

--- a/developers/node-tutorial.md
+++ b/developers/node-tutorial.md
@@ -305,7 +305,9 @@ your keys will be stored.
 ### Connect to a public core endpoint
 
 Let's now run the Celestia Light node with a gRPC connection
-to an example public core endpoint.
+to an example public core endpoint. Connecting to a public core endpoint 
+provides the light node with access to state queries (reading balances, submitting 
+transactions, and other state-related queries). 
 
 Note: You are also encouraged to find a community-run API endpoint
 and there are several in the Discord. This one is used for demonstration

--- a/developers/node-tutorial.md
+++ b/developers/node-tutorial.md
@@ -302,10 +302,10 @@ Instantiating (or initializing) the node means setting up
 a node store on your machine. This is where the data and
 your keys will be stored.
 
-### Connect to a public core endpoint
+### Connect to a core endpoint
 
 Let's now run the Celestia Light node with a gRPC connection
-to an example public core endpoint. Connecting to a public core endpoint
+to an example core endpoint. Connecting to a core endpoint
 provides the light node with access to state queries (reading balances, submitting
 transactions, and other state-related queries).
 

--- a/developers/prompt-scavenger.md
+++ b/developers/prompt-scavenger.md
@@ -85,6 +85,10 @@ Next, we will start our node:
 celestia light start --core.ip $CORE_IP --p2p.network $NETWORK --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --keyring.accname $KEYNAME
 ```
 
+Connecting to a public core endpoint with `--core.ip string`
+provides the light node with access to state queries (reading balances, submitting
+transactions, and other state-related queries).
+
 :::tip
 The `--core.ip` gRPC port defaults to 9090,
 so if you do not specify it in the command

--- a/developers/prompt-scavenger.md
+++ b/developers/prompt-scavenger.md
@@ -85,7 +85,7 @@ Next, we will start our node:
 celestia light start --core.ip $CORE_IP --p2p.network $NETWORK --gateway.deprecated-endpoints --gateway --gateway.addr 127.0.0.1 --gateway.port 26659 --keyring.accname $KEYNAME
 ```
 
-Connecting to a public core endpoint with `--core.ip string`
+Connecting to a core endpoint with `--core.ip string`
 provides the light node with access to state queries (reading balances, submitting
 transactions, and other state-related queries).
 

--- a/nodes/bridge-node.md
+++ b/nodes/bridge-node.md
@@ -92,7 +92,7 @@ Using an RPC of your own, or one from the
 [list on the Arabica devnet page](./arabica-devnet.md#rpc-endpoints),
 start your node.
 
-Connecting to a public core endpoint with `--core.ip string`
+Connecting to a core endpoint with `--core.ip string`
 provides the light node with access to state queries (reading balances, submitting
 transactions, and other state-related queries).
 

--- a/nodes/bridge-node.md
+++ b/nodes/bridge-node.md
@@ -92,6 +92,10 @@ Using an RPC of your own, or one from the
 [list on the Arabica devnet page](./arabica-devnet.md#rpc-endpoints),
 start your node.
 
+Connecting to a public core endpoint with `--core.ip string`
+provides the light node with access to state queries (reading balances, submitting
+transactions, and other state-related queries).
+
 Here is an example of initializing the bridge node:
 
 ::: code-group

--- a/nodes/docker-images.md
+++ b/nodes/docker-images.md
@@ -116,7 +116,7 @@ Congratulations! You now have a celestia-node running!
 
 If you would like to run the node with custom flags,
 you can refer to the
-[celestia-node tutorial](../developers/node-tutorial.md#connect-to-a-public-core-endpoint) page. Refer to
+[celestia-node tutorial](../developers/node-tutorial.md#connect-to-a-core-endpoint) page. Refer to
 [the ports section of the celestia-node troubleshooting page](./celestia-node-troubleshooting.md#ports)
 for information on which ports are required to be open on your machine.
 

--- a/nodes/full-storage-node.md
+++ b/nodes/full-storage-node.md
@@ -85,7 +85,7 @@ Using an RPC of your own, or one from the
 [list on the Arabica devnet page](./arabica-devnet.md#rpc-endpoints),
 start your node.
 
-Connecting to a public core endpoint with `--core.ip string`
+Connecting to a core endpoint with `--core.ip string`
 provides the light node with access to state queries (reading balances, submitting
 transactions, and other state-related queries).
 

--- a/nodes/full-storage-node.md
+++ b/nodes/full-storage-node.md
@@ -85,6 +85,10 @@ Using an RPC of your own, or one from the
 [list on the Arabica devnet page](./arabica-devnet.md#rpc-endpoints),
 start your node.
 
+Connecting to a public core endpoint with `--core.ip string`
+provides the light node with access to state queries (reading balances, submitting
+transactions, and other state-related queries).
+
 You can create your key for your node by following
 [the `cel-key` instructions](../../developers/celestia-node-key)
 

--- a/nodes/light-node.md
+++ b/nodes/light-node.md
@@ -98,7 +98,7 @@ Using an RPC of your own, or one from the
 [list on the Arabica devnet page](arabica-devnet.md#rpc-endpoints),
 start your node.
 
-Connecting to a public core endpoint with `--core.ip string`
+Connecting to a core endpoint with `--core.ip string`
 provides the light node with access to state queries (reading balances, submitting
 transactions, and other state-related queries).
 

--- a/nodes/light-node.md
+++ b/nodes/light-node.md
@@ -98,6 +98,10 @@ Using an RPC of your own, or one from the
 [list on the Arabica devnet page](arabica-devnet.md#rpc-endpoints),
 start your node.
 
+Connecting to a public core endpoint with `--core.ip string`
+provides the light node with access to state queries (reading balances, submitting
+transactions, and other state-related queries).
+
 For example, your command might look something like this for Mocha:
 
 ```sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **Documentation**
	- Enhanced the tutorial on connecting to a public core endpoint for the Celestia Light node, emphasizing access to state queries, transactions, and other state-related queries.
	- Added information about connecting to a public core endpoint using `--core.ip string` in various node tutorials to provide access to state queries and transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->