### PR TITLE
celestia-node v0.14.0: RPC port no longer necessary for nodes to query state

### DIFF
--- a/nodes/arabica-devnet.md
+++ b/nodes/arabica-devnet.md
@@ -80,19 +80,18 @@ You can [find the status of these endpoints](https://celestia-tools.brightlystak
 
 ### Using consensus endpoints with DA nodes
 
-Consensus RPC endpoints are used to provide DA nodes with state access for
+A consensus gRPC endpoint is used to provide DA nodes with state access for
 querying the chain’s state and broadcasting transactions (balances, blobs,
 etc.) to the Celestia network.
 
 Developers will need to provide a
 `–core.ip string` from a consensus node’s URI or an IP that populates
-2 ports for 2 types (RPC and gRPC, at ports 26657 and 9090, respectively)
-to their respective DA node.
+a port for gRPC at 9090 to their respective DA node.
 
 :::tip EXAMPLE
 
 ```bash
-celestia <da_type> start –core.ip <url> –core.rpc.port <port> \
+celestia <da_type> start –core.ip <url> \
     –core.grpc.port <port> \
 ```
 

--- a/nodes/arabica-devnet.md
+++ b/nodes/arabica-devnet.md
@@ -80,19 +80,25 @@ You can [find the status of these endpoints](https://celestia-tools.brightlystak
 
 ### Using consensus endpoints with DA nodes
 
-A consensus gRPC endpoint is used to provide DA nodes with state access for
-querying the chain’s state and broadcasting transactions (balances, blobs,
-etc.) to the Celestia network.
+#### Data availability (DA) RPC endpoints for bridge node sync
 
-Developers will need to provide a
-`–core.ip string` from a consensus node’s URI or an IP that populates
-a port for gRPC at 9090 to their respective DA node.
+These RPC endpoints allow bridge nodes to sync blocks from the Celestia network.
+For users, they will need to provide a `–core.ip string`
+from a consensus node’s URL or IP that populates a default RPC port at 26657
+to their respective DA node.
+
+#### Data availability (DA) gRPC endpoints for state access
+
+These gRPC endpoints for DA nodes provide state access for querying the
+chain’s state and broadcasting transactions (balances, blobs, etc.) to the
+Celestia network. For users, they will need to provide a `–core.ip string`
+from a consensus node’s URL or IP that populates a default gRPC port at 9090
+to their respective DA node.
 
 :::tip EXAMPLE
 
 ```bash
-celestia <da_type> start –core.ip <url> \
-    –core.grpc.port <port> \
+celestia <da_type> start –core.ip <url> -–core.grpc.port <port>
 ```
 
 :::

--- a/nodes/docker-images.md
+++ b/nodes/docker-images.md
@@ -79,7 +79,7 @@ Ubuntu. You can
 
    :::
 
-3. Set an RPC endpoint for either [Mainnet Beta](./mainnet.md#da-rpc-endpoints),
+3. Set an RPC endpoint for either [Mainnet Beta](./mainnet.md#data-availability-da-grpc-endpoints-for-state-access),
    [Mocha](./mocha-testnet.md#rpc-endpoints), or
    [Arabica](./arabica-devnet.md#rpc-endpoints)
    using the bare URL (without http or https):

--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -187,19 +187,23 @@ to participate in Mainnet Beta:
 - [Bridge node](./bridge-node.md)
 - [Full storage node](./full-storage-node.md)
 
-#### Data availability (DA) RPC endpoints
+#### Data availability (DA) RPC endpoints for Bridge Node sync
+These RPC endpoints allow Bridge nodes to sync blocks from the Celestia network.
+For users, they will need to provide a `–core.ip string`
+from a consensus node’s URL or IP that populates a default RPC port at 26657
+to their respective DA node.
 
-These RPC endpoints for DA nodes are to provide state access for querying the
+#### Data availability (DA) gRPC endpoints for state access
+These gRPC endpoints for DA nodes provide state access for querying the
 chain’s state and broadcasting transactions (balances, blobs, etc.) to the
 Celestia network. For users, they will need to provide a `–core.ip string`
-from a consensus node’s URL or IP that populates 2 ports for 2 types
-(RPC and gRPC, at ports 26657 and 9090, respectively) to their respective DA
-node.
+from a consensus node’s URL or IP that populates a default gRPC port at 9090
+to their respective DA node.
 
 :::tip
 
 ```bash
-celestia <da_type> start --core.ip <url> –core.rpc.port <port> \
+celestia <da_type> start --core.ip <url> \
     –core.grpc.port <port>
 ```
 

--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -187,13 +187,15 @@ to participate in Mainnet Beta:
 - [Bridge node](./bridge-node.md)
 - [Full storage node](./full-storage-node.md)
 
-#### Data availability (DA) RPC endpoints for Bridge Node sync
-These RPC endpoints allow Bridge nodes to sync blocks from the Celestia network.
+#### Data availability (DA) RPC endpoints for bridge node sync
+
+These RPC endpoints allow bridge nodes to sync blocks from the Celestia network.
 For users, they will need to provide a `–core.ip string`
 from a consensus node’s URL or IP that populates a default RPC port at 26657
 to their respective DA node.
 
 #### Data availability (DA) gRPC endpoints for state access
+
 These gRPC endpoints for DA nodes provide state access for querying the
 chain’s state and broadcasting transactions (balances, blobs, etc.) to the
 Celestia network. For users, they will need to provide a `–core.ip string`
@@ -203,8 +205,7 @@ to their respective DA node.
 :::tip
 
 ```bash
-celestia <da_type> start --core.ip <url> \
-    –core.grpc.port <port>
+celestia <da_type> start --core.ip <url> -–core.grpc.port <port>
 ```
 
 :::

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -54,12 +54,20 @@ import MochaTestnetDetails from '../.vitepress/components/MochaTestnetDetails.vu
 
 ## RPC for DA bridge, full, and light nodes
 
-These RPC endpoints for DA nodes are to provide state access for querying the
+### Data availability (DA) RPC endpoints for bridge node sync
+
+These RPC endpoints allow bridge nodes to sync blocks from the Celestia network.
+For users, they will need to provide a `–core.ip string`
+from a consensus node’s URL or IP that populates a default RPC port at 26657
+to their respective DA node.
+
+### Data availability (DA) gRPC endpoints for state access
+
+These gRPC endpoints for DA nodes provide state access for querying the
 chain’s state and broadcasting transactions (balances, blobs, etc.) to the
 Celestia network. For users, they will need to provide a `–core.ip string`
-from a consensus node’s URL or IP that populates 2 ports for 2 types
-(RPC and gRPC, at ports 26657 and 9090, respectively) to their respective DA
-node.
+from a consensus node’s URL or IP that populates a default gRPC port at 9090
+to their respective DA node.
 
 :::tip Bridge nodes
 Mentioned below RPC endpoints do not guarantee you the download of full blocks from


### PR DESCRIPTION
I tried to add all information I could here, but @jcstein maybe you can also help to make sure I've addressed all areas where rpc port is mentioned for state queries for DA nodes

What's important to note is that

LNs and FNs no longer need a `--core.rpc.port` **period** but BNs still need it for block syncing.

This feature will only be included in v0.14.0 of celestia-node!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated terminology from "Consensus RPC endpoints" to "consensus gRPC endpoint."
	- Simplified port configuration for Data Availability (DA) nodes, now requiring only one port for gRPC communication.
- **Documentation**
	- Updated descriptions and configurations related to DA RPC and gRPC endpoints for Bridge Node sync and state access.
	- Added information about Bridge nodes syncing blocks from the Celestia network.
- **Refactor**
	- Consolidated port configurations for easier setup and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->