### PR TITLE
docs: Add cohort information

### DIFF
--- a/community/foundation-delegation-program.md
+++ b/community/foundation-delegation-program.md
@@ -168,7 +168,7 @@ their respective delegations.
 
 * [Cohort 1](https://docs.google.com/spreadsheets/d/1Fxu9uYJ4wxfHChEiSg5bmXAMU8IZSq7J3GYDCFgk1HA/edit#gid=0): 50 Validator Seats
 * Cohort 2: 15 Validator Seats (Applications open June 1, 2024)
-* Cohort 3: 15 Validator Seats (Applications open Oct 1, 2024)
+* Cohort 3: 15 Validator Seats (Applications open October 1, 2024)
 * Cohort 4: 20 Validator Seats (Applications open February 1, 2025)
 
 ## Feedback process

--- a/community/foundation-delegation-program.md
+++ b/community/foundation-delegation-program.md
@@ -166,12 +166,12 @@ in the active validator set.
 The Foundation will report each cohort’s composition and the duration of
 their respective delegations.
 
-* [Cohort 1](https://docs.google.com/spreadsheets/d/1Fxu9uYJ4wxfHChEiSg5bmXAMU8IZSq7J3GYDCFgk1HA/edit#gid=0) 50 Validator Seats
+* [Cohort 1](https://docs.google.com/spreadsheets/d/1Fxu9uYJ4wxfHChEiSg5bmXAMU8IZSq7J3GYDCFgk1HA/edit#gid=0): 50 Validator Seats
 * Cohort 2: 15 Validator Seats (Applications open June 1, 2024)
 * Cohort 3: 15 Validator Seats (Applications open Oct 1, 2024)
 * Cohort 4: 20 Validator Seats (Applications open February 1, 2025)
 
 ## Feedback process
 
-Validators in the program will receive a feedback form every quarter so
+Validators in the program will receive a feedback form every quarter, so
 the program can be continually improved.

--- a/community/foundation-delegation-program.md
+++ b/community/foundation-delegation-program.md
@@ -166,6 +166,11 @@ in the active validator set.
 The Foundation will report each cohort’s composition and the duration of
 their respective delegations.
 
+* [Cohort 1](https://docs.google.com/spreadsheets/d/1Fxu9uYJ4wxfHChEiSg5bmXAMU8IZSq7J3GYDCFgk1HA/edit#gid=0) 50 Validator Seats
+* Cohort 2: 15 Validator Seats (Applications open June 1, 2024)
+* Cohort 3: 15 Validator Seats (Applications open Oct 1, 2024)
+* Cohort 4: 20 Validator Seats (Applications open February 1, 2025)
+
 ## Feedback process
 
 Validators in the program will receive a feedback form every quarter so


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Updated the Foundation Delegation Program with details about validator seat cohorts, including seat numbers and application opening dates for each cohort.
    - Cohort 1: 50 Validator Seats
    - Cohort 2: 15 Validator Seats (Applications open June 1, 2024)
    - Cohort 3: 15 Validator Seats (Applications open Oct 1, 2024)
    - Cohort 4: 20 Validator Seats (Applications open February 1, 2025)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->