### PR TITLE
docs: name the querying the proof's tuple root nonce section

### DIFF
--- a/developers/blobstream-proof-queries.md
+++ b/developers/blobstream-proof-queries.md
@@ -1097,7 +1097,6 @@ If the `dataRoot` or the `tupleRootNonce` is unknown during the verification:
 
 ### Querying the proof's `tupleRootNonce`
 
-
 <!-- markdownlint-disable MD013 -->
 
 <div style="overflow-y: auto; max-height: 400px;">

--- a/developers/blobstream-proof-queries.md
+++ b/developers/blobstream-proof-queries.md
@@ -1095,7 +1095,8 @@ If the `dataRoot` or the `tupleRootNonce` is unknown during the verification:
   contract and looking for the nonce attesting to the
   corresponding data. An example:
 
-#### Querying the proof's `tupleRootNonce`
+### Querying the proof's `tupleRootNonce`
+
 
 <!-- markdownlint-disable MD013 -->
 

--- a/developers/blobstream-proof-queries.md
+++ b/developers/blobstream-proof-queries.md
@@ -1095,6 +1095,8 @@ If the `dataRoot` or the `tupleRootNonce` is unknown during the verification:
   contract and looking for the nonce attesting to the
   corresponding data. An example:
 
+#### Querying the proof's `tupleRootNonce`
+
 <!-- markdownlint-disable MD013 -->
 
 <div style="overflow-y: auto; max-height: 400px;">


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Make it more clear that that section is for querying the proof's tuple root nonce. The community ask about it often meaning that it's not that apparent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Updated the developer documentation with a new section on querying the proof's `tupleRootNonce` in Blobstream proof queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->