### PR TITLE
feat: add section on maxblob size

### DIFF
--- a/developers/node-tutorial.md
+++ b/developers/node-tutorial.md
@@ -462,6 +462,10 @@ once your node store is set:
 celestia blob submit 0x42690c204d39600fddd3 'gm' --node.store $NODE_STORE
 ```
 
+:::tip
+[Learn more about maximum blob size](submit-data.md).
+:::
+
 Alternatively, you could use the `--token` flag to set your auth token:
 
 ```bash

--- a/developers/submit-data.md
+++ b/developers/submit-data.md
@@ -12,6 +12,16 @@ To submit data to Celestia, users submit blob transactions (`BlobTx`). Blob
 transactions contain two components, a standard Cosmos-SDK transaction called
 `MsgPayForBlobs` and one or more `Blob`s of data.
 
+## Maximum blob size
+
+The maximum total blob size in a transaction is just under **2 MiB
+(1,973,786 bytes)**, based on a 64x64 share grid (4096 shares).
+With one share for the PFB transaction, 4095 shares remain:
+1 at 478 bytes and 4094 at 482 bytes each.
+
+This is subject to change based on governance parameters.
+Learn more on [the Mainnet Beta page under "Maximum bytes"](../nodes/mainnet.md#maximum-bytes).
+
 ## Fee market and mempool
 
 Celestia makes use of a standard gas-priced prioritized mempool. By default,

--- a/developers/submit-data.md
+++ b/developers/submit-data.md
@@ -22,6 +22,12 @@ With one share for the PFB transaction, 4095 shares remain:
 This is subject to change based on governance parameters.
 Learn more on [the Mainnet Beta page under "Maximum bytes"](../nodes/mainnet.md#maximum-bytes).
 
+It is advisable to submit transactions where the total blob size is significantly
+smaller than 1.8 MiB (e.g. 500 KiB) in order for your transaction to get included
+in a block quickly. If a tx contains blobs approaching 1.8 MiB then there will
+be no room for any other transactions. This means that your transaction will
+only be included in a block if it has a higher gas price than every other
+transaction in the mempool.
 ## Fee market and mempool
 
 Celestia makes use of a standard gas-priced prioritized mempool. By default,

--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -82,6 +82,10 @@ blob size. It depends on several factors:
 These factors can cause the maximum total blob size that can be included in one
 block to vary.
 
+See the code in
+[celestia-app](https://github.com/celestiaorg/celestia-app/blob/2e49d665b3275e769dfe0371b1ca41e39dc3f5f5/pkg/appconsts/initial_consts.go#L14)
+and [celestia-node](https://github.com/celestiaorg/celestia-node/blob/540192259c144ccbd24e45e34616a41389232a51/blob/blob.go#L93).
+
 ## Integrations
 
 This guide contains the relevant sections for how to connect to Mainnet Beta,


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

[PREVIEW](https://celestiaorg.github.io/docs-preview/pr-1608/developers/submit-data#maximum-blob-size)
<img width="1424" alt="Screenshot 2024-06-14 at 3 51 26 PM" src="https://github.com/celestiaorg/docs/assets/46639943/4a7372f2-d818-4d81-bce8-d9a7f88ee097">

- [x] Adds a section on max blob size to mainnet beta page https://github.com/celestiaorg/docs/commit/4f4a3cf7aa5fe15f73878a28f6a21b2edd607383
- [x] a link to the long description from the short description https://github.com/celestiaorg/docs/commit/4f4a3cf7aa5fe15f73878a28f6a21b2edd607383
- [x] adds link on node-tutorial in callout to the new, shorter description https://github.com/celestiaorg/docs/pull/1608/commits/5f8768bc2c724fc6cf29cb4d65b5fd2730d0ad28
- [x] adds a link to code in the long description https://github.com/celestiaorg/docs/pull/1608/commits/5044134210a2e268407d514c0f6f60e4d05b6b45

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated guidelines on maximum blob size in a transaction.
  - Added a tip on maximum blob size in the Node tutorial.
  - Included references to code snippets for blob size calculations in the mainnet documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->