### PR TITLE
add endpoints for mocha, from CrypTech team

### DIFF
--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -84,6 +84,8 @@ full blocks from it.
 - `celestia-testnet-consensus.itrocket.net`
   - RPC port: 26657
   - gRPC port: 9090
+- `rpc-celestia-testnet.cryptech.com.ua`
+  - gRPC: grpc-celestia-testnet.cryptech.com.ua:443
 
 ## RPC endpoints
 
@@ -107,6 +109,7 @@ Celestia network. The default port is 26657.
 - `rpc-1.testnet.celestia.nodes.guru`
 - `rpc-2.testnet.celestia.nodes.guru`
 - `celestia-testnet-rpc.itrocket.net:443`
+- `rpc-celestia-testnet.cryptech.com.ua:443`
 
 ## API endpoints
 
@@ -131,6 +134,7 @@ The default port is 1317.
 - [https://api-1.testnet.celestia.nodes.guru](https://api-1.testnet.celestia.nodes.guru)
 - [https://api-2.testnet.celestia.nodes.guru](https://api-2.testnet.celestia.nodes.guru)
 - [https://celestia-testnet-api.itrocket.net](https://celestia-testnet-api.itrocket.net)
+- [https://api-celestia-testnet.cryptech.com.ua](https://api-celestia-testnet.cryptech.com.ua)
 
 ## gRPC endpoints
 
@@ -158,6 +162,7 @@ broadcast transactions.
 - `grpc-1.testnet.celestia.nodes.guru:10790`
 - `grpc-2.testnet.celestia.nodes.guru:10790`
 - `celestia-testnet-grpc.itrocket.net:443`
+- `grpc-celestia-testnet.cryptech.com.ua:443`
 
 ## Bridge and full node endpoints
 
@@ -216,6 +221,7 @@ There are several explorers you can use for Mocha:
 - [https://stakeflow.io/celestia-testnet](https://stakeflow.io/celestia-testnet)
 - [https://testnet.celestia.explorers.guru](https://testnet.celestia.explorers.guru)
 - [https://testnet.itrocket.net/celestia](https://testnet.itrocket.net/celestia)
+- [https://explorers.cryptech.com.ua/Celestia-Testnet](https://explorers.cryptech.com.ua/Celestia-Testnet)
 
 ## Network upgrades
 


### PR DESCRIPTION
- New Features
   - Introduced new endpoints for Celestia testnet, including consensus, RPC, API, and gRPC services based on Archive FullNode without Pruning.
   - Added a backup explorer endpoint for easier access to testnet data.
