### PR TITLE
fix: setting node doc links to use mainnetVersions

### DIFF
--- a/developers/blobstream-offchain.md
+++ b/developers/blobstream-offchain.md
@@ -2,6 +2,10 @@
 description: Learn how to integrate your L2's offchain logic with Blobstream
 ---
 
+<script setup>
+import mainnetVersions from '/.vitepress/constants/mainnet_versions.js'
+</script>
+
 # Integrate with Blobstream client
 
 ## Blobstream demo rollup
@@ -104,7 +108,7 @@ connecting to a Celestia light node,
 which can detect faults in consensus such as hidden data. For the connection
 to Ethereum, this would likely mean running and connecting to a full node.
 More information on the RPC that is exposed by a Celestia light node can be found
-[in the RPC documentation](https://node-rpc-docs.celestia.org/?version=v0.11.0).
+[in the RPC documentation](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}).
 Additionally, if you need more information on how to run a light node, you can
 [check out the documentation](../nodes/light-node.md).
 
@@ -328,7 +332,7 @@ contracts.
 #### Submitting block data to Celestia via light node
 
 As linked above, use the
-[Celestia light node RPC](https://node-rpc-docs.celestia.org/?version=v0.11.0#blob.Submit)
+[Celestia light node RPC](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#blob.Submit)
 to submit the data to Celestia.
 
 #### Posting headers to Ethereum

--- a/developers/golang-client-tutorial.md
+++ b/developers/golang-client-tutorial.md
@@ -1,3 +1,7 @@
+<script setup>
+import mainnetVersions from '/.vitepress/constants/mainnet_versions.js'
+</script>
+
 # Golang client library tutorial {#golang-client-library}
 
 This section tutorial will guide you through using the most common RPC endpoints with the golang client library.
@@ -20,13 +24,13 @@ The default URL is `http://localhost:26658`. If you would like to use subscripti
 
 ## Submitting and retrieving blobs
 
-The [blob.Submit](https://node-rpc-docs.celestia.org/?version=v0.11.0#blob.Submit) method takes a slice of blobs and a gas price, returning the height the blob was successfully posted at.
+The [blob.Submit](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#blob.Submit) method takes a slice of blobs and a gas price, returning the height the blob was successfully posted at.
 
 - The namespace can be generated with `share.NewBlobNamespaceV0`.
 - The blobs can be generated with `blob.NewBlobV0`.
 - You can set `blob.DefaultGasPrice()` as the gas price to have celestia-node automatically determine an appropriate gas price.
 
-The [blob.GetAll](https://node-rpc-docs.celestia.org/?version=v0.11.0#blob.GetAll) method takes a height and slice of namespaces, returning the slice of blobs found in the given namespaces.
+The [blob.GetAll](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#blob.GetAll) method takes a height and slice of namespaces, returning the slice of blobs found in the given namespaces.
 
 ```go
 import (
@@ -83,7 +87,7 @@ func SubmitBlob(ctx context.Context, url string, token string) error {
 Yet another thing: There is a argument rn that GetAll should return an error if no blobs are found. I do not agree with this argument, as it is not intuitive to the user, as seen in this example. I will try to resolve this before this PR is merged.
 --->
 
-You can subscribe to new headers using the [header.Subscribe](https://node-rpc-docs.celestia.org/?version=v0.11.0#header.Subscribe) method. This method returns a channel that will receive new headers as they are produced. In this example, we will fetch all blobs at the height of the new header in the `0xDEADBEEF` namespace.
+You can subscribe to new headers using the [header.Subscribe](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#header.Subscribe) method. This method returns a channel that will receive new headers as they are produced. In this example, we will fetch all blobs at the height of the new header in the `0xDEADBEEF` namespace.
 
 ```go
 // SubscribeHeaders subscribes to new headers and fetches all blobs at the height of the new header in the 0xDEADBEEF namespace.
@@ -124,7 +128,7 @@ func SubscribeHeaders(ctx context.Context, url string, token string) error {
 
 ## Fetching an Extended Data Square (EDS)
 
-You can fetch an [Extended Data Square (EDS)](https://celestiaorg.github.io/celestia-app/specs/data_structures.html#erasure-coding) using the [share.GetEDS](https://node-rpc-docs.celestia.org/?version=v0.11.0#share.GetEDS) method. This method takes a header and returns the EDS at the given height.
+You can fetch an [Extended Data Square (EDS)](https://celestiaorg.github.io/celestia-app/specs/data_structures.html#erasure-coding) using the [share.GetEDS](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#share.GetEDS) method. This method takes a header and returns the EDS at the given height.
 
 ```go
 // GetEDS fetches the EDS at the given height.
@@ -147,4 +151,4 @@ func GetEDS(ctx context.Context, url string, token string, height uint64) (*rsmt
 
 ## API documentation
 
-To see the full list of available methods, see the [API documentation](https://node-rpc-docs.celestia.org/?version=v0.11.0).
+To see the full list of available methods, see the [API documentation](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}).

--- a/developers/node-tutorial.md
+++ b/developers/node-tutorial.md
@@ -424,7 +424,7 @@ With your wallet funded, you can move on to the next step.
 ## RPC CLI guide
 
 This section of the tutorial will teach you how to interact with a Celestia node's
-[remote procedure call (RPC) API](https://node-rpc-docs.celestia.org/?version=v0.11.0)
+[remote procedure call (RPC) API](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}})
 using the command line interface (CLI).
 
 You will need to
@@ -443,14 +443,14 @@ Where:
 
 - `celestia` is the main command to interact with the node.
 - `<module>` is the specific module in the node you want to interact with, such as
-  [`blob`](https://node-rpc-docs.celestia.org/?version=v0.11.0#blob),
-  [`state`](https://node-rpc-docs.celestia.org/?version=v0.11.0#state),
-  [`p2p`](https://node-rpc-docs.celestia.org/?version=v0.11.0#p2p), etc.
+  [`blob`](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#blob),
+  [`state`](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#state),
+  [`p2p`](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#p2p), etc.
 - `<method>` is the specific method within the module that performs
   the action you want, such as
-  [`blob.Submit`](https://node-rpc-docs.celestia.org/?version=v0.11.0#blob.Submit),
-  [`state.AccountAddress`](https://node-rpc-docs.celestia.org/?version=v0.11.0#state.AccountAddress),
-  [`p2p.Info`](https://node-rpc-docs.celestia.org/?version=v0.11.0#node.Info), etc.
+  [`blob.Submit`](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#blob.Submit),
+  [`state.AccountAddress`](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#state.AccountAddress),
+  [`p2p.Info`](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#node.Info), etc.
 - `[args...]` represents any additional arguments that the method might require.
 - `[flags...]` are parameters that modify the behavior of the command.
   They start with `--` (e.g., `--node.store`, `--token`, or `--url`).
@@ -578,7 +578,7 @@ export AUTH_TOKEN=$(celestia light auth admin --p2p.network private \
 ### Submitting data
 
 In this example, we will be submitting a blob to the network with a
-[blob.Submit](https://node-rpc-docs.celestia.org/?version=v0.11.0#blob.Submit)
+[blob.Submit](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#blob.Submit)
 transaction with our light node.
 
 Some things to consider:

--- a/developers/rust-client-tutorial.md
+++ b/developers/rust-client-tutorial.md
@@ -4,6 +4,10 @@ next:
   link: "/developers/prompt-scavenger"
 ---
 
+<script setup>
+import mainnetVersions from '/.vitepress/constants/mainnet_versions.js'
+</script>
+
 # Rust client library tutorial {#rust-client-library}
 
 This section tutorial will guide you through using the most common RPC endpoints with [Lumina](https://github.com/eigerco/lumina/tree/main/rpc)'s rust client library.
@@ -26,13 +30,13 @@ The default URL is `http://localhost:26658`. If you would like to use subscripti
 
 ## Submitting and retrieving blobs
 
-The [blob.Submit](https://node-rpc-docs.celestia.org/?version=v0.11.0#blob.Submit) method takes an array of blobs and a gas price, returning the height the blob was successfully posted at.
+The [blob.Submit](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#blob.Submit) method takes an array of blobs and a gas price, returning the height the blob was successfully posted at.
 
 - The namespace can be generated with `Namespace::new_v0`.
 - The blobs can be generated with `Blob::new`.
 - You can set `GasPrice::default()` as the gas price to have celestia-node automatically determine an appropriate gas price.
 
-The [blob.GetAll](https://node-rpc-docs.celestia.org/?version=v0.11.0#blob.GetAll) method takes a height and array of namespaces, returning the array of blobs found in the given namespaces.
+The [blob.GetAll](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#blob.GetAll) method takes a height and array of namespaces, returning the array of blobs found in the given namespaces.
 
 ```rust
 use celestia_rpc::{BlobClient, Client, HeaderClient, ShareClient};
@@ -72,7 +76,7 @@ async fn submit_blob(url: &str, token: &str) {
 
 ## Subscribing to new headers
 
-You can subscribe to new headers using the [header.Subscribe](https://node-rpc-docs.celestia.org/?version=v0.11.0#header.Subscribe) method. This method returns a `Subscription` that will receive new headers as they are produced. In this example, we will fetch all blobs at the height of the new header in the `0xDEADBEEF` namespace.
+You can subscribe to new headers using the [header.Subscribe](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#header.Subscribe) method. This method returns a `Subscription` that will receive new headers as they are produced. In this example, we will fetch all blobs at the height of the new header in the `0xDEADBEEF` namespace.
 
 ```rust
 async fn subscribe_headers(url: &str, token: &str) {
@@ -119,7 +123,7 @@ async fn subscribe_headers(url: &str, token: &str) {
 
 ## Fetching an Extended Data Square (EDS)
 
-You can fetch an [Extended Data Square (EDS)](https://celestiaorg.github.io/celestia-app/specs/data_structures.html#erasure-coding) using the [share.GetEDS](https://node-rpc-docs.celestia.org/?version=v0.11.0#share.GetEDS) method. This method takes a header and returns the EDS at the given height.
+You can fetch an [Extended Data Square (EDS)](https://celestiaorg.github.io/celestia-app/specs/data_structures.html#erasure-coding) using the [share.GetEDS](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}#share.GetEDS) method. This method takes a header and returns the EDS at the given height.
 
 ```rust
 async fn get_eds(url: &str, token: &str) -> ExtendedDataSquare {
@@ -142,4 +146,4 @@ async fn get_eds(url: &str, token: &str) -> ExtendedDataSquare {
 
 ## API documentation
 
-To see the full list of available methods, see the [API documentation](https://node-rpc-docs.celestia.org/?version=v0.11.0).
+To see the full list of available methods, see the [API documentation](https://node-rpc-docs.celestia.org/?version={{mainnetVersions['node-latest-tag']}}).


### PR DESCRIPTION
Self-explanatory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated URLs in multiple developer guides to dynamically reference the latest version of the Celestia node documentation.
  - Improved accuracy and flexibility by ensuring API endpoint links always point to the latest version.
  - Ensured users access the most up-to-date documentation for methods like `blob.Submit`, `blob.GetAll`, `header.Subscribe`, and `share.GetEDS`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->