### PR TITLE
fix: links for succinct docs

### DIFF
--- a/developers/blobstream-x-deploy.md
+++ b/developers/blobstream-x-deploy.md
@@ -6,17 +6,17 @@ next:
 
 # New Blobstream X deployments
 
-If you want to deploy Blobstream X to a new chain, where a Gateway 
+If you want to deploy Blobstream X to a new chain, where a Gateway
 contract does not exist, you need to do the following.
 
 If Succinct Gateway already exists on this chain, you can skip
 this step.
-You can check the list of deployed `SuccinctGateway` contracts in this [list](https://docs.succinct.xyz/platform/onchain-integration#succinctgateway).
+You can check the list of deployed `SuccinctGateway` contracts in this [list](https://platform-docs.succinct.xyz/platform/onchain-integration#succinctgateway).
 
 ## Deploy a new `SuccinctGateway` contract
 
-To Deploy a new `SuccinctGateway` contract to the new chain, follow 
-the [succinct documentation](https://docs.succinct.xyz/platform/onchain-integration#gateway-deployment).
+To Deploy a new `SuccinctGateway` contract to the new chain, follow
+the [Succinct documentation](https://platform-docs.succinct.xyz/platform/onchain-integration#non-canonical-chain-contract-deployment).
 
 ## Deploy a `BlobstreamX` contract to the new chain
 

--- a/developers/blobstream.md
+++ b/developers/blobstream.md
@@ -17,7 +17,7 @@ developers to build high-throughput L2s using Celestia's optimised DA layer,
 the first with Data Availability Sampling (DAS). Any ecosystem can deploy a
 Blobstream light client onchain to allow L2s and L3s to access DA from Celestia.
 
-An implementation of Blobstream, by [Succinct](https://docs.succinct.xyz/), called
+An implementation of Blobstream, by [Succinct](https://platform-docs.succinct.xyz/), called
 [Blobstream X](https://github.com/succinctlabs/blobstreamx), is out
 and will be used in the upcoming deployments. This implementation proves the
 validity of Celestia block headers on a target EVM chain using zero-knowledge (ZK)
@@ -86,7 +86,7 @@ accessible all Celestia data roots (verifiable with a Merkle inclusion proof
 against the stored Merkle root) to rollups.
 
 Blobstream X is built and deployed with
-[Succinct's protocol](https://docs.succinct.xyz).
+[Succinct's protocol](https://platform-docs.succinct.xyz).
 
 ![blobstream x draft diagram](/img/blobstream/Celestia_Blobstream_X1b.png)
 
@@ -131,7 +131,7 @@ X contract is through the `SuccinctGateway` smart contract, which is a
 simple entrypoint contract that verifies proofs (against a deployed
 onchain verifier for the Blobstream X circuit) and then calls the
 `BlobstreamX.sol` contract to update it.
-[Find more information about the `SuccinctGateway`](https://docs.succinct.xyz/platform/onchain-integration#succinct-gateway).
+[Find more information about the `SuccinctGateway`](https://platform-docs.succinct.xyz/platform/onchain-integration#succinct-gateway).
 
 ![blobstream x overview diagram draft](/img/blobstream/Celestia_Blobstream_X2b.png)
 
@@ -140,7 +140,7 @@ onchain verifier for the Blobstream X circuit) and then calls the
 :::tip NOTE
 If the Blobstream X contract is not deployed on a desired chain,
 it needs to be deployed before it can be used by your rollup. See the
-[deployment documentation](https://docs.succinct.xyz/platform/onchain-integration#gateway-deployment)
+[deployment documentation](https://platform-docs.succinct.xyz/platform/onchain-integration#non-canonical-chain-contract-deployment)
 for more details.
 :::
 
@@ -182,13 +182,11 @@ Blobstream X is in beta and slashing is not enabled yet.
 | Blobstream X | Arbitrum Sepolia           | [`0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2`](https://sepolia.arbiscan.io/address/0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2#events)  | [Mocha testnet](../nodes/mocha-testnet.md) | [Deployment on Celenium](https://mocha-4.celenium.io/blobstream?network=arbitrum&page=1) |
 | Blobstream X | Base Sepolia           | [`0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2`](https://sepolia.basescan.org/address/0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2#events)  | [Mocha testnet](../nodes/mocha-testnet.md) | [Deployment on Celenium](https://mocha-4.celenium.io/blobstream?network=base&page=1) |
 
-<!-- markdownlint-enable MD013 -->
-
 ## Deploy Blobstream X
 
 If your target chain is [still not supported](#deployed-contracts), it is possible to deploy and maintain a Blobstream x instance and have the same security guarantees.
 
-First, you will need to create a multisig that governs the Blobstream X contract and also the function identifiers. The function identifiers can be registered in the [succinct gateway](https://docs.succinct.xyz/platform/onchain-integration#gateway-deployment).
+First, you will need to create a multisig that governs the Blobstream X contract and also the function identifiers. The function identifiers can be registered in the [Succinct gateway](https://platform-docs.succinct.xyz/platform/onchain-integration#register-circuits-with-your-deployed-succinct-gateway).
 
 Then, check the [deployment](https://github.com/succinctlabs/blobstreamx/blob/main/README.md#blobstreamx-contract-overview) documentation for how to deploy the contract.
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Updates links to platform-docs subdomain for succinct docs.
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated URLs and references for deploying `Blobstream X` and `SuccinctGateway` contracts.
  - Ensured consistency in naming conventions and corrected documentation links for better navigation and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->