### PR TITLE
add NODERS info 

### DIFF
--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -242,6 +242,9 @@ RPCs for DA nodes to initialise or start your celestia-node to Mainnet Beta with
 - `celestia-mainnet-consensus.itrocket.net`
   - gRPC: port 9090
   - RPC: port 26657
+- `celestia-consensus-mainnet.noders.services`
+  - gRPC: port 9080
+  - RPC: port 26557
 
 DA full and light nodes might have troubles connecting to the networks, so you
 can check out this

--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -291,6 +291,7 @@ The following websites provide analytics for Celestia:
 - [https://alphab.ai/s/m/celestia/](https://alphab.ai/s/m/celestia/)
 - [https://services.kjnodes.com/mainnet/celestia/slashboard](https://services.kjnodes.com/mainnet/celestia/slashboard)
 - [https://itrocket.net/services/mainnet/celestia/decentralization/](https://itrocket.net/services/mainnet/celestia/decentralization/)
+- [https://cosmoslist.co/mainnet/celestia](https://cosmoslist.co/mainnet/celestia)
 
 ## Network upgrades
 

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -86,6 +86,9 @@ full blocks from it.
   - gRPC port: 9090
 - `rpc-celestia-testnet.cryptech.com.ua`
   - gRPC: grpc-celestia-testnet.cryptech.com.ua:443
+- `celestia-consensus-testnet.noders.services`
+  - RPC port: 26357
+  - gRPC port: 9070
 
 ## RPC endpoints
 

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -213,6 +213,12 @@ Where `<CELESTIA-ADDRESS>` is a `celestia1******` generated address.
 Faucet has a limit of 10 tokens per week per address/Discord ID.
 :::
 
+## Analytics
+
+The following websites provide analytics for Celestia:
+
+- [https://cosmoslist.co/testnet/celestia](https://cosmoslist.co/testnet/celestia)
+
 ## Explorers
 
 There are several explorers you can use for Mocha:

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -215,7 +215,7 @@ Faucet has a limit of 10 tokens per week per address/Discord ID.
 
 ## Analytics
 
-The following websites provide analytics for Celestia:
+The following websites provide analytics for Mocha Testnet:
 
 - [https://cosmoslist.co/testnet/celestia](https://cosmoslist.co/testnet/celestia)
 


### PR DESCRIPTION
This PR includes the addition of Consensus node NODERS for Mainnet and Testnet as well as the celestia and mocha-4 network endpoints parser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced gRPC and RPC endpoints for Mainnet Beta and Mocha Testnet, improving connectivity for DA nodes.
  - Added new websites for Celestia analytics on both Mainnet Beta and Mocha Testnet, providing enhanced monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->