### PR TITLE
Add Openbitlab services

### DIFF
--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -127,6 +127,7 @@ to participate in Mainnet Beta:
 - `celestia-rpc.noders.services`
 - `celestia.moonli.me`
 - `celestia-mainnet-rpc.itrocket.net:443`
+- `celestia-rpc.openbitlab.com`
 
 #### API endpoints
 
@@ -155,6 +156,7 @@ to participate in Mainnet Beta:
 - `celestia-api.noders.services`
 - `celestia.moonli.me/api`
 - `celestia-mainnet-api.itrocket.net:443`
+- `celestia-api.openbitlab.com`
 
 #### gRPC endpoints
 
@@ -181,6 +183,7 @@ to participate in Mainnet Beta:
 - `grpc-celestia.staker.space`
 - `celestia-grpc.noders.services:11090`
 - `celestia-mainnet-grpc.itrocket.net:443`
+- `celestia-grpc.openbitlab.com:443`
 
 #### WebSocket endpoints
 

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -110,6 +110,7 @@ Celestia network. The default port is 26657.
 - `rpc-2.testnet.celestia.nodes.guru`
 - `celestia-testnet-rpc.itrocket.net:443`
 - `rpc-celestia-testnet.cryptech.com.ua:443`
+- `celestia-testnet-rpc.openbitlab.com`
 
 ## API endpoints
 
@@ -135,6 +136,7 @@ The default port is 1317.
 - [https://api-2.testnet.celestia.nodes.guru](https://api-2.testnet.celestia.nodes.guru)
 - [https://celestia-testnet-api.itrocket.net](https://celestia-testnet-api.itrocket.net)
 - [https://api-celestia-testnet.cryptech.com.ua](https://api-celestia-testnet.cryptech.com.ua)
+- [https://celestia-testnet-api.openbitlab.com](https://celestia-testnet-api.openbitlab.com)
 
 ## gRPC endpoints
 
@@ -163,6 +165,7 @@ broadcast transactions.
 - `grpc-2.testnet.celestia.nodes.guru:10790`
 - `celestia-testnet-grpc.itrocket.net:443`
 - `grpc-celestia-testnet.cryptech.com.ua:443`
+- `celestia-testnet-grpc.openbitlab.com:443`
 
 ## Bridge and full node endpoints
 


### PR DESCRIPTION
## Overview

Introduced new endpoints for Mainnet and Testnet, including RPC, API and  gRPC, enhancing network connectivity options for participants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new RPC, API, gRPC, and WebSocket endpoints for Mainnet Beta.
	- Introduced new RPC, API, and gRPC endpoints for Mocha Testnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->