### PR TITLE
docs: Lemongrass hardfork

### DIFF
--- a/nodes/full-consensus-node.md
+++ b/nodes/full-consensus-node.md
@@ -431,3 +431,12 @@ If you encounter an error like:
 ```
 
 then it is likely that the network has upgraded to a new app version but your consensus node was not prepared for the upgrade. To fix this, you'll need to update your binary to the latest version and restart your node with the relevant `--v2-upgrade-height` for the network you're running on. If your node still can't sync to the tip of the chain after the above steps, consider a `celestia-appd tendermint unsafe-reset-all` to reset your node and start syncing from the genesis block.
+
+### Lemongrass hardfork
+
+What is the Lemongrass hardfork and how can I be prepared for it?
+
+The Lemongrass hardfork is the first consensus layer breaking change since Celestia's genesis. The Lemongrass hardfork includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass hardfork will be executed on Arabica, then Mocha, then Mainnet Beta. The hardfork will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (follow Telegram and Discord) to give node operators time to download and start a compatible binary prior to the upgrade height.
+
+- If you are a full consensus node or validator operator: you will need to download and run a celestia-app v2.x.x binary prior to the `--v2-upgrade-height` to remain on the canonical chain.
+- If you are a DA node operator, you will need to download and run a compatible celestia-node binary (likely v0.16.0) prior to the upgrade height.

--- a/nodes/full-consensus-node.md
+++ b/nodes/full-consensus-node.md
@@ -289,7 +289,7 @@ If you are running celestia-app v1.x.x:
 celestia-appd start
 ```
 
-If you are running celestia-app >= v2.0.0: then you'll want to start the node with a `--v2-upgrade-height` that is dependent on the network.
+If you are running celestia-app >= v2.0.0: then you'll want to start the node with a `--v2-upgrade-height` that is dependent on the network. The `--v2-upgrade-height` flag is only needed during the v2 upgrade height so after your node has executed the upgrade (e.g. you see the log `upgraded from app version 1 to 2`), you don't need to provide this flag for future `celestia-appd start` invocations.
 
 ::: code-group
 

--- a/nodes/full-consensus-node.md
+++ b/nodes/full-consensus-node.md
@@ -431,12 +431,3 @@ If you encounter an error like:
 ```
 
 then it is likely that the network has upgraded to a new app version but your consensus node was not prepared for the upgrade. To fix this, you'll need to update your binary to the latest version and restart your node with the relevant `--v2-upgrade-height` for the network you're running on. If your node still can't sync to the tip of the chain after the above steps, consider a `celestia-appd tendermint unsafe-reset-all` to reset your node and start syncing from the genesis block.
-
-### Lemongrass hardfork
-
-What is the Lemongrass hardfork and how can I be prepared for it?
-
-The Lemongrass hardfork is the first consensus layer breaking change since Celestia's genesis. The Lemongrass hardfork includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass hardfork will be executed on Arabica, then Mocha, then Mainnet Beta. The hardfork will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (follow Telegram and Discord) to give node operators time to download and start a compatible binary prior to the upgrade height.
-
-- If you are a full consensus node or validator operator: you will need to download and run a celestia-app v2.x.x binary prior to the `--v2-upgrade-height` to remain on the canonical chain.
-- If you are a DA node operator, you will need to download and run a compatible celestia-node binary (likely v0.16.0) prior to the upgrade height.

--- a/nodes/full-consensus-node.md
+++ b/nodes/full-consensus-node.md
@@ -283,11 +283,29 @@ tar xf celestia-snap.tar -C ~/.celestia-app/data/
 
 ## Start the consensus node
 
-In order to start your full consensus node, run the following:
+If you are running celestia-app v1.x.x:
 
 ```sh
 celestia-appd start
 ```
+
+If you are running celestia-app >= v2.0.0: then you'll want to start the node with a `--v2-upgrade-height` that is dependent on the network.
+
+::: code-group
+
+```sh-vue [Mainnet Beta]
+celestia-appd start --v2-upgrade-height <height>
+```
+
+```sh-vue [Mocha]
+celestia-appd start --v2-upgrade-height <height>
+```
+
+```sh-vue [Arabica]
+celestia-appd start --v2-upgrade-height <height>
+```
+
+:::
 
 Optional: If you would like celestia-app to run as a background process, you can follow the [SystemD tutorial](./systemd.md).
 

--- a/nodes/hardfork-process.md
+++ b/nodes/hardfork-process.md
@@ -38,7 +38,7 @@ The two testnets where hardforks are deployed are:
 
 ### Lemongrass hardfork
 
-The Lemongrass hardfork is the first consensus layer breaking change since Celestia's Mainnet Beta genesis block. The Lemongrass hardfork includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass hardfork will be executed on Arabica, then Mocha, then Mainnet Beta. The hardfork will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (see [Network upgrades](./participate#network-upgrades) Telegram channel) to give node operators time to download and start a compatible binary prior to the upgrade height.
+The Lemongrass hardfork is the first consensus layer breaking change since Celestia's Mainnet Beta genesis block. The Lemongrass hardfork includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass hardfork will be executed on Arabica, then Mocha, then Mainnet Beta. The hardfork will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (see [Network upgrades](./participate#network-upgrades)) to give node operators time to download and start a compatible binary prior to the upgrade height.
 
 - If you are a full consensus node or validator operator: you will need to download and run a celestia-app v2.x.x binary prior to the `--v2-upgrade-height` to remain on the canonical chain.
 - If you are a DA node operator, you will need to download and run a compatible celestia-node binary (likely v0.16.0) prior to the upgrade height.

--- a/nodes/hardfork-process.md
+++ b/nodes/hardfork-process.md
@@ -38,7 +38,7 @@ The two testnets where hardforks are deployed are:
 
 ### Lemongrass hardfork
 
-The Lemongrass hardfork is the first consensus layer breaking change since Celestia's mainnet genesis block. The Lemongrass hardfork includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass hardfork will be executed on Arabica, then Mocha, then Mainnet Beta. The hardfork will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (follow Telegram and Discord) to give node operators time to download and start a compatible binary prior to the upgrade height.
+The Lemongrass hardfork is the first consensus layer breaking change since Celestia's Mainnet Beta genesis block. The Lemongrass hardfork includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass hardfork will be executed on Arabica, then Mocha, then Mainnet Beta. The hardfork will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (see [Network upgrades](./participate#network-upgrades) Telegram channel) to give node operators time to download and start a compatible binary prior to the upgrade height.
 
 - If you are a full consensus node or validator operator: you will need to download and run a celestia-app v2.x.x binary prior to the `--v2-upgrade-height` to remain on the canonical chain.
 - If you are a DA node operator, you will need to download and run a compatible celestia-node binary (likely v0.16.0) prior to the upgrade height.

--- a/nodes/hardfork-process.md
+++ b/nodes/hardfork-process.md
@@ -31,34 +31,14 @@ The general process can be broken down into several components:
 - Testing of the features (happens on testnets first prior to activating on
   mainnet in order to ensure the network can upgrade securely).
 
-The two testnets were hardforks are deployed on are:
+The two testnets where hardforks are deployed are:
 
 - [Arabica devnet](./arabica-devnet.md)
 - [Mocha testnet](./mocha-testnet.md)
 
-### Mocha hardfork
+### Lemongrass hardfork
 
-Celestia is planning the Mocha Hardfork upgrade on the Mamaki Testnet.
-This hardfork is unique as it will reset the Mamaki network to block 0
-while maintaining the existing state and also will rename Mamaki to Mocha.
+The Lemongrass hardfork is the first consensus layer breaking change since Celestia's mainnet genesis block. The Lemongrass hardfork includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass hardfork will be executed on Arabica, then Mocha, then Mainnet Beta. The hardfork will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (follow Telegram and Discord) to give node operators time to download and start a compatible binary prior to the upgrade height.
 
-The new chain-id will be `mocha`.
-
-You can find the
-[release logs for consensus nodes on the celestia-app releases page](https://github.com/celestiaorg/celestia-app/releases).
-
-The most exciting feature included is setting the stage for Blobstream on Mocha.
-
-Validators will need to generate 2 new keys in order to be Blobstream-ready.
-Note that for the Mocha Hardfork, Blobstream will not launch yet so you
-can swap those keys after for new ones if needed. The keys needed are:
-
-- 1 EVM key
-- 1 Celestia key
-
-So, in order for this to happen, validators will need to maintain two
-new keys in order to have a successful upgrade.
-
-Those two keys will need to be added to 2 new flags on `celestia-app`:
-
-- `--evm-address`: This flag should contain a `0x` EVM address.
+- If you are a full consensus node or validator operator: you will need to download and run a celestia-app v2.x.x binary prior to the `--v2-upgrade-height` to remain on the canonical chain.
+- If you are a DA node operator, you will need to download and run a compatible celestia-node binary (likely v0.16.0) prior to the upgrade height.

--- a/nodes/validator-node.md
+++ b/nodes/validator-node.md
@@ -142,12 +142,29 @@ You have successfully set up a bridge node that is syncing with the network.
 
 ## Run the validator node
 
-In order to start your validator node, run the following:
+If you are running celestia-app v1.x.x:
 
-```bash
+```sh
 celestia-appd start
 ```
 
+If you are running celestia-app >= v2.0.0: then you'll want to start the node with a `--v2-upgrade-height` that is dependent on the network.
+
+::: code-group
+
+```sh-vue [Mainnet Beta]
+celestia-appd start --v2-upgrade-height <height>
+```
+
+```sh-vue [Mocha]
+celestia-appd start --v2-upgrade-height <height>
+```
+
+```sh-vue [Arabica]
+celestia-appd start --v2-upgrade-height <height>
+```
+
+:::
 After completing all the necessary steps, you are now ready to run a validator!
 In order to create your validator onchain, follow the instructions below.
 Keep in mind that these steps are necessary ONLY if you want to participate

--- a/nodes/validator-node.md
+++ b/nodes/validator-node.md
@@ -254,3 +254,12 @@ If you encounter an error like:
 ```
 
 then it is likely that the network has upgraded to a new app version but your consensus node was not prepared for the upgrade. To fix this, you'll need to update your binary to the latest version and restart your node with the relevant `--v2-upgrade-height` for the network you're running on. If your node still can't sync to the tip of the chain after the above steps, consider a `celestia-appd tendermint unsafe-reset-all` to reset your node and start syncing from the genesis block.
+
+### Lemongrass hardfork
+
+What is the Lemongrass hardfork and how can I be prepared for it?
+
+The Lemongrass hardfork is the first consensus layer breaking change since Celestia's genesis. The Lemongrass hardfork includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass hardfork will be executed on Arabica, then Mocha, then Mainnet Beta. The hardfork will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (follow Telegram and Discord) to give node operators time to download and start a compatible binary prior to the upgrade height.
+
+- If you are a full consensus node or validator operator: you will need to download and run a celestia-app v2.x.x binary prior to the `--v2-upgrade-height` to remain on the canonical chain.
+- If you are a DA node operator, you will need to download and run a compatible celestia-node binary (likely v0.16.0) prior to the upgrade height.

--- a/nodes/validator-node.md
+++ b/nodes/validator-node.md
@@ -148,7 +148,7 @@ If you are running celestia-app v1.x.x:
 celestia-appd start
 ```
 
-If you are running celestia-app >= v2.0.0: then you'll want to start the node with a `--v2-upgrade-height` that is dependent on the network.
+If you are running celestia-app >= v2.0.0: then you'll want to start the node with a `--v2-upgrade-height` that is dependent on the network. The `--v2-upgrade-height` flag is only needed during the v2 upgrade height so after your node has executed the upgrade (e.g. you see the log `upgraded from app version 1 to 2`), you don't need to provide this flag for future `celestia-appd start` invocations.
 
 ::: code-group
 

--- a/nodes/validator-node.md
+++ b/nodes/validator-node.md
@@ -254,12 +254,3 @@ If you encounter an error like:
 ```
 
 then it is likely that the network has upgraded to a new app version but your consensus node was not prepared for the upgrade. To fix this, you'll need to update your binary to the latest version and restart your node with the relevant `--v2-upgrade-height` for the network you're running on. If your node still can't sync to the tip of the chain after the above steps, consider a `celestia-appd tendermint unsafe-reset-all` to reset your node and start syncing from the genesis block.
-
-### Lemongrass hardfork
-
-What is the Lemongrass hardfork and how can I be prepared for it?
-
-The Lemongrass hardfork is the first consensus layer breaking change since Celestia's genesis. The Lemongrass hardfork includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass hardfork will be executed on Arabica, then Mocha, then Mainnet Beta. The hardfork will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (follow Telegram and Discord) to give node operators time to download and start a compatible binary prior to the upgrade height.
-
-- If you are a full consensus node or validator operator: you will need to download and run a celestia-app v2.x.x binary prior to the `--v2-upgrade-height` to remain on the canonical chain.
-- If you are a DA node operator, you will need to download and run a compatible celestia-node binary (likely v0.16.0) prior to the upgrade height.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/docs/issues/1638

Note: we'll need to update the placeholder `<upgrade-height>`s when when we pick them for each network.

FYI: @cmwaters I moved content from the FAQ page on consensus-node / validator pages to the hardfork page you pointed out. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for starting a full consensus node with version-specific details and background process guidance.
  - Revised hardfork process document to include comprehensive details on the Lemongrass hardfork, replacing Mocha hardfork information.
  - Added version-specific commands for running validator nodes, enhancing clarity for different networks (Mainnet Beta, Mocha, Arabica).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->