### PR TITLE
docs: remove old part for cloning networks repo

### DIFF
--- a/nodes/full-consensus-node.md
+++ b/nodes/full-consensus-node.md
@@ -50,14 +50,6 @@ Follow the tutorial on [installing `celestia-app`](./celestia-app.md).
 
 ### Set up the P2P networks
 
-Now we will set up the P2P Networks by cloning the networks repository:
-
-```sh
-cd $HOME
-rm -rf networks
-git clone https://github.com/celestiaorg/networks.git
-```
-
 To initialize the network, pick a "node-name" that describes your
 node. Keep in mind that this might change if a new testnet is deployed.
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This is not necessary because the files are later queried directly:
https://github.com/celestiaorg/docs/blob/1470a358af74e9f223cbe609a8a638f2e3cb30af/nodes/full-consensus-node.md?plain=1#L132
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation for the full consensus node by removing outdated instructions for setting up P2P networks, streamlining the setup process for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->