### PR TITLE
docs: add trusted hash doc resolve #1460

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -449,6 +449,10 @@ function sidebarHome() {
                   link: "/nodes/celestia-node-custom-networks",
                 },
                 {
+                  text: "Syncing a light node from a trusted hash",
+                  link: "/nodes/celestia-node-trusted-hash",
+                },
+                {
                   text: "Troubleshooting",
                   link: "/nodes/celestia-node-troubleshooting",
                 },

--- a/nodes/celestia-node-trusted-hash.md
+++ b/nodes/celestia-node-trusted-hash.md
@@ -31,8 +31,8 @@ Celenium
 celestia light start --headers.trusted-hash <hash_of_block_n>
 ```
 
-## For rollup operators
+## For service operators
 
-If you're using multiple light nodes for similar things like tracking the same rollup,
-it is recommended to use the same hash and height for them all rollups or applications using
+If you're using multiple light nodes for similar services like tracking the same rollup,
+it is recommended to use the same hash and height for them all services using
 the same starting height.

--- a/nodes/celestia-node-trusted-hash.md
+++ b/nodes/celestia-node-trusted-hash.md
@@ -1,0 +1,38 @@
+---
+description: How to sync a light node from a trusted hash.
+---
+
+# Syncing a light node from a trusted hash
+
+This guide goes over how to sync a DA light node from a trusted hash.
+The example is with Mainnet Beta. You will need to adjust the commands
+accordingly for Mocha, Arabica, or a custom network.
+
+::: warning
+Syncing to a trusted hash means that you will not sample the entire chain. This adds a trust
+assumption that you trust the history of chain up to that point and that you trust the entity
+where you get the hash from. In this example, the trusted entity is a consensus endpoint or
+Celenium
+:::
+
+1. Get trusted height & hash from a consensus endpoint or [Celenium](https://celenium.io).
+1. Initialize the node store
+
+    ```sh
+    celestia light init
+    ```
+
+1. Set the trusted height & hash
+    1. Open your config.toml at `.celestia-light/config.toml` (or `.celestia-light-<other-network>/config.toml`)
+    1. Set `DASer.SampleFrom` to the trusted height (e.g. `SampleFrom = 123456`)
+1. Run the node with the hash and flag:
+
+```sh
+celestia light start --headers.trusted-hash <hash_of_block_n>
+```
+
+## For rollup operators
+
+If you're using multiple light nodes for similar things like tracking the same rollup,
+it is recommended to use the same hash and height for them all rollups or applications using
+same starting height.

--- a/nodes/celestia-node-trusted-hash.md
+++ b/nodes/celestia-node-trusted-hash.md
@@ -10,7 +10,7 @@ accordingly for Mocha, Arabica, or a custom network.
 
 ::: warning
 Syncing to a trusted hash means that you will not sample the entire chain. This adds a trust
-assumption that you trust the history of chain up to that point and that you trust the entity
+assumption that you trust the history of the chain up to that point and that you trust the entity
 where you get the hash from. In this example, the trusted entity is a consensus endpoint or
 Celenium
 :::
@@ -35,4 +35,4 @@ celestia light start --headers.trusted-hash <hash_of_block_n>
 
 If you're using multiple light nodes for similar things like tracking the same rollup,
 it is recommended to use the same hash and height for them all rollups or applications using
-same starting height.
+the same starting height.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves #1460 

[Direct link to preview
](https://celestiaorg.github.io/docs-preview/pr-1651/nodes/celestia-node-trusted-hash#syncing-a-light-node-from-a-trusted-hash)

<img width="976" alt="Screenshot 2024-07-25 at 12 55 06 PM" src="https://github.com/user-attachments/assets/344be59a-2f38-4e6a-b112-7ffeec3d57fd">

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new sidebar entry titled "Syncing a light node from a trusted hash" for easier navigation.
	- Introduced a comprehensive guide on syncing light nodes from a trusted hash, detailing setup for Mainnet Beta and other networks. 
- **Documentation**
	- Enhanced user resources with a step-by-step guide on initializing and running a light node, focusing on trust and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->