### PR TITLE
docs: mocha upgrade height

### DIFF
--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -307,7 +307,7 @@ celestia-appd start --v2-upgrade-height <height>
 ```
 
 ```sh-vue [Mocha]
-celestia-appd start --v2-upgrade-height 2534734
+celestia-appd start --v2-upgrade-height 2534757
 ```
 
 ```sh-vue [Arabica]

--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -307,7 +307,7 @@ celestia-appd start --v2-upgrade-height <height>
 ```
 
 ```sh-vue [Mocha]
-celestia-appd start --v2-upgrade-height <height>
+celestia-appd start --v2-upgrade-height 2534734
 ```
 
 ```sh-vue [Arabica]

--- a/nodes/hardfork-process.md
+++ b/nodes/hardfork-process.md
@@ -46,5 +46,5 @@ The Lemongrass hardfork is the first consensus layer breaking change since Celes
 Network      | Chain ID   | Datetime                                 | `--v2-upgrade-height`
 -------------|------------|------------------------------------------|----------------------
 Arabica      | arabica-11 | 2024/08/19 @ 14:00 UTC                   | 1751707
-Mocha        | mocha-4    | TBD approximately 2024/08/28 @ 14:00 UTC | TBD
+Mocha        | mocha-4    | 2024/08/28 @ 14:00 UTC                   | 2534734
 Mainnet Beta | celestia   | TBD approximately 2024/09/18 @ 14:00 UTC | TBD

--- a/nodes/hardfork-process.md
+++ b/nodes/hardfork-process.md
@@ -46,5 +46,5 @@ The Lemongrass hardfork is the first consensus layer breaking change since Celes
 Network      | Chain ID   | Datetime                                 | `--v2-upgrade-height`
 -------------|------------|------------------------------------------|----------------------
 Arabica      | arabica-11 | 2024/08/19 @ 14:00 UTC                   | 1751707
-Mocha        | mocha-4    | 2024/08/28 @ 14:00 UTC                   | 2534734
+Mocha        | mocha-4    | 2024/08/28 @ 14:00 UTC                   | 2534757
 Mainnet Beta | celestia   | TBD approximately 2024/09/18 @ 14:00 UTC | TBD

--- a/nodes/validator-node.md
+++ b/nodes/validator-node.md
@@ -157,7 +157,7 @@ celestia-appd start --v2-upgrade-height <height>
 ```
 
 ```sh-vue [Mocha]
-celestia-appd start --v2-upgrade-height <height>
+celestia-appd start --v2-upgrade-height 2534734
 ```
 
 ```sh-vue [Arabica]

--- a/nodes/validator-node.md
+++ b/nodes/validator-node.md
@@ -157,7 +157,7 @@ celestia-appd start --v2-upgrade-height <height>
 ```
 
 ```sh-vue [Mocha]
-celestia-appd start --v2-upgrade-height 2534734
+celestia-appd start --v2-upgrade-height 2534757
 ```
 
 ```sh-vue [Arabica]


### PR DESCRIPTION
## Description

Add the v2 upgrade height for Mocha. Tagging @tty47 for awareness.

## Resources

This value was derived using the `blockheight` tool from [celestia-app/tools](https://github.com/celestiaorg/celestia-app/tree/main/tools) with a 12.03 second blocktime based on [Mintscan](https://www.mintscan.io/celestia-testnet/)

```shell
$ go run main.go https://celestia-mocha-rpc.publicnode.com:443 2024-08-21T14:00:00
chainID: mocha-4
currentHeight: 2528740
currentTime: 2024-08-20 17:53:30.162475958 +0000 UTC
targetHeight: 2534757
targetTime: 2024-08-21 14:00:00 +0000 UTC
diffInSeconds: 72389
diffInBlockHeight: 6017
```