### PR TITLE
fix: mocha upgrade height

### DIFF
--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -307,7 +307,7 @@ celestia-appd start --v2-upgrade-height <height>
 ```
 
 ```sh-vue [Mocha]
-celestia-appd start --v2-upgrade-height 2534757
+celestia-appd start --v2-upgrade-height 2585031
 ```
 
 ```sh-vue [Arabica]

--- a/nodes/hardfork-process.md
+++ b/nodes/hardfork-process.md
@@ -46,5 +46,5 @@ The Lemongrass hardfork is the first consensus layer breaking change since Celes
 Network      | Chain ID   | Datetime                                 | `--v2-upgrade-height`
 -------------|------------|------------------------------------------|----------------------
 Arabica      | arabica-11 | 2024/08/19 @ 14:00 UTC                   | 1751707
-Mocha        | mocha-4    | 2024/08/28 @ 14:00 UTC                   | 2534757
+Mocha        | mocha-4    | 2024/08/28 @ 14:00 UTC                   | 2585031
 Mainnet Beta | celestia   | TBD approximately 2024/09/18 @ 14:00 UTC | TBD

--- a/nodes/validator-node.md
+++ b/nodes/validator-node.md
@@ -157,7 +157,7 @@ celestia-appd start --v2-upgrade-height <height>
 ```
 
 ```sh-vue [Mocha]
-celestia-appd start --v2-upgrade-height 2534757
+celestia-appd start --v2-upgrade-height 2585031
 ```
 
 ```sh-vue [Arabica]


### PR DESCRIPTION
Follow up to https://github.com/celestiaorg/docs/pull/1672 the upgrade should happen on August 28th not August 21st. New height is based on:

```shell
$ go run main.go https://celestia-mocha-rpc.publicnode.com:443 2024-08-28T14:00:00
chainID: mocha-4
currentHeight: 2528880
currentTime: 2024-08-20 18:21:39.920330922 +0000 UTC
targetHeight: 2585031
targetTime: 2024-08-28 14:00:00 +0000 UTC
diffInSeconds: 675500
diffInBlockHeight: 56151
```