### PR TITLE
docs: fix inconsistent casing

### DIFF
--- a/nodes/arabica-devnet.md
+++ b/nodes/arabica-devnet.md
@@ -183,4 +183,4 @@ Join our [Telegram announcement channel](https://t.me/+smSFIA7XXLU4MjJh)
 for network upgrades.
 
 See the [Hardfork process page](./hardfork-process.md) to learn more
-about specific upgrades like the [Lemongrass Hardfork](./hardfork-process.md#lemongrass-hardfork).
+about specific upgrades like the [Lemongrass hardfork](./hardfork-process.md#lemongrass-hardfork).

--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -340,4 +340,4 @@ There are a few ways to stay informed about network upgrades on Mainnet Beta:
 - Discord [Mainnet Beta announcements](https://discord.com/channels/638338779505229824/1169237690114388039)
 
 See the [Hardfork process page](./hardfork-process.md) to learn more
-about specific upgrades like the [Lemongrass Hardfork](./hardfork-process.md#lemongrass-hardfork).
+about specific upgrades like the [Lemongrass hardfork](./hardfork-process.md#lemongrass-hardfork).

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -267,4 +267,4 @@ There are a few ways to stay informed about network upgrades on Mocha testnet:
 - Discord [Mocha announcements](https://discord.com/channels/638338779505229824/979037494735691816)
 
 See the [Hardfork process page](./hardfork-process.md) to learn more
-about specific upgrades like the [Lemongrass Hardfork](./hardfork-process.md#lemongrass-hardfork).
+about specific upgrades like the [Lemongrass hardfork](./hardfork-process.md#lemongrass-hardfork).

--- a/nodes/overview.md
+++ b/nodes/overview.md
@@ -41,7 +41,7 @@ each tutorial guide.
 
 ## Consensus nodes
 
-| Node Type        | Memory      | CPU         | Disk       | Bandwidth |
+| Node type        | Memory      | CPU         | Disk       | Bandwidth |
 |------------------|-------------|-------------|------------|-----------|
 | Validator        | 16 GB RAM   | 8 cores     | 2 TB SSD   | 1 Gbps    |
 | Consensus node   | 16 GB RAM   | Quad-core   | 2 TB SSD   | 1 Gbps    |

--- a/nodes/participate.md
+++ b/nodes/participate.md
@@ -61,4 +61,4 @@ There are a few ways to stay informed about network upgrades:
 - Discord [Mocha announcements](https://discord.com/channels/638338779505229824/979037494735691816)
 
 See the [Hardfork process page](./hardfork-process.md) to learn more
-about specific upgrades like the [Lemongrass Hardfork](./hardfork-process.md#lemongrass-hardfork).
+about specific upgrades like the [Lemongrass hardfork](./hardfork-process.md#lemongrass-hardfork).


### PR DESCRIPTION
"Node Type" -> "Node type" to match the table above

Also cleans up "Hardfork" to "hardfork" from #1675 
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Standardized the capitalization of "Hardfork" to "hardfork" across multiple documentation files for improved consistency.
	- Updated the capitalization of the "Node Type" header to "Node type" for enhanced clarity in the table formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->