### PR TITLE
docs: add multiaccounts doc

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -667,6 +667,10 @@ function sidebarHome() {
               link: "/developers/feegrant-for-blobs",
             },
             {
+              text: "MultiAccounts feature for blobs submission",
+              link: "/developers/multiaccounts",
+            },
+            {
               text: "Transaction resubmission guidelines",
               link: "/developers/transaction-resubmission",
             },

--- a/developers/multiaccounts.md
+++ b/developers/multiaccounts.md
@@ -1,0 +1,78 @@
+# MultiAccounts feature for blobs submission
+
+## Overview
+
+By default, a celestia-node creates a key named `my_celes_key` during
+initialization. This document explains how to run a node with a different
+default key name and how to submit blobs using different signers.
+
+## Running a node with a different default key name
+
+To start a Celestia node with a different default key name, use the following
+command:
+
+```sh
+celestia light start --core.ip=consensus.celestia-arabica-11.com \
+    --p2p.network=arabica --keyring.keyname testKey
+```
+
+In this example, `testKey` becomes the default node key, and the
+node's address will change accordingly.
+
+## Submitting blobs with a different signer/key name
+
+### Option 1: Submit passing key name
+
+You can submit a blob by specifying a different key name:
+
+```sh
+celestia blob submit 0x42690c204d39600fddd3 'gm' --key.name testKey2
+```
+
+This transaction will be signed by the address associated with `testKey2`.
+
+### Option 2: Submit passing signer address
+
+Alternatively, you can submit a blob by specifying the signer's address:
+
+```sh
+celestia blob submit 0x42690c204d39600fddd3 'gm' --signer $SIGNER_ADDRESS
+```
+
+Both options achieve the same result but use different inputs. The
+`testKey2` points to `SIGNER_ADDRESS` in the KeyStore.
+
+## Key management
+
+All keys and addresses must be added to the KeyStore. To create a new key,
+use the [`cel-key` library](https://github.com/celestiaorg/celestia-node/blob/main/cmd/cel-key/main.go):
+
+### Creating a new key
+
+```sh
+./cel-key add testKey --keyring-backend test \
+    --node.type light --p2p.network arabica
+```
+
+### Importing an existing key
+
+```sh
+./cel-key import
+```
+
+## Optional flags for write transactions
+
+All other flags are now optional for all write transactions. This
+means you don't have to specify gas/fee parameters each time.
+The configuration can handle it for you automatically.
+
+
+The default configuration applies to all write transactions,
+including those in the [state module](https://node-rpc-docs.celestia.org/#state)
+and [blob.Submit](https://node-rpc-docs.celestia.org/#blob.Submit).
+This simplifies the process of submitting transactions and
+reduces the need for manual input.
+
+For reference, see the:
+- [Transaction configuration](https://github.com/celestiaorg/celestia-node/blob/87e2802b687065055e117b4ed2a0128d0666587d/state/tx_config.go#L35)
+- [State module command implementation](https://github.com/celestiaorg/celestia-node/blob/87e2802b687065055e117b4ed2a0128d0666587d/nodebuilder/state/cmd/state.go#L420)

--- a/developers/multiaccounts.md
+++ b/developers/multiaccounts.md
@@ -59,6 +59,9 @@ use the [`cel-key` library](https://github.com/celestiaorg/celestia-node/blob/ma
 ```sh
 ./cel-key import
 ```
+Learn more on the
+[./celestia-node-key#create-a-wallet-with-celestia-node](Create a wallet with celestia-node)
+page.
 
 ## Optional flags for write transactions
 

--- a/developers/multiaccounts.md
+++ b/developers/multiaccounts.md
@@ -60,7 +60,7 @@ use the [`cel-key` library](https://github.com/celestiaorg/celestia-node/blob/ma
 ./cel-key import
 ```
 Learn more on the
-[./celestia-node-key#create-a-wallet-with-celestia-node](Create a wallet with celestia-node)
+[Create a wallet with celestia-node](./celestia-node-key#create-a-wallet-with-celestia-node)
 page.
 
 ## Optional flags for write transactions


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Adds MultiAccounts doc to submitting blobs section. 

[LIVE PREVIEW
](https://celestiaorg.github.io/docs-preview/pr-1684/developers/multiaccounts#multiaccounts-feature-for-blobs-submission)
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a new section in the sidebar for the "MultiAccounts feature for blobs submission."
	- Introduced documentation outlining the MultiAccounts feature, including customizable key names and simplified blob submission methods.

- **Documentation**
	- Comprehensive guide on operating a Celestia node with customizable keys, submission methods, and key management instructions.
	- Updated the blob submission process to make all flags for write transactions optional, streamlining user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->