### PR TITLE
docs: migrate node ID in bridge-node, full-storage-node, light-node

### DIFF
--- a/nodes/bridge-node.md
+++ b/nodes/bridge-node.md
@@ -189,7 +189,7 @@ celestia bridge start --core.ip <URI> --keyring.keyname <name-of-custom-key> \
 
 :::
 
-#### Optional: migrate node id to another server
+#### Optional: Migrate node id to another server
 
 To migrate a bridge node ID:
 

--- a/nodes/bridge-node.md
+++ b/nodes/bridge-node.md
@@ -189,6 +189,13 @@ celestia bridge start --core.ip <URI> --keyring.keyname <name-of-custom-key> \
 
 :::
 
+#### Optional: migrate node id to another server
+
+To migrate a bridge node ID:
+
+1. You need to backup two files located in the celestia-bridge node directory at the correct path (default: `~/.celestia-bridge/keys`).
+2. Upload the files to the new server and start the node.
+
 ### Optional: start the bridge node with SystemD
 
 Follow the

--- a/nodes/bridge-node.md
+++ b/nodes/bridge-node.md
@@ -193,7 +193,7 @@ celestia bridge start --core.ip <URI> --keyring.keyname <name-of-custom-key> \
 
 To migrate a bridge node ID:
 
-1. You need to backup two files located in the celestia-bridge node directory at the correct path (default: `~/.celestia-bridge/keys`).
+1. You need to back up two files located in the celestia-bridge node directory at the correct path (default: `~/.celestia-bridge/keys`).
 2. Upload the files to the new server and start the node.
 
 ### Optional: start the bridge node with SystemD

--- a/nodes/full-storage-node.md
+++ b/nodes/full-storage-node.md
@@ -148,7 +148,7 @@ celestia full start --core.ip <URI> \
 
 :::
 
-#### Optional: migrate node id to another server
+#### Optional: Migrate node id to another server
 
 To migrate a full storage node ID:
 

--- a/nodes/full-storage-node.md
+++ b/nodes/full-storage-node.md
@@ -152,7 +152,7 @@ celestia full start --core.ip <URI> \
 
 To migrate a full storage node ID:
 
-1. You need to backup two files located in the celestia-full node directory at the correct path (default: `~/.celestia-full/keys`).
+1. You need to back up two files located in the celestia-full node directory at the correct path (default: `~/.celestia-full/keys`).
 2. Upload the files to the new server and start the node.
 
 ### Optional: start the full storage node with SystemD

--- a/nodes/full-storage-node.md
+++ b/nodes/full-storage-node.md
@@ -148,6 +148,13 @@ celestia full start --core.ip <URI> \
 
 :::
 
+#### Optional: migrate node id to another server
+
+To migrate a full storage node ID:
+
+1. You need to backup two files located in the celestia-full node directory at the correct path (default: `~/.celestia-full/keys`).
+2. Upload the files to the new server and start the node.
+
 ### Optional: start the full storage node with SystemD
 
 If you would like to run the full storage node as a background process, follow the

--- a/nodes/light-node.md
+++ b/nodes/light-node.md
@@ -191,6 +191,13 @@ celestia light start --core.ip <URI> \
 
 :::
 
+#### Optional: migrate node id to another server
+
+To migrate a light node ID:
+
+1. You need to backup two files located in the celestia-light node directory at the correct path (default: `~/.celestia-light/keys`).
+2. Upload the files to the new server and start the node.
+
 ### Optional: start light node with SystemD
 
 Follow

--- a/nodes/light-node.md
+++ b/nodes/light-node.md
@@ -195,7 +195,7 @@ celestia light start --core.ip <URI> \
 
 To migrate a light node ID:
 
-1. You need to backup two files located in the celestia-light node directory at the correct path (default: `~/.celestia-light/keys`).
+1. You need to back up two files located in the celestia-light node directory at the correct path (default: `~/.celestia-light/keys`).
 2. Upload the files to the new server and start the node.
 
 ### Optional: start light node with SystemD

--- a/nodes/light-node.md
+++ b/nodes/light-node.md
@@ -191,7 +191,7 @@ celestia light start --core.ip <URI> \
 
 :::
 
-#### Optional: migrate node id to another server
+#### Optional: Migrate node id to another server
 
 To migrate a light node ID:
 


### PR DESCRIPTION
## Overview

Currently, the node id migration process is not very transparent in the documentation. This PR fixes that


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added detailed migration instructions for bridge, full storage, and light nodes in the documentation, enhancing usability and functionality for users transferring node IDs to new servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->