### PR TITLE
docs: use same checkout for node and app

### DIFF
--- a/nodes/celestia-app.md
+++ b/nodes/celestia-app.md
@@ -41,15 +41,15 @@ Be sure to select the correct network to install the binary for.
    ::: code-group
 
    ```bash-vue [Mainnet Beta]
-   git checkout tags/{{mainnetVersions['app-latest-tag']}} -b {{mainnetVersions['app-latest-tag']}}
+   git checkout tags/{{mainnetVersions['app-latest-tag']}}
    ```
 
    ```bash-vue [Mocha]
-   git checkout tags/{{mochaVersions['app-latest-tag']}} -b {{mochaVersions['app-latest-tag']}}
+   git checkout tags/{{mochaVersions['app-latest-tag']}}
    ```
 
    ```bash-vue [Arabica]
-   git checkout tags/{{arabicaVersions['app-latest-tag']}} -b {{arabicaVersions['app-latest-tag']}}
+   git checkout tags/{{arabicaVersions['app-latest-tag']}}
    ```
 
    :::


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This removes `-b <version>` from git checkout command for celestia-app.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
