### PR TITLE
docs: v2 upgrade height for mainnet beta

### DIFF
--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -303,7 +303,7 @@ If you are running celestia-app >= v2.0.0: then you'll want to start the node wi
 ::: code-group
 
 ```sh-vue [Mainnet Beta]
-celestia-appd start --v2-upgrade-height 2371728
+celestia-appd start --v2-upgrade-height 2371495
 ```
 
 ```sh-vue [Mocha]

--- a/nodes/consensus-node.md
+++ b/nodes/consensus-node.md
@@ -303,7 +303,7 @@ If you are running celestia-app >= v2.0.0: then you'll want to start the node wi
 ::: code-group
 
 ```sh-vue [Mainnet Beta]
-celestia-appd start --v2-upgrade-height <height>
+celestia-appd start --v2-upgrade-height 2371728
 ```
 
 ```sh-vue [Mocha]

--- a/nodes/hardfork-process.md
+++ b/nodes/hardfork-process.md
@@ -43,8 +43,8 @@ The Lemongrass hardfork is the first consensus layer breaking change since Celes
 - If you are a consensus node or validator operator: you will need to download and run a celestia-app binary >= v2.0.0 prior to the `--v2-upgrade-height` to remain on the canonical chain. You do not need to use a tool like [cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) to upgrade the binary at the upgrade height.
 - If you are a DA node operator, you will need to download and run a compatible celestia-node binary >= v0.16.0-rc0 prior to the upgrade height.
 
-Network      | Chain ID   | Datetime                                 | `--v2-upgrade-height`
+Network      | Chain ID   | Date and approximate time                | `--v2-upgrade-height`
 -------------|------------|------------------------------------------|----------------------
 Arabica      | arabica-11 | 2024/08/19 @ 14:00 UTC                   | 1751707
 Mocha        | mocha-4    | 2024/08/28 @ 14:00 UTC                   | 2585031
-Mainnet Beta | celestia   | TBD approximately 2024/09/18 @ 14:00 UTC | TBD
+Mainnet Beta | celestia   | 2024/09/18 @ 14:00 UTC                   | 2371728

--- a/nodes/hardfork-process.md
+++ b/nodes/hardfork-process.md
@@ -47,4 +47,4 @@ Network      | Chain ID   | Date and approximate time                | `--v2-upg
 -------------|------------|------------------------------------------|----------------------
 Arabica      | arabica-11 | 2024/08/19 @ 14:00 UTC                   | 1751707
 Mocha        | mocha-4    | 2024/08/28 @ 14:00 UTC                   | 2585031
-Mainnet Beta | celestia   | 2024/09/18 @ 14:00 UTC                   | 2371728
+Mainnet Beta | celestia   | 2024/09/18 @ 14:00 UTC                   | 2371495

--- a/nodes/validator-node.md
+++ b/nodes/validator-node.md
@@ -153,7 +153,7 @@ If you are running celestia-app >= v2.0.0: then you'll want to start the node wi
 ::: code-group
 
 ```sh-vue [Mainnet Beta]
-celestia-appd start --v2-upgrade-height 2371728
+celestia-appd start --v2-upgrade-height 2371495
 ```
 
 ```sh-vue [Mocha]

--- a/nodes/validator-node.md
+++ b/nodes/validator-node.md
@@ -153,7 +153,7 @@ If you are running celestia-app >= v2.0.0: then you'll want to start the node wi
 ::: code-group
 
 ```sh-vue [Mainnet Beta]
-celestia-appd start --v2-upgrade-height <height>
+celestia-appd start --v2-upgrade-height 2371728
 ```
 
 ```sh-vue [Mocha]


### PR DESCRIPTION
I estimated this height using the blockheight tool from celestia-app repo. On mainnet the block time is **11.75 seconds**

```
$ go run main.go https://celestia-rpc.publicnode.com:443 2024-09-18T14:00:00
chainID: celestia
currentHeight: 2268730
currentTime: 2024-09-04 13:49:30.057435899 +0000 UTC
targetHeight: 2371728
targetTime: 2024-09-18 14:00:00 +0000 UTC
diffInSeconds: 1.210229e+06
diffInBlockHeight: 102998
```

Then we revised the estimate to a block height that is 5 blocks before a multiple of 1500 so that a state sync snapshot is created shortly after the upgrade.

```
$ go run main.go https://celestia-rpc.publicnode.com:443 2371495
chainID: celestia
currentHeight: 2269085
currentTime: 2024-09-04 14:58:54.478635553 +0000 UTC
diffInBlockHeight: 102410
diffInTime: 334h15m17.5s
arrivalTime: 2024-09-18 13:14:11.978635553 +0000 UTC
```