### PR TITLE
docs: remove dependency of roll-op because it is installed in op-plasma-celestia

### DIFF
--- a/developers/optimism.md
+++ b/developers/optimism.md
@@ -16,7 +16,6 @@ If you don't have devops experience and would like to use a Rollups as a Service
 ## Dependency setup
 
 - [celestia-node](../nodes/celestia-node.md)
-- [roll-op](https://github.com/celestiaorg/roll-op?tab=readme-ov-file#prerequisites)
 
 ### Setting up your light node
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
