### PR TITLE
docs: use `breaking network upgrade` for lemongrass

### DIFF
--- a/nodes/arabica-devnet.md
+++ b/nodes/arabica-devnet.md
@@ -183,4 +183,4 @@ Join our [Telegram announcement channel](https://t.me/+smSFIA7XXLU4MjJh)
 for network upgrades.
 
 See the [network upgrade process page](./network-upgrade-process.md) to learn more
-about specific upgrades like the [Lemongrass network upgrade](./network-upgrade-process.md#lemongrass-network-upgrade).
+about specific upgrades like the [Lemongrass breaking network upgrade](./network-upgrade-process.md#lemongrass-breaking-network-upgrade).

--- a/nodes/mainnet.md
+++ b/nodes/mainnet.md
@@ -340,4 +340,4 @@ There are a few ways to stay informed about network upgrades on Mainnet Beta:
 - Discord [Mainnet Beta announcements](https://discord.com/channels/638338779505229824/1169237690114388039)
 
 See the [network upgrade process page](./network-upgrade-process.md) to learn more
-about specific upgrades like the [Lemongrass network upgrade](./network-upgrade-process.md#lemongrass-network-upgrade).
+about specific upgrades like the [Lemongrass breaking network upgrade](./network-upgrade-process.md#lemongrass-breaking-network-upgrade).

--- a/nodes/mocha-testnet.md
+++ b/nodes/mocha-testnet.md
@@ -267,4 +267,4 @@ There are a few ways to stay informed about network upgrades on Mocha testnet:
 - Discord [Mocha announcements](https://discord.com/channels/638338779505229824/979037494735691816)
 
 See the [network upgrade process page](./network-upgrade-process.md) to learn more
-about specific upgrades like the [Lemongrass network upgrade](./network-upgrade-process.md#lemongrass-network-upgrade).
+about specific upgrades like the [Lemongrass breaking network upgrade](./network-upgrade-process.md#lemongrass-breaking-network-upgrade).

--- a/nodes/network-upgrade-process.md
+++ b/nodes/network-upgrade-process.md
@@ -38,9 +38,9 @@ The two testnets where network upgrades are deployed are:
 - [Arabica devnet](./arabica-devnet.md)
 - [Mocha testnet](./mocha-testnet.md)
 
-### Lemongrass network upgrade
+### Lemongrass breaking network upgrade
 
-The Lemongrass network upgrade is the first consensus layer breaking change since Celestia's Mainnet Beta genesis block. The Lemongrass network upgrade includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass network upgrade will be executed on Arabica, then Mocha, then Mainnet Beta. The network upgrade will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (see [network upgrades channels](./participate#network-upgrades)) to give node operators time to download and start a compatible binary prior to the upgrade height.
+The Lemongrass breaking network upgrade is the first consensus layer breaking change since Celestia's Mainnet Beta genesis block. The Lemongrass breaking network upgrade includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass breaking network upgrade will be executed on Arabica, then Mocha, then Mainnet Beta. The network upgrade will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (see [network upgrades channels](./participate#network-upgrades)) to give node operators time to download and start a compatible binary prior to the upgrade height.
 
 - If you are a consensus node or validator operator: you will need to download and run a celestia-app binary >= v2.0.0 prior to the `--v2-upgrade-height` to remain on the canonical chain. You do not need to use a tool like [cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) to upgrade the binary at the upgrade height.
 - If you are a DA node operator, you will need to download and run a compatible celestia-node binary >= v0.16.0-rc0 prior to the upgrade height.

--- a/nodes/participate.md
+++ b/nodes/participate.md
@@ -61,4 +61,4 @@ There are a few ways to stay informed about network upgrades:
 - Discord [Mocha announcements](https://discord.com/channels/638338779505229824/979037494735691816)
 
 See the [network upgrade process page](./network-upgrade-process.md) to learn more
-about specific upgrades like the [Lemongrass network upgrade](./network-upgrade-process.md#lemongrass-network-upgrade).
+about specific upgrades like the [Lemongrass breaking network upgrade](./network-upgrade-process.md#lemongrass-breaking-network-upgrade).


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Clarifies "breaking network upgrade" based on:

- Hardfork === Breaking network upgrade
- Softfork === (non-breaking) Network upgrade
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Clarified the nature of the "Lemongrass network upgrade" by updating terminology to "Lemongrass breaking network upgrade" across multiple documents, highlighting potential breaking changes for users.
  
- **Documentation**
	- Enhanced clarity on the implications of the Lemongrass upgrade for users regarding compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->