### PR TITLE
docs: warning for cosmovisor

### DIFF
--- a/nodes/network-upgrade-process.md
+++ b/nodes/network-upgrade-process.md
@@ -42,7 +42,7 @@ The two testnets where network upgrades are deployed are:
 
 The Lemongrass network upgrade is the first consensus layer breaking change since Celestia's Mainnet Beta genesis block. The Lemongrass network upgrade includes all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-17.md). The Lemongrass network upgrade will be executed on Arabica, then Mocha, then Mainnet Beta. The network upgrade will take place at an "upgrade height" that will be coordinated offline on a per-network basis. The upgrade heights will be announced in advance (see [network upgrades channels](./participate#network-upgrades)) to give node operators time to download and start a compatible binary prior to the upgrade height.
 
-- If you are a consensus node or validator operator: you will need to download and run a celestia-app binary >= v2.0.0 prior to the `--v2-upgrade-height` to remain on the canonical chain. You do not need to use a tool like [cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) to upgrade the binary at the upgrade height.
+- If you are a consensus node or validator operator: you will need to download and run a celestia-app binary >= v2.0.0 prior to the `--v2-upgrade-height` to remain on the canonical chain.
 - If you are a DA node operator, you will need to download and run a compatible celestia-node binary >= v0.16.0-rc0 prior to the upgrade height.
 
 Network      | Chain ID   | Date and approximate time                | `--v2-upgrade-height`
@@ -50,3 +50,9 @@ Network      | Chain ID   | Date and approximate time                | `--v2-upg
 Arabica      | arabica-11 | 2024/08/19 @ 14:00 UTC                   | 1751707
 Mocha        | mocha-4    | 2024/08/28 @ 14:00 UTC                   | 2585031
 Mainnet Beta | celestia   | 2024/09/18 @ 14:00 UTC                   | 2371495
+
+:::warning
+
+You do not need to use a tool like [cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) to upgrade the binary at the upgrade height. Please upgrade your binary several blocks before the upgrade height.
+
+:::


### PR DESCRIPTION
Closes https://github.com/celestiaorg/docs/issues/1720

## Screenshot

![Screenshot 2024-09-18 at 12 12 14 PM](https://github.com/user-attachments/assets/983a8270-128e-40a5-821b-751dfaaa6582)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified requirements for consensus node and validator operators regarding the Lemongrass network upgrade.
	- Removed instructions for using the `cosmovisor` tool and emphasized the need to upgrade binaries before the specified height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->