### PR TITLE
docs: add trusted hash to top of node tut

### DIFF
--- a/developers/node-tutorial.md
+++ b/developers/node-tutorial.md
@@ -30,6 +30,10 @@ Read
 :::tip
 If you already have a running and funded node,
 you can skip to the [RPC CLI guide section](#rpc-cli-guide).
+
+If you would like to skip syncing, you can use
+this
+[guide to sync from trusted hash and height](../nodes/celestia-node-trusted-hash.md).
 :::
 
 :::warning


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an informational tip in the Node tutorial to guide users on skipping syncing by referring to a trusted hash and height.

- **Documentation**
	- Enhanced guidance in the `developers/node-tutorial.md` file for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->