### PR TITLE
feat: Cookbook Onboard (AI Assistant) integration

### DIFF
--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -11,6 +11,31 @@ export default {
     });
   },
   enhanceApp({ app, router, siteData }) {
-    // ...
+    // Ask Cookbook Integration start
+    if (typeof window !== "undefined") {
+      /** It's a public API key, so it's safe to expose it here */
+      const COOKBOOK_API_KEY =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NmVhZmRmNTE3MDkyYjQzMGUyOGFkYTgiLCJpYXQiOjE3MjY2NzY0NjksImV4cCI6MjA0MjI1MjQ2OX0.yfmY5Zm70Xt6rMHTi9g_2aRSQauYyiglzv9-pvOW8zg";
+
+      let element = document.getElementById("__cookbook");
+      if (!element) {
+        element = document.createElement("div");
+        element.id = "__cookbook";
+        element.dataset.apiKey = COOKBOOK_API_KEY;
+        document.body.appendChild(element);
+      }
+      let script = document.getElementById(
+        "__cookbook-script",
+      ) as HTMLScriptElement | null;
+      if (!script) {
+        script = document.createElement("script");
+        script.src =
+          "https://cdn.jsdelivr.net/npm/@cookbookdev/docsbot/dist/standalone/index.cjs.js";
+        script.id = "__cookbook-script";
+        script.defer = true;
+        document.body.appendChild(script);
+      }
+    }
   },
+  // Ask Cookbook Integration end
 };


### PR DESCRIPTION
## Preview
Preview link: https://celestia-docs-cookbook.vercel.app/

## Ask Cookbook AI Assistant
Cookbook's Ask Cookbook AI assistant and co-pilot is trained on all existing Celestia resources (source code, docs website, etc.) and is available as a standalone modal, embeddable as a button on any page (recommended for technical docs). It answers developer questions about using Celestia, acting as an enhanced and streamlined technical documentation search tool as well as a Solidity coding co-pilot.

Ask Cookbook AI can also access context from thousands of data sources indexed by Cookbook.dev in addition to Celestia-specific data sources, providing the best blockchain developer-focused answers of any chatbot on the market. Cookbook will assist in the tuning and calibration of the AI assistant to ensure the highest answer quality.

![image](https://github.com/user-attachments/assets/6c6b8065-865b-4b1c-9c2b-afa5929adbf5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Cookbook integration that enhances the application with new functionality when run in a browser.
	- Automatically creates necessary HTML elements and script tags for the Cookbook service if they do not already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->