### PR TITLE
test(ci): add deploy status badge to readme and add build ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build VitePress Site
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn 
+      - name: Install dependencies
+        run: yarn install 
+      - name: Build with VitePress
+        run: yarn build 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy](https://github.com/celestiaorg/docs/actions/workflows/deploy.yml/badge.svg)](https://github.com/celestiaorg/docs/actions/workflows/deploy.yml)
+
 # Celestia Documentation Site
 
 Welcome to the official documentation repository for [Celestia](https://celestia.org/).


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Currently there is no branch protect from a CI perspective. This PR as the build stage without deployment so that it can run on all PRs and be require to merge. 
Additionally this adds the deploy status badge to the README for visibility if it were to fail. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a GitHub Actions workflow to automate the build process for the VitePress site.
	- Added a deployment status badge to the README for enhanced visibility of the deployment process.

- **Documentation**
	- Updated the README.md to include the new deployment status badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->