### PR TITLE
fix:update go versions

### DIFF
--- a/.vitepress/constants/constants.js
+++ b/.vitepress/constants/constants.js
@@ -1,7 +1,7 @@
 const constants = Object.freeze({
   golangNodeMainnet: "1.23.0",
-  golangNodeMocha: "1.23.0",
-  golangNodeArabica: "1.23.0",
+  golangNodeMocha: "1.23.2",
+  golangNodeArabica: "1.23.2",
   golangApp: "1.22.6",
   golangCore: "1.22.6",
   golang: "1.22.0",


### PR DESCRIPTION
Upgrading the golang version to the required versions.


`❯ make build
--> Building Celestia
go: go.mod requires go >= 1.23.2 (running go 1.23.1; GOTOOLCHAIN=local)
make: *** [build] Error 1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version numbers for `golangNodeMocha` and `golangNodeArabica` to enhance compatibility and performance. 

These updates ensure users benefit from the latest improvements and bug fixes associated with these properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->