### PR TITLE
docs: update directory structure in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ making a pull request.
 ## Directory Structure
 
 - /learn: A category for learning about Celestia.
-- /developers: A category with tutorials and guides for deploying
-  rollups and interacting with Celestia nodes.
-- /nodes: Technical reference materials for all node types.
+- /how-to guides: A category with guides for running a node, deploying
+  rollups, and building on Celestia.
+- /tutorials: A category with tutorials on interacting with celestia-node.
 <!-- * /guides [WIP]: In-depth articles that cover specific topics in detail. -->
 - /community: A category for the Celestia community.
 - /public: Images, diagrams, and other media files used in the documentation.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
This PR updates the directory structure in the README to reflect the new directories.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the directory structure in the README for improved clarity.
	- Replaced `/developers` with `/how-to guides` and `/nodes` with `/tutorials`.
	- Added guides for running a node, deploying rollups, and building on Celestia under the new categories. 
	- Marked the comment regarding the `/guides` category as a work-in-progress (WIP).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->