### PR TITLE
Update network-upgrade-process.md

### DIFF
--- a/how-to-guides/network-upgrade-process.md
+++ b/how-to-guides/network-upgrade-process.md
@@ -23,7 +23,7 @@ The upgrade process can be broken down into a few steps:
 1. A new binary is released with the new features to be tested on testnets.
 1. Validators upgrade their nodes to the new binary, on [Arabica devnet](./arabica-devnet.md), [Mocha testnet](./mocha-testnet.md), and finally on Celestia [Mainnet Beta](./mainnet.md).
     - Upgrades using pre-programmed height (v2) activate at a predetermined block number.
-    - Upgrades using in-protocol signaling (v3+) activate one week after 5/6 of the voting power has signaled for a particular version
+    - Upgrades using in-protocol signaling (v3+) activate two weeks after 5/6 of the voting power has signaled for a particular version
 
 ### Upcoming upgrade
 
@@ -38,7 +38,7 @@ Key features include:
 - [CIP-27](https://cips.celestia.org/cip-27.html): Block limits for number of PFBs and non-PFBs
 - [CIP-28](https://cips.celestia.org/cip-28.html): Transaction size limit
 
-Unlike the Lemongrass upgrade, there will not be a pre-programmed upgrade height. Instead, validators will signal their readiness for v3 through in-protocol signaling, and the upgrade will automatically activate one week after 5/6 of voting power have signaled for a particular version.
+Unlike the Lemongrass upgrade, there will not be a pre-programmed upgrade height. Instead, validators will signal their readiness for v3 through in-protocol signaling, and the upgrade will automatically activate two weeks after 5/6 of voting power have signaled for a particular version.
 
 :::info
 Validators should ensure they are running a v3 binary before signaling support for the upgrade.


### PR DESCRIPTION
Temp hotfix for 2 weeks upgrade timeline

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Celestia network upgrade process document to reflect a new activation timeline, now set to two weeks after quorum signaling.
	- Clarified details regarding the upcoming Ginger network upgrade and its use of the new in-protocol signaling mechanism.
	- Maintained the overall structure while emphasizing coordination and implementation of network upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->