### PR TITLE
Typo corrections

### DIFF
--- a/tutorials/golang-client-tutorial.md
+++ b/tutorials/golang-client-tutorial.md
@@ -1,6 +1,6 @@
 # Golang client library tutorial {#golang-client-library}
 
-This section tutorial will guide you through using the most common RPC endpoints with the golang client library.
+This tutorial section will guide you through using the most common RPC endpoints with the golang client library.
 
 Install [dependencies](../how-to-guides/environment.md) and
 [celestia-node](../how-to-guides/celestia-node.md) if you have

--- a/tutorials/integrate-celestia.md
+++ b/tutorials/integrate-celestia.md
@@ -12,7 +12,7 @@ explorers, integrating the Celestia network.
 
 ## Getting started
 
-When getting started Celestia, we recommend checking out these resources first:
+When getting started with Celestia, we recommend checking out these resources first:
 
 - [Introduction to Celestia](../learn/how-celestia-works/overview.md)
 - [Monolithic v. Modular](../learn/how-celestia-works/monolithic-vs-modular.md)

--- a/tutorials/prompt-scavenger.md
+++ b/tutorials/prompt-scavenger.md
@@ -80,7 +80,7 @@ Make sure you run this command in a different terminal window because the node h
 ### OpenAI key
 
 Visit [OpenAI](https://platform.openai.com/) to sign up for an account and generate an API key.
-order to sign up for an account and generate an OpenAI API key.
+In order to sign up for an account and generate an OpenAI API key.
 The key will be needed to communicate with OpenAI.
 
 Once you have created an API key, set it as an environment variable with the following command, pasting in your own key:

--- a/tutorials/rust-client-tutorial.md
+++ b/tutorials/rust-client-tutorial.md
@@ -6,7 +6,7 @@ next:
 
 # Rust client library tutorial {#rust-client-library}
 
-This section tutorial will guide you through using the most common RPC endpoints with [Lumina](https://github.com/eigerco/lumina/tree/main/rpc)'s rust client library.
+This tutorial section will guide you through using the most common RPC endpoints with [Lumina](https://github.com/eigerco/lumina/tree/main/rpc)'s rust client library.
 
 Install [dependencies](../how-to-guides/environment.md) and
 [celestia-node](../how-to-guides/celestia-node.md) if you have


### PR DESCRIPTION
## Overview

**Added typo corrections to documentation for the following files:**

**tutorials/golang-client-tutorial.md**

"This section tutorial will guide you" — the correct phrasing would be "This tutorial section will guide you".

The mistake is in the word order. "Section tutorial" should be rephrased as "tutorial section" or "section of the tutorial."

**tutorials/integrate-celestia.md**

"When getting started Celestia" — should be "When getting started with Celestia".

The word "with" is missing.
The correct phrase is "getting started with Celestia."

**tutorials/prompt-scavenger.md**

"order to sign up for an account and generate an OpenAI API key."

This sentence has an extra "order" at the beginning. It should be: "In order to sign up for an account and generate an OpenAI API key."

**tutorials/rust-client-tutorial.md**

"This section tutorial will guide you through using the most common RPC endpoints with..."
The word "section" is incorrect here. It should be:

"This tutorial section will guide you through using the most common RPC endpoints with..."
This change ensures the sentence flows correctly and makes more sense grammatically.

### The purpose of corrections

Correct grammatical errors and improve readability of the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a tutorial for "Prompt Scavenger," detailing setup and interaction with Celestia’s Node API and OpenAI’s GPT-3.5.
  
- **Improvements**
	- Updated titles and introductory texts in the Golang and Rust client tutorials for clarity.
	- Enhanced readability in the "Integrate Celestia for service providers" document.
  
- **Bug Fixes**
	- Minor grammatical corrections across various tutorials for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->