### PR TITLE
Typo Update foundation-delegation-program.md

### DIFF
--- a/community/foundation-delegation-program.md
+++ b/community/foundation-delegation-program.md
@@ -40,7 +40,7 @@ process will work for Cohort 1 and what that means for future cohorts.
 
 * Initial Cohort (Cohort 1): 50 applicants will be accepted
   * Grading System: Applicants in Cohort 1 are divided into first, second,
-  and third place based eligibility criteria outlined in this document.
+  and third place based on eligibility criteria outlined in this document.
   * Delegation Duration: This varies based on the applicant’s placement in
   Cohort 1. First place receives 12 months of delegation, second place receives
   8 months, third place receives 4 months.


### PR DESCRIPTION
## Overview

It is better to write "**based on eligibility criteria**" because the phrase "based eligibility criteria" is grammatically incomplete. The word "based" requires a preposition, and in this case, "on" is necessary to link the action ("based") with what it is based on (the "eligibility criteria"). The phrase "based on eligibility criteria" provides clearer meaning and maintains grammatical correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and structure of the Celestia Foundation Delegation Program document.
	- Specified launch date for prospective validators as February 6, 2024.
	- Clarified application review process and cohort distribution of stakes.
	- Reformatted eligibility criteria for better readability.
	- Detailed application process and required information for applicants.
	- Updated timeline for future cohort application openings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->