### PR TITLE
add op stack walkthrough to docs

### DIFF
--- a/how-to-guides/optimism.md
+++ b/how-to-guides/optimism.md
@@ -11,6 +11,16 @@ import constants from '/.vitepress/constants/constants.js'
 
 This guide will show you how to run your own OP Stack devnet and testnet that posts data to Celestia's Mocha testnet using [roll-op](https://github.com/celestiaorg/roll-op) and [op-plasma-celestia](https://github.com/celestiaorg/op-plasma-celestia).
 
+The roll-op tool is used to deploy and manage the OP Stack rollup environment, including the rollup, batcher, and other components. While the op-plasma-celestia integration allows the OP Stack to utilize Celestia's Mocha testnet as the data availability (DA) layer.
+
+This guide is in two parts:
+
+- First, you'll spin up a mock L1 environment and deploy a devnet that posts data to the Mocha testnet. 
+
+- In the second part, you'll deploy a testnet that posts data to the Mocha testnet, but this time on a real L1 environment; the Ethereum Sepolia testnet. This will involve setting up a configuration file with the necessary details like Sepolia chain ID, RPC URL, and your deployment keys.
+
+After successful deployments, you'll be able to observe data blobs being successfully submitted to the Mocha testnet in the logs, as well as some activity on your rollup account on [Celenium](celenium.io).
+
 If you don't have devops experience and would like to use a Rollups as a Service (RaaS) provider, see the RaaS category in the menu.
 
 ## Dependency setup

--- a/how-to-guides/optimism.md
+++ b/how-to-guides/optimism.md
@@ -11,17 +11,18 @@ import constants from '/.vitepress/constants/constants.js'
 
 This guide will show you how to run your own OP Stack devnet and testnet that posts data to Celestia's Mocha testnet using [roll-op](https://github.com/celestiaorg/roll-op) and [op-plasma-celestia](https://github.com/celestiaorg/op-plasma-celestia).
 
-The roll-op tool is used to deploy and manage the OP Stack rollup environment, including the rollup, batcher, and other components. While the op-plasma-celestia integration allows the OP Stack to utilize Celestia's Mocha testnet as the data availability (DA) layer.
+The roll-op tool is used to deploy and manage the OP Stack rollup environment, including the rollup, batcher, and other components. While the op-plasma-celestia integration allows the OP Stack to use Celestia as the data availability (DA) layer.
 
 This guide is in two parts:
 
-- First, you'll spin up a mock L1 environment and deploy a devnet that posts data to the Mocha testnet. 
-
+- First, you'll spin up a mock L1 environment and deploy a devnet that posts data to the Mocha testnet.
 - In the second part, you'll deploy a testnet that posts data to the Mocha testnet, but this time on a real L1 environment; the Ethereum Sepolia testnet. This will involve setting up a configuration file with the necessary details like Sepolia chain ID, RPC URL, and your deployment keys.
 
 After successful deployments, you'll be able to observe data blobs being successfully submitted to the Mocha testnet in the logs, as well as some activity on your rollup account on [Celenium](https://celenium.io).
 
 If you don't have devops experience and would like to use a Rollups as a Service (RaaS) provider, see the RaaS category in the menu.
+
+This guide is also available on [YouTube](https://www.youtube.com/watch?v=lOLw4uLX644) if you'd like to follow along with a video.
 
 ## Dependency setup
 

--- a/how-to-guides/optimism.md
+++ b/how-to-guides/optimism.md
@@ -19,7 +19,7 @@ This guide is in two parts:
 
 - In the second part, you'll deploy a testnet that posts data to the Mocha testnet, but this time on a real L1 environment; the Ethereum Sepolia testnet. This will involve setting up a configuration file with the necessary details like Sepolia chain ID, RPC URL, and your deployment keys.
 
-After successful deployments, you'll be able to observe data blobs being successfully submitted to the Mocha testnet in the logs, as well as some activity on your rollup account on [Celenium](celenium.io).
+After successful deployments, you'll be able to observe data blobs being successfully submitted to the Mocha testnet in the logs, as well as some activity on your rollup account on [Celenium](https://celenium.io).
 
 If you don't have devops experience and would like to use a Rollups as a Service (RaaS) provider, see the RaaS category in the menu.
 


### PR DESCRIPTION
closes #1705


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced guide for running an OP Stack rollup with Celestia, including detailed sections on mock L1 environment and real L1 testnet deployment.
	- Added instructions for observing data submissions and account activity.
	- Included setup tips for macOS users and expanded deployment instructions with relevant links.
	- Added a link to a YouTube video for visual guidance.

- **Documentation**
	- Updated configuration requirements for testnet setup, including chain ID, RPC URL, and deployment keys.
	- Clarified configuration example for deploying to a live EVM network, including specific parameters for the rollup and Sepolia Ethereum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->