### PR TITLE
Typo Update how-to-stake-tia.md

### DIFF
--- a/learn/how-to-stake-tia.md
+++ b/learn/how-to-stake-tia.md
@@ -106,9 +106,9 @@ Navigate to `Celestia` and select `Stake`.
 
 ![Gem1](/img/gem/gem1.gif)
 
-### :two: Choose the amount of Celestia and search for a validator.
+### :two: Choose the amount of TIA and search for a validator.
 
-Select the amount of Celestia tokens and choose a validator from the list.
+Select the amount of TIA tokens and choose a validator from the list.
 
 ![Gem2](/img/gem/gem2.gif)
 


### PR DESCRIPTION
**Description**: 

This PR addresses a typo in the staking tutorial where "Celestia" was incorrectly used when referring to the staking amount in the Gem Wallet section.

### Issue:
The sentence:  
> "Choose the amount of Celestia and search for a validator."

is incorrect because it refers to the wrong token. The tutorial is about staking **TIA tokens**, not Celestia.

### Correction:
The sentence has been corrected to:  
> "Choose the amount of **TIA** and search for a validator."

This change is important to ensure accuracy in the tutorial, as users might be confused by the incorrect mention of "Celestia" when it should refer to "TIA", the native token for staking.

---

This pull request improves clarity and ensures the tutorial is aligned with the correct terminology for staking **TIA** tokens.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated terminology in the staking tutorial to consistently use "TIA" instead of "Celestia."
	- Made minor formatting adjustments for improved clarity and uniformity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->