### PR TITLE
docs: change build-whatever page to rollup-stacks

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -233,7 +233,7 @@ function nav() {
       items: [
         { text: "Learn", link: "/learn/how-celestia-works/overview" },
         { text: "Quick start", link: "/how-to-guides/quick-start" },
-        { text: "Build whatever", link: "/how-to-guides/build-whatever" },
+        { text: "Rollup stacks", link: "/how-to-guides/rollup-stacks" },
         {
           text: "Resources",
           items: [
@@ -535,12 +535,12 @@ function sidebarHome() {
           ],
         },
         {
-          text: "Build whatever",
+          text: "Rollup stacks",
           collapsed: true,
           items: [
             {
               text: "Overview",
-              link: "/how-to-guides/build-whatever",
+              link: "/how-to-guides/rollup-stacks",
             },
             {
               text: "EVM",

--- a/how-to-guides/quick-start.md
+++ b/how-to-guides/quick-start.md
@@ -277,6 +277,6 @@ If you run into issues, check out the [troubleshooting](./celestia-node-troubles
 
 ## Next steps
 
-Check out the [build whatever page](./build-whatever.md) to get started learning about ways to build with Celestia underneath.
+Check out the [rollup stacks page](./rollup-stacks.md) to get started learning about ways to build whatever with Celestia underneath.
 
 Head to the next page to learn about different node types for the consensus and DA networks.

--- a/how-to-guides/rollup-stacks.md
+++ b/how-to-guides/rollup-stacks.md
@@ -2,7 +2,7 @@
 description: Advantages of building on modular blockchains like Celestia.
 ---
 
-# Build whatever
+# Rollup stacks
 
 If you're a developer and want to know what the benefits of modular blockchains
 are for you, you’ve come to the right place. This page will give you the rundown on modular
@@ -26,7 +26,6 @@ Here are a few options that are currently available for developers.
 <div style="display: flex; flex-wrap: wrap; justify-content: center; align-items: center; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 20px;">
   <UrlImageButton url="/how-to-guides/intro-to-op-stack" imageSrc="/build/opstack.webp" text="OP Stack" notes="EVM" target="_self" alt="OP Stack logo" aria-label="OP Stack"/>
   <UrlImageButton url="/how-to-guides/arbitrum-integration" imageSrc="/build/arbitrum.webp" text="Arbitrum Orbit" notes="EVM" target="_self" alt="Arbitrum logo" aria-label="Arbitrum"/>
-  <!-- <UrlImageButton url="/how-to-guides/build-whatever" imageSrc="/build/polygon.webp" text="Polygon CDK" target="_self" notes="EVM: Coming soon" alt="Polygon logo" aria-label="Polygon"/> -->
   <UrlImageButton url="https://github.com/Sovereign-Labs/sovereign-sdk/tree/stable/examples/demo-rollup#demo-rollup" imageSrc="/build/sovereign.webp" text="Sovereign SDK" notes="Sovereign" alt="Sovereign logo" aria-label="Sovereign"/>
   <UrlImageButton url="https://docs.dymension.xyz/" imageSrc="/build/dymension.webp" text="Dymension" alt="Dymension logo" aria-label="Dymension"/>
   <UrlImageButton url="https://docs.stf.xyz" imageSrc="/build/stackr.webp" text="Stackr" alt="Stackr logo" aria-label="Stackr"/>

--- a/tutorials/integrate-celestia.md
+++ b/tutorials/integrate-celestia.md
@@ -19,7 +19,7 @@ When getting started with Celestia, we recommend checking out these resources fi
 - [Celestia's DA Layer](../learn/how-celestia-works/data-availability-layer.md)
 - [Learn modular](https://celestia.org/learn)
 - [Overview to running nodes on Celestia](../how-to-guides/nodes-overview.md)
-- [Build whatever](./build-whatever.md)
+- [Rollup stacks](./rollup-stacks.md)
 
 ## Celestia service provider notes
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves #1799 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Navigation item renamed from "Build whatever" to "Rollup stacks," with updated links.
	- Expanded sidebar section on "Rollup stacks" with detailed sub-items related to various rollup technologies.
  
- **Documentation**
	- Enhanced clarity in `quick-start.md` with updated commands and references.
	- Reorganized `rollup-stacks.md` to focus on modular blockchains and their benefits for developers.
	- Updated `integrate-celestia.md` to clarify the target audience as service providers and revised relevant links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->