### PR TITLE
Documentation Grammar and Spelling Standardization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We love contributions from the community! Whether you're fixing typos,
 improving content clarity, or adding new topics, every contribution helps.
 
 - Fork & clone: Fork this repository and clone it to your local machine.
-- Branch: Always create a new branch for your changes. Naming it relevantly.
+- Branch: Always create a new branch for your changes. Name it relevantly.
 - Commit Changes: Make your changes and commit them with a clear and concise
   commit message.
 - Push & Create PR: Push your changes to your fork and create a pull request

--- a/how-to-guides/blobstream.md
+++ b/how-to-guides/blobstream.md
@@ -13,7 +13,7 @@ is the first data availability solution for Ethereum that securely
 scales with the number of users. Formerly known as the [Quantum Gravity Bridge (QGB)](https://blog.celestia.org/celestiums/),
 Blobstream relays commitments to Celestia's data root to an onchain light client
 on Ethereum, for integration by developers into L2 contracts. This enables Ethereum
-developers to build high-throughput L2s using Celestia's optimised DA layer,
+developers to build high-throughput L2s using Celestia's optimized DA layer,
 the first with Data Availability Sampling (DAS). Any ecosystem can deploy a
 Blobstream light client onchain to allow L2s and L3s to access DA from Celestia.
 

--- a/how-to-guides/systemd.md
+++ b/how-to-guides/systemd.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to setup your node as a background process with SystemD.
+description: Learn how to set up your node as a background process with SystemD.
 ---
 
 # Setting up your node as a background process with SystemD


### PR DESCRIPTION
1. File: README.md
Old: Branch: Always create a new branch for your changes. Naming it relevantly.
New: Branch: Always create a new branch for your changes. Name it relevantly.
Reason: Fixed to use proper imperative form in instructions. The imperative form is standard for command instructions and maintains consistency with other documentation guidelines.

2. File: how-to-guides/blobstream.md
Old: developers to build high-throughput L2s using Celestia's optimised DA layer,
New: developers to build high-throughput L2s using Celestia's optimized DA layer,
Reason: Standardized to American English spelling. The project follows American English conventions throughout its documentation for consistency.

3. File: how-to-guides/systemd.md
Old: description: Learn how to setup your node as a background process with SystemD.
New: description: Learn how to set up your node as a background process with SystemD.
Reason: Corrected the usage of "set up" (verb) versus "setup" (noun). When used as a verb phrase, it should be two words.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated contribution guidelines for clarity in the README.md.
	- Enhanced clarity and terminology in the blobstream.md, including expanded sections on functionalities and integration for developers.
	- Corrected phrasing in systemd.md to improve readability while maintaining existing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->