### PR TITLE
docs: add v3 release notes to ginger upgrade section

### DIFF
--- a/how-to-guides/network-upgrade-process.md
+++ b/how-to-guides/network-upgrade-process.md
@@ -38,9 +38,9 @@ Key features include:
 - [CIP-27](https://cips.celestia.org/cip-27.html): Block limits for number of PFBs and non-PFBs
 - [CIP-28](https://cips.celestia.org/cip-28.html): Transaction size limit
 
-Learn more in the [v3.0.0 release notes](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md#v300).
-
 Unlike the Lemongrass upgrade, there will not be a pre-programmed upgrade height. Instead, validators will signal their readiness for v3 through in-protocol signaling, and the upgrade will automatically activate one week after 5/6 of voting power have signaled for a particular version.
+
+Learn more in the [v3.0.0 release notes](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md#v300).
 
 :::info
 Validators should ensure they are running a v3 binary before signaling support for the upgrade.

--- a/how-to-guides/network-upgrade-process.md
+++ b/how-to-guides/network-upgrade-process.md
@@ -38,6 +38,8 @@ Key features include:
 - [CIP-27](https://cips.celestia.org/cip-27.html): Block limits for number of PFBs and non-PFBs
 - [CIP-28](https://cips.celestia.org/cip-28.html): Transaction size limit
 
+Learn more in the [v3.0.0 release notes](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md#v300).
+
 Unlike the Lemongrass upgrade, there will not be a pre-programmed upgrade height. Instead, validators will signal their readiness for v3 through in-protocol signaling, and the upgrade will automatically activate one week after 5/6 of voting power have signaled for a particular version.
 
 :::info


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the guide on the Celestia network upgrade process, clarifying the distinction between breaking and non-breaking upgrades.
	- Expanded details on network upgrade coordination methods, including "Pre-programmed height" and "In-protocol signaling."
	- Introduced the upcoming Ginger network upgrade, highlighting its key features and the importance of using the correct binary.
	- Added warnings and informational notes for validators regarding the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->