### PR TITLE
Fix: Update broken links in documentation

### DIFF
--- a/how-to-guides/arbitrum-deploy.md
+++ b/how-to-guides/arbitrum-deploy.md
@@ -413,7 +413,7 @@ Extra resources in Arbitrum documentation:
 | Component | Version | Details |
 |-----------|---------|---------|
 | Nitro | [v2.3.1-rc.1](https://github.com/celestiaorg/nitro/releases/tag/v2.3.1-rc.1) | Includes the replay binary for the WASM root `0x10c65b27d5031ce2351c719072e58f3153228887f027f9f6d65300d2b5b30152`. [Read the overview for overall changes](../how-to-guides/arbitrum-integration.md). |
-| Contracts | [v1.2.1-celestia](https://github.com/celestiaorg/nitro-contracts/releases/tag/v1.2.1-celestia) | Integrates Blobstream X functionality into nitro-contracts v1.2.1 |
+| Contracts | [v1.2.1](https://github.com/celestiaorg/nitro-contracts/releases/tag/v1.2.1) | Integrates Blobstream X functionality into nitro-contracts v1.2.1 |
 | Orbit SDK | [v0.8.2 Orbit SDK for Celestia DA](https://github.com/celestiaorg/arbitrum-orbit-sdk/releases/tag/v0.8.2) | This is not compatible with Orbit SDK v0.8.2 or with the latest changes to nitro-contracts for the Atlas upgrade. The Orbit SDK itself is in Alpha. |
 | celestia-node | [v0.13.1](https://github.com/celestiaorg/celestia-node/releases/tag/v0.13.1) | This integration has only been tested with celestia-node 0.13.1 and only works with said version, and with future versions after that. Under the hood, the Nitro node uses [this commit](https://github.com/celestiaorg/celestia-openrpc/commit/64f04840aa97d4deb821b654b1fb59167d242bd1) of celestia-openrpc. |
 <!-- markdownlint-enable MD013 -->

--- a/how-to-guides/blobstream-offchain.md
+++ b/how-to-guides/blobstream-offchain.md
@@ -179,7 +179,7 @@ proof used to verify state. Find more information in the
 Also, see the documentation for the
 [data square layout](https://github.com/celestiaorg/celestia-app/blob/v1.1.0/specs/src/specs/data_square_layout.md)
 and the
-[shares](https://github.com/celestiaorg/celestia-app/blob/main/specs/src/specs/shares.md)
+[shares](https://github.com/celestiaorg/celestia-app/blob/main/specs/src/shares.md)
 of the Celestia block to see how the data is encoded in Celestia.
 
 ### Creating blocks

--- a/how-to-guides/blobstream.md
+++ b/how-to-guides/blobstream.md
@@ -116,7 +116,7 @@ along with code for:
 
 - [The SP1 Blobstream smart contract - `SP1Blobstream.sol`](https://github.com/succinctlabs/sp1-blobstream/blob/main/contracts/src/SP1Blobstream.sol)
 - [The SP1 program](https://github.com/succinctlabs/sp1-blobstream/tree/main/program)
-- [The SP1 Blobstream contract Golang bindings](//TODO)
+- [The SP1 Blobstream contract Golang bindings](https://github.com/succinctlabs/sp1-blobstream/blob/main/bindings/SP1Blobstream.go)
 
 The first deployments of SP1 Blobstream will be maintained on the
 following chains: Arbitrum One, Base and Ethereum Mainnet. Every 1

--- a/how-to-guides/celestia-node.md
+++ b/how-to-guides/celestia-node.md
@@ -144,7 +144,7 @@ View [the script](https://github.com/celestiaorg/docs/tree/main/public/celestia-
 
 ## Next steps
 
-First, we recommend [reading the overview](./overview.md)
+First, we recommend [reading the overview](./nodes-overview.md)
 of our node types, if you haven't yet.
 
 Now that you've installed Celestia Node, it's time to

--- a/how-to-guides/decide-node.md
+++ b/how-to-guides/decide-node.md
@@ -23,7 +23,7 @@ or a [full DA node](./full-storage-node.md).
 ## Consensus node
 
 If you are looking to run a consensus node, please follow the
-[tutorial for running a consensus node](./full-consensus-node.md).
+[tutorial for running a consensus node](./consensus-node.md).
 
 Note that running a validator means you must also run a bridge node,
 which is covered in [this section](./bridge-node.md).

--- a/how-to-guides/feegrant-for-blobs.md
+++ b/how-to-guides/feegrant-for-blobs.md
@@ -24,7 +24,7 @@ a DA node's (grantee) account. You will need one account that will
 contain the funds, the granter, and another account that will be in the
 DA node you run to post blobs, the grantee. You will see the DA node's account
 once you initialize the node. Learn more about managing accounts with
-`cel-key` in [create a wallet with celestia-node](./celestia-node-key#create-a-wallet-with-celestia-node).
+`cel-key` in [create a wallet with celestia-node](../tutorials/celestia-node-key.md#create-a-wallet-with-celestia-node).
 
 ## Granting fee allowances using celestia-node
 


### PR DESCRIPTION
This pull request addresses the issue of broken links in the documentation. I replaced non-functional links with verified working ones. Before making the replacements, I tested the old links to confirm they were broken. These changes enhance the accuracy and usability of the documentation.

Each link was reviewed and updated to point to the correct and functional resource.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Documentation Updates**
  - Enhanced clarity and detail in deployment guides for Arbitrum and Blobstream integration.
  - Updated prerequisites and setup instructions for deploying on the Celestia Orbit chain.
  - Added sections on WebSocket connections and configuration for light nodes.
  - Improved links and structured guidance for integrating with Blobstream and FeeGrant module.
  - Expanded compatibility matrix and clarified roles in the Blobstream architecture.

These updates aim to provide users with comprehensive and accessible resources for effective deployment and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->