### PR TITLE
Update mocha-testnet.md

### DIFF
--- a/how-to-guides/mocha-testnet.md
+++ b/how-to-guides/mocha-testnet.md
@@ -126,6 +126,7 @@ Celestia network. The default port is 26657.
 - `rpc-2.testnet.celestia.nodes.guru`
 - `celestia-testnet-rpc.itrocket.net:443`
 - `rpc-celestia-testnet.cryptech.com.ua:443`
+- `celestia-t-rpc.noders.services`
 
 ## Community API endpoints
 
@@ -147,6 +148,7 @@ The default port is 1317.
 - [https://api-2.testnet.celestia.nodes.guru](https://api-2.testnet.celestia.nodes.guru)
 - [https://celestia-testnet-api.itrocket.net](https://celestia-testnet-api.itrocket.net)
 - [https://api-celestia-testnet.cryptech.com.ua](https://api-celestia-testnet.cryptech.com.ua)
+- [https://celestia-t-api.noders.services](https://celestia-t-api.noders.services)
 
 ## Community gRPC endpoints
 
@@ -171,6 +173,7 @@ broadcast transactions.
 - `grpc-2.testnet.celestia.nodes.guru:10790`
 - `celestia-testnet-grpc.itrocket.net:443`
 - `grpc-celestia-testnet.cryptech.com.ua:443`
+- `celestia-t-grpc.noders.services:21090`
 
 ## Community bridge and full node endpoints
 


### PR DESCRIPTION
add NODERS endpoints

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new community RPC, API, and gRPC endpoints for the Mocha testnet.
		- RPC: `celestia-t-rpc.noders.services`
		- API: `https://celestia-t-api.noders.services`
		- gRPC: `celestia-t-grpc.noders.services:21090`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->