### PR TITLE
Update documentation link in rollup-stacks.md

### DIFF
--- a/how-to-guides/rollup-stacks.md
+++ b/how-to-guides/rollup-stacks.md
@@ -86,7 +86,7 @@ any monolithic chain. But, the data of those transactions get sent to a
 layer 1 blockchain to carry out the remaining functions.
 
 If you want to brush up on your understanding of modular blockchains,
-head over to [learn modular](https://celestia.org/learn/).
+head over to [learn modular](https://docs.celestia.org/learn/how-celestia-works/monolithic-vs-modular).
 
 ## Benefits of modular blockchains
 

--- a/how-to-guides/rollup-stacks.md
+++ b/how-to-guides/rollup-stacks.md
@@ -86,7 +86,7 @@ any monolithic chain. But, the data of those transactions get sent to a
 layer 1 blockchain to carry out the remaining functions.
 
 If you want to brush up on your understanding of modular blockchains,
-head over to [learn modular](https://docs.celestia.org/learn/how-celestia-works/monolithic-vs-modular).
+head over to [learn modular](../learn/how-celestia-works/monolithic-vs-modular).
 
 ## Benefits of modular blockchains
 


### PR DESCRIPTION
Changes:
Old: head over to [learn modular] https://celestia.org/learn/
New: head over to [learn modular] https://docs.celestia.org/learn/how-celestia-works/monolithic-vs-modular

Reason:
- Fixed broken link
- Added direct link to modular vs monolithic comparison documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated hyperlink in the "What is a modular blockchain?" section for improved resource accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->