### PR TITLE
Update quick-start.md

### DIFF
--- a/how-to-guides/quick-start.md
+++ b/how-to-guides/quick-start.md
@@ -173,7 +173,7 @@ Feeling creative? Post your favorite quote and [share it on Twitter](https://x.c
 celestia blob submit 0x71756f746573 '"Simplicity is the ultimate sophistication." -Leonardo da Vinci'
 ```
 
-Once you run this command, you'll see a height and data committment in the response. This means your data has been successfully posted to the network!
+Once you run this command, you'll see a height and data commitment in the response. This means your data has been successfully posted to the network!
 
 ```bash
 {


### PR DESCRIPTION
Update with fixing minor typo at the [Quick-start guide](https://docs.celestia.org/how-to-guides/quick-start) docs page.

updated word from "**committment**" to "**commitment**" .

![image](https://github.com/user-attachments/assets/16e41ace-0bc8-4d12-9e46-879127027b6a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a spelling error in the quick-start guide, correcting "committment" to "commitment"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->