### PR TITLE
Documentation grammar improvements in Mocha testnet guide

### DIFF
--- a/how-to-guides/mocha-testnet.md
+++ b/how-to-guides/mocha-testnet.md
@@ -243,7 +243,7 @@ There are several explorers you can use for Mocha:
 
 ## Network upgrades
 
-There are a few ways to stay informed about network upgrades on Mocha testnet:
+There are a few ways to stay informed about network upgrades on the Mocha testnet:
 
 - Telegram [announcement channel](https://t.me/+smSFIA7XXLU4MjJh)
 - Discord [Mocha announcements](https://discord.com/channels/638338779505229824/979037494735691816)

--- a/how-to-guides/optimism.md
+++ b/how-to-guides/optimism.md
@@ -78,7 +78,7 @@ Congrats! Your devnet is running on a mock EVM chain and Celestia Mocha.
 See [the Alt-DA x Celestia README](https://github.com/celestiaorg/op-plasma-celestia/blob/main/README.md) for instructions on [how to deploy a Testnet](https://github.com/celestiaorg/op-plasma-celestia/blob/main/README.md#testnet).
 
 :::tip
-If you are using a public RPC for your EVM chain, you should to enable `deploy_slowly = true` in your `config.toml`. If you still have issues, we recommend running the
+If you are using a public RPC for your EVM chain, you should enable `deploy_slowly = true` in your `config.toml`. If you still have issues, we recommend running the
 integration with a high-availability, paid endpoint.
 :::
 


### PR DESCRIPTION


Changes in how-to-guides/mocha-testnet.md:

1. Removed unnecessary "to":
- If you are using a public RPC for your EVM chain, you should to enable
+ If you are using a public RPC for your EVM chain, you should enable

2. Added missing article:
- network upgrades on Mocha testnet
+ network upgrades on the Mocha testnet

Reason: Improved grammar and readability while maintaining technical accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Minor grammatical corrections in Mocha testnet and Optimism how-to guides
	- Improved text clarity by fixing wording and adding definite articles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->