### PR TITLE
feat: make sidebar menu medium font weight

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -159,12 +159,20 @@ body {
   font-family: var(--font-body);
 }
 
-.VPSidebarItem.level-1 .text,
-.VPSidebarItem.level-2 .text,
-.VPSidebarItem.level-3 .text {
-  font-weight: 300 !important;
+.VPSidebar {
+  font-family: var(--font-body) !important;
+}
+
+.VPSidebarItem .text,
+.VPSidebarGroup .title,
+.VPSidebarGroup .items,
+.VPSidebarGroup .VPLink,
+.VPDocAsideOutline .outline-title,
+.VPDocAsideOutline .outline-link {
+  font-family: var(--font-body) !important;
+  font-weight: 400 !important;
 }
 
 .VPSidebarItem.is-active .text {
-  color: var(--vp-c-brand); 
+  color: var(--vp-c-brand);
 }

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -158,3 +158,13 @@ body {
 .VPHome {
   font-family: var(--font-body);
 }
+
+.VPSidebarItem.level-1 .text,
+.VPSidebarItem.level-2 .text,
+.VPSidebarItem.level-3 .text {
+  font-weight: normal !important;
+}
+
+.VPSidebarItem.is-active .text {
+  color: var(--vp-c-brand); 
+}

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -162,7 +162,7 @@ body {
 .VPSidebarItem.level-1 .text,
 .VPSidebarItem.level-2 .text,
 .VPSidebarItem.level-3 .text {
-  font-weight: normal !important;
+  font-weight: 300 !important;
 }
 
 .VPSidebarItem.is-active .text {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Modifies the font weight on sidebar, making it look less bold.
Update:
<img width="254" alt="Screenshot 2025-01-09 at 13 31 38" src="https://github.com/user-attachments/assets/46413207-c7a2-4dc6-bafe-b530bcf2f1c6" />

Original:
![image](https://github.com/user-attachments/assets/64dc9f6c-b4d4-44ce-be42-ac388471300d)


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated sidebar item styling with consistent font family and weight across different levels
	- Enhanced active sidebar item appearance with brand color text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->