### PR TITLE
Add Lava RPC Endpoints to Mainnet Beta and Mocha Testnet Documentation

### DIFF
--- a/how-to-guides/mainnet.md
+++ b/how-to-guides/mainnet.md
@@ -172,6 +172,8 @@ on [service providers with SLAs](#production-rpc-endpoints).
 - `celestia-api.chainode.tech`
 - `celestia-mainnet-api.itrocket.net:443`
 - `celestia-api.noders.services`
+- `celestia.rest.lava.build`
+
 
 #### Community gRPC endpoints
 
@@ -192,6 +194,8 @@ on [service providers with SLAs](#production-rpc-endpoints).
 - `celestia-grpc.chainode.tech:443`
 - `celestia-mainnet-grpc.itrocket.net:443`
 - `celestia-grpc.noders.services:11090`
+- `celestia.grpc.lava.build:443`
+
 
 #### Community WebSocket endpoints
 

--- a/how-to-guides/mocha-testnet.md
+++ b/how-to-guides/mocha-testnet.md
@@ -149,6 +149,7 @@ The default port is 1317.
 - [https://celestia-testnet-api.itrocket.net](https://celestia-testnet-api.itrocket.net)
 - [https://api-celestia-testnet.cryptech.com.ua](https://api-celestia-testnet.cryptech.com.ua)
 - [https://celestia-t-api.noders.services](https://celestia-t-api.noders.services)
+- [http://celestiam.rest.lava.build](http://celestiam.rest.lava.build)
 
 ## Community gRPC endpoints
 
@@ -174,6 +175,16 @@ broadcast transactions.
 - `celestia-testnet-grpc.itrocket.net:443`
 - `grpc-celestia-testnet.cryptech.com.ua:443`
 - `celestia-t-grpc.noders.services:21090`
+- `celestiam.grpc.lava.build:443`
+
+## Community JSON-RPC Endpoints
+
+- `celestiam.jsonrpc.lava.build`
+
+## Community Tendermint RPC Endpoints
+
+- `celestiam.tendermintrpc.lava.build`
+
 
 ## Community bridge and full node endpoints
 


### PR DESCRIPTION
# Add Lava RPC Endpoints to Mainnet Beta and Mocha Testnet Documentation

This pull request updates the documentation for both **Mainnet Beta** and **Mocha Testnet** to include new RPC endpoints provided by [Lava](https://www.lavanet.xyz/). 

## Mainnet Beta

1. **Community JSON-RPC Endpoints**
   - Added a new section with the endpoint `celestia.jsonrpc.lava.build`.

2. **Community Tendermint RPC Endpoints**
   - Added a new section with the endpoint `celestia.tendermintrpc.lava.build`.

3. **Community API Endpoints**
   - Added `celestia.rest.lava.build` to the existing list.

4. **Community gRPC Endpoints**
   - Added `celestia.grpc.lava.build:443` to the existing list.

---

## Mocha Testnet

1. **Community JSON-RPC Endpoints**
   - Added a new section with the endpoint `celestiam.jsonrpc.lava.build`.

2. **Community Tendermint RPC Endpoints**
   - Added a new section with the endpoint `celestiam.tendermintrpc.lava.build`.

3. **Community API Endpoints**
   - Added `celestiam.rest.lava.build` to the existing list.

4. **Community gRPC Endpoints**
   - Added `celestiam.grpc.lava.build:443` to the existing list.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new community endpoints for Celestia Mainnet Beta
  - Added multiple community RPC endpoints for Mocha Testnet, including:
    - REST API
    - gRPC
    - JSON-RPC
    - Tendermint RPC endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->