### PR TITLE
Fix broken internal links and some 404s

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ improving content clarity, or adding new topics, every contribution helps.
 Please ensure to review the detailed Contribution Guidelines above before
 making a pull request.
 
+### Link Format Guidelines
+
+When adding internal links to documentation, please use the following format:
+`[link text](/base-working-dir/subdir/page.md#section-id)`, i.e. `[link text](/how-to-guides/quick-start.md#get-your-auth-token)`
+
+This format ensures long-term compatibility and consistent behavior across different platforms and documentation builds.
+
 ## Directory Structure
 
 - /learn: A category for learning about Celestia.

--- a/how-to-guides/arabica-devnet.md
+++ b/how-to-guides/arabica-devnet.md
@@ -175,7 +175,6 @@ There are multiple explorers you can use for Arabica:
 
 - [https://arabica.celenium.io](https://arabica.celenium.io)
 - [https://explorer.celestia-arabica-11.com](https://explorer.celestia-arabica-11.com)
-- [https://celestiascan.com](https://celestiascan.com)
 
 ## Network upgrades
 

--- a/how-to-guides/arbitrum-integration.md
+++ b/how-to-guides/arbitrum-integration.md
@@ -47,7 +47,7 @@ Then the `Read` logic takes care of taking the deserialized Blob Pointer struct 
 
 The following represents a non-exhaustive list of considerations when running a Batch Poster node for a chain with Celestia underneath:
 - You will need to use a consensus node RPC endpoint, you can
-[find a list of them for Mocha](../how-to-guides/mocha-testnet#community-rpc-endpoints)
+[find a list of them for Mocha](../how-to-guides/mocha-testnet.md#community-rpc-endpoints)
 - The Batch Poster will only post a Celestia batch to the underlying chain if the height for which it posted is in a recent range in BlobstreamX and if the verification succeeds, otherwise it will discard the batch. Since it will wait until a range is relayed, it can take several minutes for a batch to be posted, but one can always make an on-chain request for the BlobstreamX contract to relay a header promptly.
 
 The following represents a non-exhaustive list of considerations when running a Nitro node for a chain with Celestia underneath:

--- a/how-to-guides/bridge-node.md
+++ b/how-to-guides/bridge-node.md
@@ -84,7 +84,7 @@ add the port after the IP address or use the
 port if you prefer.
 
 Refer to
-[the ports section of the celestia-node troubleshooting page](../how-to-guides/celestia-node-troubleshooting.md#ports)
+[the ports section of the celestia-node troubleshooting page](/how-to-guides/celestia-node-troubleshooting.md#ports)
 for information on which ports are required to be open on your machine.
 
 Using an RPC of your own, or one from the
@@ -136,7 +136,7 @@ celestia bridge start --core.ip validator-1.celestia-arabica-11.com \
   --p2p.network arabica
 ```
 
-You can create your key for your node by [following the `cel-key` instructions](../../tutorials/celestia-node-key).
+You can create your key for your node by [following the `cel-key` instructions](/tutorials/celestia-node-key.md).
 
 Once you start the bridge node, a wallet key will be generated for you.
 You will need to fund that address with Testnet tokens to pay for

--- a/how-to-guides/bubs-testnet.md
+++ b/how-to-guides/bubs-testnet.md
@@ -9,7 +9,7 @@ next:
 
 ![Bubs testnet](/img/Celestia_Bubs_Testnet.jpg)
 
-[Bubs Testnet](https://bubstestnet.com/) is a the first
+[Bubs Testnet](https://bubstestnet.com/) is the first
 OP Stack testnet with Celestia underneath hosted by
 [Caldera](https://caldera.xyz) with support from Celestia Labs. Bubs is dedicated to providing developers with
 an EVM-compatible execution layer to deploy their EVM applications on.

--- a/how-to-guides/bubs-testnet.md
+++ b/how-to-guides/bubs-testnet.md
@@ -37,7 +37,6 @@ execution layer, making it an ideal platform for developers looking to
 build and test applications in a setting that closely mirrors an OP Stack
 rollup on Celestia.
 
-Learn more at <https://bubs-sepolia.hub.caldera.xyz/>.
 
 ### RPC URLs
 

--- a/how-to-guides/bubs-testnet.md
+++ b/how-to-guides/bubs-testnet.md
@@ -39,4 +39,4 @@ rollup on Celestia.
 
 ## Next steps
 
-Now that you have a better understanding of the Bubs Testnet and its integration of OP Stack and Celestia, you can start exploring its capabilities.
+Now that you understand how Bubs Testnet integrated OP Stack with Celestia, you can explore current testnet options like [Gelato's Raspberry testnet](https://raas.gelato.network/rollups/details/public/opcelestia-raspberry).

--- a/how-to-guides/bubs-testnet.md
+++ b/how-to-guides/bubs-testnet.md
@@ -9,20 +9,20 @@ next:
 
 ![Bubs testnet](/img/Celestia_Bubs_Testnet.jpg)
 
-[Bubs Testnet](https://bubstestnet.com/) is the first
+[Bubs Testnet](https://bubstestnet.com/) was the first
 OP Stack testnet with Celestia underneath hosted by
-[Caldera](https://caldera.xyz) with support from Celestia Labs. Bubs is dedicated to providing developers with
+[Caldera](https://caldera.xyz) with support from Celestia Labs. Bubs was dedicated to providing developers with
 an EVM-compatible execution layer to deploy their EVM applications on.
 
 ## Built with the OP Stack and Celestia
 
-The Bubs Testnet is a testnet rollup, a modified version of
+The Bubs Testnet was a testnet rollup, a modified version of
 `optimism-bedrock` that uses Celestia as a data availability (DA)
 layer. This integration can be found in the
 [@celestiaorg/optimism repository](https://github.com/celestiaorg/optimism).
-The testnet is hosted by [Caldera](https://caldera.xyz),
+The testnet was hosted by [Caldera](https://caldera.xyz),
 who makes it easy to launch rollups with no code required.
-Bubs' data is posted to Celestia
+Bubs' data was posted to Celestia
 on the [Mocha testnet](../how-to-guides/mocha-testnet.md).
 [View the namespace for Bubs on Celestia's Mocha testnet](https://mocha-4.celenium.io/namespace/000000000000000000000000000000000000ca1de12ad45362e77e87).
 
@@ -36,41 +36,6 @@ Ethereum Virtual Machine (EVM) applications. It offers an EVM-compatible
 execution layer, making it an ideal platform for developers looking to
 build and test applications in a setting that closely mirrors an OP Stack
 rollup on Celestia.
-
-
-### RPC URLs
-
-Remote Procedure Call (RPC) URLs are endpoints that allow developers to
-interact with the blockchain. They are essential for sending transactions,
-querying blockchain data, and performing other interactions with the
-blockchain.
-
-For the Bubs Testnet, you can connect to the following RPC URLs:
-
-#### HTTPS
-
-- `https://bubs.calderachain.xyz/http`
-
-#### WSS
-
-- `wss://bubs.calderachain.xyz/ws`
-
-This URL serves as the entry point to the Bubs Testnet. You can use it
-in your applications to connect to the testnet and interact with the smart
-contracts you deploy there.
-
-Remember, Bubs Testnet is a testing environment!
-
-### Bridge
-
-Bridging is a process that enables the transfer of assets between
-different blockchains.
-
-To bridge between Ethereum Sepolia and Bubs Testnet, visit the [Bubs Testnet bridge](https://bubs-sepolia.bridge.caldera.xyz/).
-
-### Faucet
-
-To visit the Bubs testnet faucet, go to <https://bubstestnet.com/> and click the "Request Faucet Funds on Bulbs rollup" button.
 
 ## Next steps
 

--- a/how-to-guides/bubs-testnet.md
+++ b/how-to-guides/bubs-testnet.md
@@ -9,7 +9,7 @@ next:
 
 ![Bubs testnet](/img/Celestia_Bubs_Testnet.jpg)
 
-[Bubs Testnet](https://bubs-sepolia.hub.caldera.xyz/) is a the first
+[Bubs Testnet](https://bubstestnet.com/) is a the first
 OP Stack testnet with Celestia underneath hosted by
 [Caldera](https://caldera.xyz) with support from Celestia Labs. Bubs is dedicated to providing developers with
 an EVM-compatible execution layer to deploy their EVM applications on.
@@ -37,7 +37,7 @@ execution layer, making it an ideal platform for developers looking to
 build and test applications in a setting that closely mirrors an OP Stack
 rollup on Celestia.
 
-Learn more at [https://bubs-sepolia.hub.caldera.xyz/](https://bubs-sepolia.hub.caldera.xyz/).
+Learn more at <https://bubs-sepolia.hub.caldera.xyz/>.
 
 ### RPC URLs
 
@@ -50,11 +50,11 @@ For the Bubs Testnet, you can connect to the following RPC URLs:
 
 #### HTTPS
 
-- `https://bubs-sepolia.rpc.caldera.xyz/http`
+- `https://bubs.calderachain.xyz/http`
 
 #### WSS
 
-- `wss://bubs-sepolia.rpc.caldera.xyz/ws`
+- `wss://bubs.calderachain.xyz/ws`
 
 This URL serves as the entry point to the Bubs Testnet. You can use it
 in your applications to connect to the testnet and interact with the smart
@@ -67,27 +67,12 @@ Remember, Bubs Testnet is a testing environment!
 Bridging is a process that enables the transfer of assets between
 different blockchains.
 
-To bridge between Ethereum Sepolia and Bubs Testnet,
-visit the [Bubs Testnet bridge](https://bubs-sepolia.bridge.caldera.xyz/).
+To bridge between Ethereum Sepolia and Bubs Testnet, visit the [Bubs Testnet bridge](https://bubs-sepolia.bridge.caldera.xyz/).
 
 ### Faucet
 
-To visit the Bubs testnet faucet, go to
-[`https://bubs-sepolia.hub.caldera.xyz/`](https://bubs-sepolia.hub.caldera.xyz/)
-and click the "Faucet" tab.
-
-### Explorer
-
-To visit the explorer, go to
-[`https://bubs-sepolia.explorer.caldera.xyz/`](https://bubs-sepolia.explorer.caldera.xyz/).
-
-### Status
-
-To see the status and uptime information for Bubs,
-[visit the status page](https://bubs-sepolia.betteruptime.com/).
+To visit the Bubs testnet faucet, go to <https://bubstestnet.com/> and click the "Request Faucet Funds on Bulbs rollup" button.
 
 ## Next steps
 
-Now that you have a better understanding of the Bubs Testnet and its
-integration of OP Stack and Celestia, you can start exploring its
-capabilities.
+Now that you have a better understanding of the Bubs Testnet and its integration of OP Stack and Celestia, you can start exploring its capabilities.

--- a/how-to-guides/full-storage-node.md
+++ b/how-to-guides/full-storage-node.md
@@ -73,7 +73,7 @@ node's account balance, a gRPC endpoint of a validator
 (core) node must be passed as directed below.
 
 Refer to
-[the ports section of the celestia-node troubleshooting page](../../how-to-guides/celestia-node-troubleshooting/#ports)
+[the ports section of the celestia-node troubleshooting page](/how-to-guides/celestia-node-troubleshooting.md#ports)
 for information on which ports are required to be open on your machine.
 
 ```sh
@@ -91,7 +91,7 @@ provides the light node with access to state queries (reading balances, submitti
 transactions, and other state-related queries).
 
 You can create your key for your node by following
-[the `cel-key` instructions](../../tutorials/celestia-node-key)
+[the `cel-key` instructions](/tutorials/celestia-node-key.md)
 
 Once you start the full storage node, a wallet key will be generated for you.
 You will need to fund that address with testnet tokens to pay for

--- a/how-to-guides/instantiate-testnet.md
+++ b/how-to-guides/instantiate-testnet.md
@@ -12,7 +12,7 @@ or if you want to test out new features to build as a core developer.
 ## Hardware requirements
 
 You will need to
-[follow hardware requirements](./validator-node#hardware-requirements).
+[follow hardware requirements](./validator-node.md#hardware-requirements).
 
 ## Setup dependencies
 

--- a/how-to-guides/light-node.md
+++ b/how-to-guides/light-node.md
@@ -90,7 +90,7 @@ node's account balance, a gRPC endpoint of a validator
 (core) node must be passed as directed below.
 
 Refer to
-[the ports section of the celestia-node troubleshooting page](../../how-to-guides/celestia-node-troubleshooting/#ports)
+[the ports section of the celestia-node troubleshooting page](/how-to-guides/celestia-node-troubleshooting.md#ports)
 for information on which ports are required to be open on your machine.
 
 ::: code-group
@@ -114,7 +114,7 @@ Tip: you can replace the core.ip with a consensus node RPC endpoint from [Mainne
 ### Keys and wallets
 
 You can create your key for your node by running the following command with the
-[`cel-key` utility](../../tutorials/celestia-node-key) in the
+[`cel-key` utility](/tutorials/celestia-node-key.md) in the
 `celestia-node` directory:
 
 ```sh

--- a/how-to-guides/mainnet.md
+++ b/how-to-guides/mainnet.md
@@ -121,8 +121,8 @@ your own node.
 
 ### Consensus nodes
 
-- [Consensus node](./consensus-node)
-- [Validator node](./validator-node)
+- [Consensus node](./consensus-node.md)
+- [Validator node](./validator-node.md)
 
 #### Community consensus RPC endpoints
 

--- a/how-to-guides/mainnet.md
+++ b/how-to-guides/mainnet.md
@@ -283,7 +283,6 @@ There are multiple explorers you can use for Mainnet Beta:
 
 - [https://celenium.io](https://celenium.io)
 - [https://celestia.explorers.guru](https://celestia.explorers.guru)
-- [https://explorer.modular.cloud/celestia-mainnet](https://explorer.modular.cloud/celestia-mainnet)
 - [https://mintscan.io/celestia](https://mintscan.io/celestia)
 - [https://explorer.nodestake.top/celestia](https://explorer.nodestake.top/celestia)
 - [https://stakeflow.io/celestia](https://stakeflow.io/celestia)

--- a/how-to-guides/mocha-testnet.md
+++ b/how-to-guides/mocha-testnet.md
@@ -24,8 +24,8 @@ participate in Mocha:
 
 Consensus:
 
-- [Consensus node](./full-consensus-node)
-- [Validator node](./validator-node)
+- [Consensus node](./consensus-node.md)
+- [Validator node](./validator-node.md)
 
 Data Availability:
 
@@ -136,19 +136,19 @@ as REST endpoints. This allows for communication with the node using REST
 calls, which can be useful if the client does not support gRPC or HTTP2.
 The default port is 1317.
 
-- [https://api-mocha.pops.one](https://api-mocha.pops.one)
-- [https://api.celestia-mocha.com/](https://api.celestia-mocha.com/)
-- [https://celestia-testnet.brightlystake.com/api](https://celestia-testnet.brightlystake.com/api)
-- [https://api-celestia-mocha.trusted-point.com](https://api-celestia-mocha.trusted-point.com)
-- [https://api-celestia-testnet-01.stakeflow.io/](https://api-celestia-testnet-01.stakeflow.io/)
-- [https://mocha.api.cumulo.me/](https://mocha.api.cumulo.me/)
-- [https://api.archive.mocha.cumulo.com.es](https://api.archive.mocha.cumulo.com.es)
-- [https://api-mocha-full.avril14th.org](https://api-mocha-full.avril14th.org)
-- [https://api-1.testnet.celestia.nodes.guru](https://api-1.testnet.celestia.nodes.guru)
-- [https://api-2.testnet.celestia.nodes.guru](https://api-2.testnet.celestia.nodes.guru)
-- [https://celestia-testnet-api.itrocket.net](https://celestia-testnet-api.itrocket.net)
-- [https://api-celestia-testnet.cryptech.com.ua](https://api-celestia-testnet.cryptech.com.ua)
-- [https://celestia-t-api.noders.services](https://celestia-t-api.noders.services)
+- `https://api-mocha.pops.one`
+- `https://api.celestia-mocha.com/`
+- `https://celestia-testnet.brightlystake.com/api`
+- `https://api-celestia-mocha.trusted-point.com`
+- `https://api-celestia-testnet-01.stakeflow.io/`
+- `https://mocha.api.cumulo.me/`
+- `https://api.archive.mocha.cumulo.com.es`
+- `https://api-mocha-full.avril14th.org`
+- `https://api-1.testnet.celestia.nodes.guru`
+- `https://api-2.testnet.celestia.nodes.guru`
+- `https://celestia-testnet-api.itrocket.net`
+- `https://api-celestia-testnet.cryptech.com.ua`
+- `https://celestia-t-api.noders.services`
 
 ## Community gRPC endpoints
 
@@ -225,20 +225,20 @@ Faucet has a limit of 10 tokens per week per address/Discord ID.
 
 The following websites provide analytics for Mocha Testnet:
 
-- [https://cosmoslist.co/testnet/celestia](https://cosmoslist.co/testnet/celestia)
+- <https://cosmoslist.co/testnet/celestia>
 
 ## Explorers
 
 There are several explorers you can use for Mocha:
 
-- [https://testnet.mintscan.io/celestia-testnet](https://testnet.mintscan.io/celestia-testnet)
-- [https://mocha.celenium.io](https://mocha.celenium.io)
-- [https://explorer.nodestake.top/celestia-testnet/](https://explorer.nodestake.top/celestia-testnet)
-- [https://stakeflow.io/celestia-testnet](https://stakeflow.io/celestia-testnet)
-- [https://testnet.celestia.explorers.guru](https://testnet.celestia.explorers.guru)
-- [https://testnet.itrocket.net/celestia](https://testnet.itrocket.net/celestia)
-- [https://explorers.cryptech.com.ua/Celestia-Testnet](https://explorers.cryptech.com.ua/Celestia-Testnet)
-- [https://testnet.celestia.valopers.com/](https://testnet.celestia.valopers.com/)
+- `https://testnet.mintscan.io/celestia-testnet`
+- `https://mocha.celenium.io`
+- `https://explorer.nodestake.top/celestia-testnet/`
+- `https://stakeflow.io/celestia-testnet`
+- `https://testnet.celestia.explorers.guru`
+- `https://testnet.itrocket.net/celestia`
+- `https://explorers.cryptech.com.ua/Celestia-Testnet`
+- `https://testnet.celestia.valopers.com/`
 
 ## Network upgrades
 

--- a/how-to-guides/mocha-testnet.md
+++ b/how-to-guides/mocha-testnet.md
@@ -232,7 +232,6 @@ The following websites provide analytics for Mocha Testnet:
 There are several explorers you can use for Mocha:
 
 - [https://testnet.mintscan.io/celestia-testnet](https://testnet.mintscan.io/celestia-testnet)
-- [https://celestiascan.com](https://celestiascan.com)
 - [https://mocha.celenium.io](https://mocha.celenium.io)
 - [https://explorer.nodestake.top/celestia-testnet/](https://explorer.nodestake.top/celestia-testnet)
 - [https://stakeflow.io/celestia-testnet](https://stakeflow.io/celestia-testnet)

--- a/how-to-guides/multiaccounts.md
+++ b/how-to-guides/multiaccounts.md
@@ -60,7 +60,7 @@ use the [`cel-key` library](https://github.com/celestiaorg/celestia-node/blob/ma
 ./cel-key import
 ```
 Learn more on the
-[Create a wallet with celestia-node](./celestia-node-key#create-a-wallet-with-celestia-node)
+[Create a wallet with celestia-node](/tutorials/celestia-node-key.md#create-a-wallet-with-celestia-node)
 page.
 
 ## Optional flags for write transactions

--- a/how-to-guides/nodes-overview.md
+++ b/how-to-guides/nodes-overview.md
@@ -11,10 +11,10 @@ Celestia node operators can run several options on the network.
 
 Consensus:
 
-- [Validator node](./validator-node):
+- [Validator node](./validator-node.md):
   This type of node participates
   in consensus by producing and voting on blocks.
-- [Consensus node](./consensus-node): A celestia-app full node
+- [Consensus node](./consensus-node.md): A celestia-app full node
   to sync blockchain history.
 
 Data Availability:

--- a/how-to-guides/rollup-stacks.md
+++ b/how-to-guides/rollup-stacks.md
@@ -86,7 +86,7 @@ any monolithic chain. But, the data of those transactions get sent to a
 layer 1 blockchain to carry out the remaining functions.
 
 If you want to brush up on your understanding of modular blockchains,
-head over to [learn modular](../learn/how-celestia-works/monolithic-vs-modular).
+head over to [learn modular](../learn/how-celestia-works/monolithic-vs-modular.md).
 
 ## Benefits of modular blockchains
 

--- a/how-to-guides/sp1-blobstream-deploy.md
+++ b/how-to-guides/sp1-blobstream-deploy.md
@@ -26,7 +26,7 @@ cd sp1-blobstream
 [sp1-blobstream README](https://github.com/succinctlabs/sp1-blobstream?tab=readme-ov-file#deployment).
 
 3. If you're deploying on a chain where there isn't a canonical verifier listed in the
-[SP1 contract addresses](https://github.com/succinctlabs/sp1/blob/main/book/onchain-verification/contract-addresses.md), you'll need to:
+[SP1 contract addresses](https://github.com/succinctlabs/sp1/blob/main/book/verification/onchain/contract-addresses.md), you'll need to:
 
    a. Deploy your own SP1 Verifier from the [sp1-contracts](https://github.com/succinctlabs/sp1-contracts) matching your `sp1-sdk` version.
    b. Set the `SP1_VERIFIER_ADDRESS` in your `.env` file to the address of your deployed verifier.

--- a/how-to-guides/submit-data.md
+++ b/how-to-guides/submit-data.md
@@ -190,7 +190,7 @@ Using `blob.Submit`:
 celestia blob submit <hex-encoded namespace> <hex-encoded data>
 ```
 
-Learn more in the [node tutorial](./node-tutorial.md).
+Learn more in the [node tutorial](/tutorials/node-tutorial.md).
 
 ### The celestia-node API golang client
 

--- a/how-to-guides/validator-node.md
+++ b/how-to-guides/validator-node.md
@@ -30,7 +30,7 @@ The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64
 instance machine.
 
 First, follow the instructions on
-[setting up a consensus node](/how-to-guides/consensus-node#set-up-a-consensus-node).
+[setting up a consensus node](/how-to-guides/consensus-node/md#set-up-a-consensus-node).
 
 ### Wallet
 
@@ -117,7 +117,7 @@ celestia bridge init --core.ip <URI>
 
 :::tip
 Refer to
-[the ports section of the celestia-node troubleshooting page](../../how-to-guides/celestia-node-troubleshooting/#ports)
+[the ports section of the celestia-node troubleshooting page](/how-to-guides/celestia-node-troubleshooting.md#ports)
 for information on which ports are required to be open on your machine.
 :::
 
@@ -138,7 +138,7 @@ celestia bridge start
 #### Optional: start the bridge node with SystemD
 
 Follow
-[the tutorial on setting up the bridge node as a background process with SystemD](../systemd).
+[the tutorial on setting up the bridge node as a background process with SystemD](/how-to-guides/systemd.md).
 
 You have successfully set up a bridge node that is syncing with the network.
 

--- a/how-to-guides/validator-node.md
+++ b/how-to-guides/validator-node.md
@@ -30,7 +30,7 @@ The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64
 instance machine.
 
 First, follow the instructions on
-[setting up a consensus node](/how-to-guides/consensus-node/md#set-up-a-consensus-node).
+[setting up a consensus node](/how-to-guides/consensus-node.md#set-up-a-consensus-node).
 
 ### Wallet
 

--- a/tutorials/integrate-celestia.md
+++ b/tutorials/integrate-celestia.md
@@ -14,12 +14,11 @@ explorers, integrating the Celestia network.
 
 When getting started with Celestia, we recommend checking out these resources first:
 
-- [Introduction to Celestia](../learn/how-celestia-works/overview.md)
-- [Monolithic v. Modular](../learn/how-celestia-works/monolithic-vs-modular.md)
-- [Celestia's DA Layer](../learn/how-celestia-works/data-availability-layer.md)
-- [Learn modular](https://celestia.org/learn)
-- [Overview to running nodes on Celestia](../how-to-guides/nodes-overview.md)
-- [Rollup stacks](./rollup-stacks.md)
+- [Introduction to Celestia](/learn/how-celestia-works/overview.md)
+- [Monolithic v. Modular](/learn/how-celestia-works/monolithic-vs-modular.md)
+- [Celestia's DA Layer](/learn/how-celestia-works/data-availability-layer.md)
+- [Overview to running nodes on Celestia](/how-to-guides/nodes-overview.md)
+- [Rollup stacks](/how-to-guides/rollup-stacks.md)
 
 ## Celestia service provider notes
 

--- a/tutorials/node-tutorial.md
+++ b/tutorials/node-tutorial.md
@@ -25,7 +25,7 @@ Celestia partitions the block data into
 multiple namespaces, one for every application. This allows applications
 to only download their data, and not the data of other applications.
 Read
-[more about Namespaced Merkle trees (NMTs)](../learn/how-celestia-works/data-availability-layer.md#namespaced-merkle-trees-nmts).
+[more about Namespaced Merkle trees (NMTs)](/learn/how-celestia-works/data-availability-layer.md#namespaced-merkle-trees-nmts).
 
 :::tip
 If you already have a running and funded node,
@@ -33,7 +33,7 @@ you can skip to the [RPC CLI guide section](#rpc-cli-guide).
 
 If you would like to skip syncing, you can use
 this
-[guide to sync from trusted hash and height](../how-to-guides/celestia-node-trusted-hash.md).
+[guide to sync from trusted hash and height](/how-to-guides/celestia-node-trusted-hash.md).
 :::
 
 :::warning
@@ -54,8 +54,8 @@ light node:
 
 ## Setting up dependencies
 
-Install [dependencies](../how-to-guides/environment.md) and
-[celestia-node](../how-to-guides/celestia-node.md) if you have
+Install [dependencies](/how-to-guides/environment.md) and
+[celestia-node](/how-to-guides/celestia-node.md) if you have
 not already.
 
 ### Instantiate a Celestia light node
@@ -95,9 +95,9 @@ provides the light node with access to state queries (reading balances, submitti
 transactions, and other state-related queries).
 
 Note: You are also encouraged to find an RPC endpoint for
-[Mainnet Beta](../how-to-guides/mainnet.md#integrations),
-[Mocha testnet](../how-to-guides/mocha-testnet.md#integrations),
-or [Arabica devnet](../how-to-guides/arabica-devnet.md#integrations).
+[Mainnet Beta](/how-to-guides/mainnet.md#integrations),
+[Mocha testnet](/how-to-guides/mocha-testnet.md#integrations),
+or [Arabica devnet](/how-to-guides/arabica-devnet.md#integrations).
 If you are running a production application, use a production endpoint.
 
 ::: code-group
@@ -125,7 +125,7 @@ add the port after the IP address or use the
 port if you prefer.
 
 Refer to
-[the ports section of the celestia-node troubleshooting page](../how-to-guides/celestia-node-troubleshooting.md#ports)
+[the ports section of the celestia-node troubleshooting page](/how-to-guides/celestia-node-troubleshooting.md#ports)
 for information on which ports are required to be open on your machine.
 :::
 
@@ -156,7 +156,7 @@ command from the celestia-node directory:
 
 :::tip
 You do not need to declare a network for Mainnet Beta. Refer to
-[the chain ID section on the troubleshooting page for more information](../how-to-guides/celestia-node-troubleshooting.md)
+[the chain ID section on the troubleshooting page for more information](/how-to-guides/celestia-node-troubleshooting.md)
 :::
 
 ```bash
@@ -252,7 +252,7 @@ once your node store is set:
 :::note
 Previously, the `node.store` flag had to be specified manually for each
 request. This has changed in v0.14.0+ and you can
-[read more about the implementation in celestia-node troubleshooting](../how-to-guides/celestia-node-troubleshooting.md#changing-the-location-of-your-node-store).
+[read more about the implementation in celestia-node troubleshooting](/how-to-guides/celestia-node-troubleshooting.md#changing-the-location-of-your-node-store).
 :::
 
 ```bash
@@ -260,7 +260,7 @@ celestia blob submit 0x42690c204d39600fddd3 'gm'
 ```
 
 :::tip
-[Learn more about maximum blob size](submit-data.md).
+[Learn more about maximum blob size](/how-to-guides/submit-data.md).
 :::
 
 Alternatively, you could use the `--token` flag to set your auth token:
@@ -574,7 +574,7 @@ To set the gas price, you can use the `--gas.price` flag.
 The gas price will be set to default (0.002) if no value
 is passed.
 
-Learn [more about gas fees and limits](../how-to-guides/submit-data.md).
+Learn [more about gas fees and limits](/how-to-guides/submit-data.md).
 
 To set a higher gas price of 0.004 utia, use the `--gas.price 0.004` flag:
 

--- a/tutorials/prompt-scavenger.md
+++ b/tutorials/prompt-scavenger.md
@@ -79,7 +79,7 @@ Make sure you run this command in a different terminal window because the node h
 
 ### OpenAI key
 
-Visit [OpenAI](https://platform.openai.com/) to sign up for an account and generate an API key.
+Visit [OpenAI](https://platform.openai.com/signup) to sign up for an account and generate an API key.
 In order to sign up for an account and generate an OpenAI API key.
 The key will be needed to communicate with OpenAI.
 


### PR DESCRIPTION
Getting familiar with the docs, I found a few broken links using https://lychee.cli.rs/ and fixed what I could that seemed obvious. 

If you like this, see #1863 :pray: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

Based on the comprehensive summary, here are the release notes:

- **Documentation Updates**
  - Updated numerous links across multiple how-to guides to use absolute paths and correct markdown file extensions.
  - Enhanced documentation for Arabica devnet with new sections on RPC endpoints, faucet usage, and network upgrades.
  - Improved integration documentation for Arbitrum and Celestia.

- **New Features**
  - Added `VerifyAttestation` method in Arbitrum node software for checking data root postings.
  - Introduced new utility function for GPT-3.5 interaction in the prompt scavenger tutorial.

- **Improvements**
  - Clarified network connectivity and resource availability guidelines.
  - Updated URLs for various testnets and community resources.
  - Simplified transaction submission process in the multiaccounts guide.
  - Added a new section in the README for link format guidelines.

These updates focus on improving documentation clarity, link reliability, and providing more comprehensive guidance for developers interacting with Celestia's ecosystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->