### PR TITLE
docs: update 2121 port for nodes

### DIFF
--- a/how-to-guides/bridge-node.md
+++ b/how-to-guides/bridge-node.md
@@ -83,6 +83,10 @@ add the port after the IP address or use the
 `--core.grpc.port` flag to specify another
 port if you prefer.
 
+:::warning Important
+Make sure port 2121 TCP/UDP is open and publicly accessible on your bridge node so it can be discovered by other peers in the DHT network. This port is essential for P2P connectivity and if not properly configured, your node won't be able to participate in the network effectively.
+:::
+
 Refer to
 [the ports section of the celestia-node troubleshooting page](/how-to-guides/celestia-node-troubleshooting.md#ports)
 for information on which ports are required to be open on your machine.

--- a/how-to-guides/full-storage-node.md
+++ b/how-to-guides/full-storage-node.md
@@ -72,6 +72,10 @@ submit `PayForBlob` transactions, or query for the
 node's account balance, a gRPC endpoint of a validator
 (core) node must be passed as directed below.
 
+:::warning Important
+Make sure port 2121 TCP/UDP is open and publicly accessible on your full storage node so it can be discovered by other peers in the DHT network. This port is essential for P2P connectivity and if not properly configured, your node won't be able to participate in the network effectively.
+:::
+
 Refer to
 [the ports section of the celestia-node troubleshooting page](/how-to-guides/celestia-node-troubleshooting.md#ports)
 for information on which ports are required to be open on your machine.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added important warning sections to bridge and full storage node setup guides about ensuring port 2121 TCP/UDP is open and publicly accessible for proper P2P network connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->