### PR TITLE
docs: Fix missing article before "installation" in celestia-node-key.md

### DIFF
--- a/tutorials/celestia-node-key.md
+++ b/tutorials/celestia-node-key.md
@@ -10,7 +10,7 @@ prev:
 This tutorial will go over using the `cel-key` utility
 to generate a wallet on celestia-node.
 
-While this tutorial will go over installation process
+While this tutorial will go over the installation process
 of `cel-key`, it is recommended that you complete
 the following prerequisites first:
 


### PR DESCRIPTION
## Overview

I noticed there was a missing article before the word "installation" in the documentation.
This small fix ensures the sentence reads correctly and maintains proper grammar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Minor grammatical correction in the Celestia node key tutorial
  - Added definite article "the" to improve text clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->