### PR TITLE
fix: typos in documentation files

### DIFF
--- a/how-to-guides/celestia-node-troubleshooting.md
+++ b/how-to-guides/celestia-node-troubleshooting.md
@@ -150,7 +150,7 @@ making the request:
 ```bash
 ❯ celestia blob get 1318129 0x42690c204d39600fddd3 0MFhYKQUi2BU+U1jxPzG7QY2BVV1lb3kiU+zAK7nUiY=
 {
- "result": "RPC client error: sendRequest failed: http status 401 Unauthorized unmarshaling response: EOF"
+ "result": "RPC client error: sendRequest failed: http status 401 Unauthorized unmarshalling response: EOF"
 }
 ```
 

--- a/how-to-guides/quick-start.md
+++ b/how-to-guides/quick-start.md
@@ -12,7 +12,7 @@ import mochaVersions from '/.vitepress/constants/mocha_versions.js'
 
 Welcome to Celestia's quick-start guide! In this guide, we'll learn how to run a Celestia data availability sampling (DAS) light node to post and retrieve data blobs on Celestia's [Mocha testnet](./mocha-testnet.md).
 
-A blob (a.k.a. [BLOB](https://en.wikipedia.org/wiki/Object_storage#Origins)) is a Binary Large OBject. In other words, a blob is arbitrary data. In this case, it's data that you want to post and make available on Celestia's data availability (DA) layer.
+A blob (a.k.a. [BLOB](https://en.wikipedia.org/wiki/Object_storage#Origins)) is a Binary Large Object. In other words, a blob is arbitrary data. In this case, it's data that you want to post and make available on Celestia's data availability (DA) layer.
 
 Your light node will allow you to post data, and then use DAS to sample and retrieve it from the DA network. Let's get started!
 

--- a/learn/how-celestia-works/data-availability-layer.md
+++ b/learn/how-celestia-works/data-availability-layer.md
@@ -109,7 +109,7 @@ For this to work, the DA layer must be able to prove that the provided
 data is complete, _i.e._, all the data for a given namespace is returned.
 To this end, Celestia is using Namespaced Merkle trees (NMTs).
 
-An NMT is a Merkle tree with the leafs ordered by the namespace identifiers
+An NMT is a Merkle tree with the leaves ordered by the namespace identifiers
 and the hash function modified so that every node in the tree includes the
 range of namespaces of all its descendants. The following figure shows an
 example of an NMT with height three (_i.e._, eight data shares). The data is


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected spelling of "unmarshalling" in Celestia node troubleshooting guide
	- Fixed acronym definition for "Binary Large Object" in quick start guide
	- Updated terminology from "leafs" to "leaves" in data availability layer documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->