### PR TITLE
Fix font preload path in VitePress config

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -157,7 +157,7 @@ export default {
         (file) => /Untitled-Sans-Regular\.\w+\.woff2/
       );
       const untitledSansMediumFont = assets.find(
-        (file) => /Unititled-Sans-Medium\.\w+\.woff2/
+        (file) => /Untitled-Sans-Medium\.\w+\.woff2/
       );
 
       const headConfig: HeadConfig[] = [];


### PR DESCRIPTION
Corrects the font filename pattern in transformHead function from "Unititled-Sans-Medium" to "Untitled-Sans-Medium" to ensure proper font preloading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
	- Fixed a minor error affecting font loading to ensure the proper display of the custom font throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->