### PR TITLE
Grammar & Consistency Fixes in Documentation

### DIFF
--- a/community/modular-meetup-guide.md
+++ b/community/modular-meetup-guide.md
@@ -80,7 +80,7 @@ creating a welcoming atmosphere for the Celestia community.
 1. Startup Incubators
    - Often they would have spaces for meetups.
 2. Libraries
-   - Libraries can normally have spaces for meetups at little to no costs
+   - Libraries can normally have spaces for meetups at little to no cost
 3. Co-working spaces:
    - Co-working spaces might be able to offer necessary equipment like
      microphones, projectors, and whiteboards.
@@ -134,7 +134,7 @@ among attendees.
 2. Offer a variety of refreshments
    - If you're ordering in, pizza and finger foods work well,
      but you can also have more budget-friendly options for food.
-   - Offering drinks like beer, soda, or lemonade are great,
+   - Offering drinks like beer, soda, or lemonade is great,
      but water also works. Keep in mind that not everyone drinks
      alcohol so it’s not a requirement. But having at least water
      and plastic cups works well.

--- a/how-to-guides/blobstream-proof-queries.md
+++ b/how-to-guides/blobstream-proof-queries.md
@@ -1200,7 +1200,7 @@ import {
 :::
 </div>
 
-### Listening for new data commitments
+### Listening to new data commitments
 
 For listening for new data commitment stored events, sequencers can
 use the `WatchDataCommitmentStored` as follows:

--- a/how-to-guides/bridge-node.md
+++ b/how-to-guides/bridge-node.md
@@ -4,7 +4,7 @@
 
 # Setting up a Celestia bridge node
 
-This tutorial will go over the steps to setting up your Celestia bridge node.
+This tutorial will go over the steps to set up your Celestia bridge node.
 
 Bridge nodes connect the data availability layer and the consensus layer.
 


### PR DESCRIPTION
Old: "at little to no costs" 
New: "at little to no cost" (uncountable noun)

Old: "are great" 
New: "is great" (singular subject)

Old: "Listening for new data commitments"
New: "Listening to new data commitments" (correct collocation)

Old: "steps to setting up"
New: "steps to set up" (correct structure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved grammatical precision and wording in the Community Meetup Guide for enhanced readability.
  - Updated headings, added clarifications, and refined examples in the Blobstream proof queries guide to ensure users follow the latest guidance.
  - Adjusted introductory phrasing in the Celestia bridge node guide for clearer setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->