### PR TITLE
Fix grammar in node troubleshooting guide

### DIFF
--- a/how-to-guides/celestia-node-troubleshooting.md
+++ b/how-to-guides/celestia-node-troubleshooting.md
@@ -194,7 +194,7 @@ node is running. It fails as expected:
 
 ## Resetting your config
 
-If you an encounter an error, it is likely that an old config file is present:
+If you encounter an error, it is likely that an old config file is present:
 
 ```sh
 Error: nodebuilder/share: interval must be positive; nodebuilder/core: invalid IP addr given:


### PR DESCRIPTION
Remove redundant "an" in the error message section of celestia-node-troubleshooting.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typographical error in the troubleshooting guide to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->