### PR TITLE
Improved Documentation Language and Consistency

### DIFF
--- a/.github/workflows/latest_tags.yml
+++ b/.github/workflows/latest_tags.yml
@@ -80,7 +80,7 @@ jobs:
 
   # This job creates a PR if there were changes. The changes are created when
   # the workflow writes to the version files. This means that the workflow
-  # should be able to be run and will just be a no-op if the is no new release.
+  # should be able to be run and will just be a no-op If there is no new release.
   # Either way, since a PR is created, this job won't break the docs on main.
   createPR:
     needs: logLatestRelease

--- a/community/speaker-list.md
+++ b/community/speaker-list.md
@@ -10,8 +10,7 @@ That's why we've created an exclusive Speaker List specifically
 tailored for organizers participating in the Modular Meetup Program.
 This resource gives you access to a curated selection of top-tier
 speakers who are passionate about Celestia and the modular ecosystem.
-Due to privacy, the list is not shared publicly but is accessible
-to participants of the Modular Meetup program when they create a meetup.
+Due to privacy, the list is not shared publicly but is accessible to participants of the Modular Meetup Program upon organizing a meetup.
 
 The Speaker List features experts from Celestia Labs, as well as prominent
 figures from the broader Celestia and modular communities. Each individual

--- a/how-to-guides/celestia-app-slashing.md
+++ b/how-to-guides/celestia-app-slashing.md
@@ -20,8 +20,7 @@ The following are the conditions for a validator to get jailed or slashed:
    of the last 5,000 blocks, they will be jailed for 1 minute.
    During this period, the validator is removed from the validator set
    temporarily, and will be unable to propose new blocks or earn rewards.
-   After the jail period, the validator can send an unjail request to
-   rejoin the validator set.
+   After the jail period, the validator can submit an unjail request to rejoin the validator set.
 
 2. **Double signing**: This is a more severe offense and results in getting slashed.
    If a validator engages in double signing, the validator


### PR DESCRIPTION
File: Speaker List Document

Change:
Old: "when they create a meetup."
New: "upon organizing a meetup."
Reason: The phrase "upon organizing a meetup" is more precise and formal, enhancing clarity regarding the action required to access the list.
File: Jailing and Slashing Document

Change:
Old: "can send an unjail request to"
New: "can submit an unjail request to"
Reason: The word "submit" is more appropriate in a technical context, indicating a formal action that the validator must take.
File: Unknown Context (as no specific file mentioned)

Change:
Old: "should be able to be run and will just be a no-op if the is no new release."
New: "should be able to be run and will just be a no-op If there is no new release."
Reason: Corrects grammatical errors ("the is" to "there is") and capitalizes "If" for consistency within a sentence structure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised speaker list details to clarify that access now requires organizing a meetup.
  - Updated validator guide instructions to specify that users should submit an unjail request.
  - Minor wording adjustments have been made to improve overall clarity.
  
Overall, these documentation updates enhance guidance and make key processes easier to understand without impacting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->