### PR TITLE
Update arabica-devnet.md

### DIFF
--- a/how-to-guides/arabica-devnet.md
+++ b/how-to-guides/arabica-devnet.md
@@ -23,7 +23,7 @@ Arabica can break unexpectedly, but given it will be continuously updated,
 it is a useful way to keep testing the latest changes in the software.
 
 Developers can still deploy on Mocha testnet their sovereign rollups if they
-chose to do so, it just will always lag behind Arabica devnet until Mocha
+choose to do so, it just will always lag behind Arabica devnet until Mocha
 undergoes network upgrades in coordination with validators.
 
 ## Network details


### PR DESCRIPTION
Hi,

A typo in this text:

"Developers can still deploy on Mocha testnet their sovereign rollups if they chose to do so, it just will always lag behind Arabica devnet..." This should be "choose" instead of "chose," since the present tense is being used.

Thanks.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated language in a guide to enhance clarity by using present tense for ongoing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->