### PR TITLE
fix: xtoken.json

### DIFF
--- a/how-to-guides/light-node.md
+++ b/how-to-guides/light-node.md
@@ -192,7 +192,7 @@ celestia light start \
 ```
 
 Where `/path-to-directory` is the path to the directory containing the
-`x-token.json` file. Ensure the file has restricted permissions (e.g., `chmod 600`) and contains:
+`xtoken.json` file. Ensure the file has restricted permissions (e.g., `chmod 600`) and contains:
 
 ```json
 {


### PR DESCRIPTION
## Overview

User reported facing this issue, upon investigation I found that the correct path is `xtoken.json`:

> Error: could not build arguments for function "github.com/celestiaorg/celestia-node/nodebuilder/gateway".Handler (/src/nodebuilder/gateway/constructors.go:12): failed to build state.Module: could not build arguments for function "reflect".makeFuncStub (/usr/local/go/src/reflect/asm_amd64.s:28): failed to build *grpc.ClientConn: received non-nil error from function "github.com/celestiaorg/celestia-node/nodebuilder/core".grpcClient (/src/nodebuilder/core/constructors.go:24): file does not exist






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the filename reference in the guide to ensure users reference the correct token file for proper permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->