### PR TITLE
docs: use 127.0.0.1 for localhost on consensus node page

### DIFF
--- a/how-to-guides/celestia-app.md
+++ b/how-to-guides/celestia-app.md
@@ -127,6 +127,6 @@ The following ports are used by Celestia app nodes:
 
 | Port  | Protocol | Address   | Description | Enabled by default on node     | Flag                    |
 | ----- | -------- | --------- | ----------- | ------------------------------ | ----------------------- |
-| 2121  | TCP/UDP  | localhost | P2P         | true                           | N/A                     |
+| 2121  | TCP/UDP  | 127.0.0.1 | P2P         | true                           | N/A                     |
 | 9090  | HTTP     | 0.0.0.0   | gRPC        | true                           | `--grpc.address string` |
-| 26657 | TCP      | localhost | RPC         | false (only open to localhost) | `--rpc.laddr string`    |
+| 26657 | TCP      | 127.0.0.1 | RPC         | false (only open to localhost) | `--rpc.laddr string`    |


### PR DESCRIPTION
The config has 127.0.0.1, so this PR updates documentation to use the same so it is clear not to change it to localhost.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
