### PR TITLE
Update indexer field value

### DIFF
--- a/how-to-guides/consensus-node.md
+++ b/how-to-guides/consensus-node.md
@@ -161,11 +161,14 @@ min-retain-blocks = 0 # retain all block data, this is default setting
 ### Query transactions by hash
 
 To query transactions using their hash, transaction
-indexing must be turned on. Set the `indexer` to `"kv"` in your `config.toml`:
+indexing must be turned on. Set the `indexer` to `"null"` in your `config.toml`:
 
 ```toml
-indexer = "kv"
+indexer = "null"
 ```
+
+The `null` indexer is a lightweight indexer. Do not use the `kv` indexer,
+as it results in substantial redundant data being saved.
 
 ### Optional: Access historical state
 

--- a/how-to-guides/consensus-node.md
+++ b/how-to-guides/consensus-node.md
@@ -471,11 +471,11 @@ The available options are:
 1. `null` (default): This option disables indexing outside of
    transaction status. If you don't need to query transaction data,
    you can choose this option to save space.
-3. `kv`: This is the simplest indexer, backed by
+2. `kv`: This is the simplest indexer, backed by
    key-value storage (defaults to levelDB; see DBBackend).
    When `kv` is chosen, `tx.height` and `tx.hash` will always be
    indexed. This option is suitable for basic queries on transactions.
-4. `psql`: This indexer is backed by PostgreSQL. When psql is chosen,
+3. `psql`: This indexer is backed by PostgreSQL. When psql is chosen,
    `tx.height` and `tx.hash` will always be indexed. This option is
    suitable for complex queries on transactions.
 

--- a/how-to-guides/consensus-node.md
+++ b/how-to-guides/consensus-node.md
@@ -161,14 +161,15 @@ min-retain-blocks = 0 # retain all block data, this is default setting
 ### Query transactions by hash
 
 To query transactions using their hash, transaction
-indexing must be turned on. Set the `indexer` to `"null"` in your `config.toml`:
+indexing must be turned on (there is currently no way of entirely disabling
+indexing). Set the `indexer` to `"null"` in your `config.toml`:
 
 ```toml
 indexer = "null"
 ```
 
-The `null` indexer is a lightweight indexer. Do not use the `kv` indexer,
-as it results in substantial redundant data being saved.
+The `null` indexer is a lightweight indexer that is sufficient for bridge
+nodes.
 
 ### Optional: Access historical state
 
@@ -467,13 +468,14 @@ may decide which transactions to index.
 
 The available options are:
 
-1. `null`: This option disables indexing. If you don't need to
-   query transactions, you can choose this option to save space.
-2. `kv` (default): This is the simplest indexer, backed by
+1. `null` (default): This option disables indexing outside of
+   transaction status. If you don't need to query transaction data,
+   you can choose this option to save space.
+3. `kv`: This is the simplest indexer, backed by
    key-value storage (defaults to levelDB; see DBBackend).
    When `kv` is chosen, `tx.height` and `tx.hash` will always be
    indexed. This option is suitable for basic queries on transactions.
-3. `psql`: This indexer is backed by PostgreSQL. When psql is chosen,
+4. `psql`: This indexer is backed by PostgreSQL. When psql is chosen,
    `tx.height` and `tx.hash` will always be indexed. This option is
    suitable for complex queries on transactions.
 


### PR DESCRIPTION
The `null` indexer is sufficient since it actually does index transaction hashes to transaction statues (which is sufficient for a bridge node). `kv` indexes additional data that isn't needed by bridge nodes.

Related:

1. https://github.com/celestiaorg/docs/pull/1219#discussion_r1377108548
1. https://github.com/celestiaorg/celestia-core/issues/1720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Updated the guide to reflect changes in transaction indexing configuration, highlighting the new default indexing option.
	- Clarified available indexing options and their roles.
- **Style**
	- Refined FAQ formatting for enhanced consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->