### PR TITLE
Fix misplaced edit

### DIFF
--- a/how-to-guides/consensus-node.md
+++ b/how-to-guides/consensus-node.md
@@ -145,9 +145,15 @@ data. This can be achieved with the following settings in your `config.toml`.
 
 #### Enable transaction indexing
 
+There is currently no way of entirely disabling indexing. Set the `indexer`
+to `"null"` in your `config.toml`:
+
 ```toml
-indexer = "kv"
+indexer = "null"
 ```
+
+The `null` indexer is a lightweight indexer that is sufficient for bridge
+nodes.
 
 #### Retain all block data
 
@@ -161,15 +167,11 @@ min-retain-blocks = 0 # retain all block data, this is default setting
 ### Query transactions by hash
 
 To query transactions using their hash, transaction
-indexing must be turned on (there is currently no way of entirely disabling
-indexing). Set the `indexer` to `"null"` in your `config.toml`:
+indexing must be turned on. Set the `indexer` to `"kv"` in your `config.toml`:
 
 ```toml
-indexer = "null"
+indexer = "kv"
 ```
-
-The `null` indexer is a lightweight indexer that is sufficient for bridge
-nodes.
 
 ### Optional: Access historical state
 


### PR DESCRIPTION
Fix misplaced edit in #1975. I put it in the wrong section.

Cumulative diff of the 2 PRs: https://github.com/celestiaorg/docs/compare/d6633ffcf06f7e0ad9ba35961f4fc6d2aabd03c0..db70238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the guidance on transaction indexing configurations.
	- Clarified that a lightweight indexing mode is available for bridge nodes.
	- Noted that querying transactions by hash now requires the full indexing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->