### PR TITLE
Install `cel-key`

### DIFF
--- a/how-to-guides/celestia-node.md
+++ b/how-to-guides/celestia-node.md
@@ -79,10 +79,11 @@ commands:
    make install
    ```
 
-5. Build the `cel-key` utility:
+5. Build and install the `cel-key` utility:
 
    ```bash
    make cel-key
+   make install-key
    ```
 
 6. Verify that the binary is working and check the version:


### PR DESCRIPTION
Likely you want to install this to the go `$PATH`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to clarify that both building and installing the `cel-key` utility are required, adding an explicit installation step to the guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->