### PR TITLE
docs:  fix typo in `arbitrum-integration.md` documentation

### DIFF
--- a/how-to-guides/arbitrum-integration.md
+++ b/how-to-guides/arbitrum-integration.md
@@ -49,7 +49,7 @@ You can [see where the preimage oracle gets used in the fraud proof replay binar
 
 ### Blobstream integration
 
-The integration ensures that in the case of a challenge in which the `ReadInboxMessage` instruction is disputed, that the corresponding batch can be confirmed to be in Celestia through the use of Blobstream (default is SP1 Blobstream by Succinct), which gives us strong security gaurantees that the data was made available on Celestia.
+The integration ensures that in the case of a challenge in which the `ReadInboxMessage` instruction is disputed, that the corresponding batch can be confirmed to be in Celestia through the use of Blobstream (default is SP1 Blobstream by Succinct), which gives us strong security guarantees that the data was made available on Celestia.
 
 ### Fallback mechanism in Nitro
 


### PR DESCRIPTION
This pull request corrects a spelling error in the Arbitrum Orbit with Celestia DA documentation. The word `gaurantees` has been corrected to `guarantees` in the Blobstream integration section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the Blobstream integration section of the Arbitrum integration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->