### PR TITLE
doc: enable celestia-app installer to take a specific version

### DIFF
--- a/how-to-guides/celestia-app.md
+++ b/how-to-guides/celestia-app.md
@@ -91,11 +91,15 @@ Pre-built binaries are available for:
 - Operating systems: Darwin (Apple), Linux
 - Architectures: x86_64 (amd64), arm64
 
-To install the latest pre-built binary you can run this command in your
+To install the latest, or a specific version of the pre-built binary you can run this command in your
 terminal:
 
 ```bash
+# Install latest version
 bash -c "$(curl -sL https://docs.celestia.org/celestia-app.sh)"
+
+# Install specific version, latest version for Mocha testnet in this example
+bash -c "$(curl -sL https://docs.celestia.org/celestia-app.sh)" -- -v {{mochaVersions['app-latest-tag']}}
 ```
 
 Follow the instructions in the terminal output to choose your installation

--- a/how-to-guides/celestia-app.md
+++ b/how-to-guides/celestia-app.md
@@ -94,7 +94,7 @@ Pre-built binaries are available for:
 To install the latest, or a specific version of the pre-built binary you can run this command in your
 terminal:
 
-```bash
+```bash-vue
 # Install latest version
 bash -c "$(curl -sL https://docs.celestia.org/celestia-app.sh)"
 


### PR DESCRIPTION
The code is taken from this PR https://github.com/celestiaorg/docs/pull/1766

## Overview

For the [celestia-node binary installer](https://docs.celestia.org/how-to-guides/celestia-node#installation-options), it has a nice feature that enables users to specify a specific version. The `celestia-app.sh` script will need it similarly. For example, installing a pre-release version for the Mocha testnet.

This PR takes the related code from `celestia-node.sh` and adds it to `celestia-app.sh`. The documentation page is updated as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated installation guide to clarify how to install either the latest or a specific version of celestia-app, including an example for specifying a version.

- **New Features**
  - Installation script now allows users to specify a desired version of celestia-app during installation via a command-line option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->