### PR TITLE
docs(consensus-node): reduce log level

### DIFF
--- a/how-to-guides/consensus-node.md
+++ b/how-to-guides/consensus-node.md
@@ -361,6 +361,7 @@ celestia-appd tendermint reset-state
 ```
 
 This preserves your configuration, validator state (`priv_validator_state.json`), and peer connections (`addrbook.json`), but removes:
+
 - blockstore.db
 - state.db
 - evidence.db
@@ -376,6 +377,7 @@ celestia-appd tendermint unsafe-reset-all --home $HOME/.celestia-app
 ```
 
 This command:
+
 - Resets blockchain data
 - Resets validator state (`priv_validator_state.json`) but NOT private keys (which are in `priv_validator_key.json`)
 - Clears address book (`addrbook.json`)
@@ -410,6 +412,7 @@ echo "{}" > ~/.celestia-app/data/priv_validator_state.json
 ```
 
 This approach:
+
 - Completely removes all blockchain data (blocks, state, evidence, etc.)
 - Removes the keyring-test directory containing transaction signing keys (but not validator consensus keys)
 - Creates a new, empty data directory structure
@@ -516,3 +519,13 @@ discard_abci_responses = false
 
 Remember to restart `celestia-appd` after making changes to the
 configuration to load the new settings.
+
+### Optional: Reduce log level
+
+To reduce the log level, you can modify the `log_level` field in your `config.toml` file.
+
+```diff
+# Output level for logging, including package level options
+-log_level = "info"
++log_level = "*:error,p2p:info,state:info"
+```


### PR DESCRIPTION
Motivated by https://github.com/celestiaorg/celestia-app/issues/4643

cc: @tac0turtle 

## Screenshot

![Screenshot 2025-04-23 at 4 52 34 PM](https://github.com/user-attachments/assets/290d975e-d5e2-4a68-b426-fec6c8729124)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved readability by adding blank lines before lists in reset command sections.
  - Added an optional section explaining how to reduce log verbosity by updating the log level in the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->