### PR TITLE
doc: improve the page of setting up a validator node

### DIFF
--- a/how-to-guides/validator-node.md
+++ b/how-to-guides/validator-node.md
@@ -30,60 +30,6 @@ First, follow the instructions on
 
 Follow [the tutorial on creating a wallet](/how-to-guides/celestia-app-wallet.md).
 
-### Delegate stake to a validator
-
-Create an environment variable for the address:
-
-```bash
-VALIDATOR_WALLET=<validator-wallet-name>
-```
-
-If you want to delegate more stake to any validator, including your own you
-will need the `celestiavaloper` address of the validator in question. You can run
-the command below to get the `celestiavaloper` of your local validator wallet in
-case you want to delegate more to it:
-
-```bash
-celestia-appd keys show $VALIDATOR_WALLET --bech val -a
-```
-
-After entering the wallet passphrase you should see a similar output:
-
-```bash
-Enter keyring passphrase:
-celestiavaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd
-```
-
-To delegate tokens to the `celestiavaloper` validator, as an
-example you can run:
-
-```bash-vue
-celestia-appd tx staking delegate \
-celestiavaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u4q4gx4p 1000000utia \
---from=$VALIDATOR_WALLET --chain-id={{constants.mochaChainId}} \
---fees=21000utia
-```
-
-If successful, you should see a similar output as:
-
-```console
-code: 0
-codespace: ""
-data: ""
-gas_used: "0"
-gas_wanted: "0"
-height: "0"
-info: ""
-logs: []
-raw_log: '[]'
-timestamp: ""
-tx: null
-txhash: <tx-hash>
-```
-
-You can check if the TX hash went through using the block explorer by
-inputting the `txhash` ID that was returned.
-
 ## Optional: Deploy the celestia-node
 
 Running a bridge node is critical to the Celestia network as it enables
@@ -167,8 +113,7 @@ Keep in mind that these steps are necessary ONLY if you want to participate
 in the consensus.
 
 Pick a `moniker` name of your choice! This is the validator name that will show
-up on public dashboards and explorers. `VALIDATOR_WALLET` must be the same you
-defined previously. Parameter `--min-self-delegation=1000000` defines the
+up on public dashboards and explorers. `VALIDATOR_WALLET` is the name of the validator's wallet you have created previously. Parameter `--min-self-delegation=1000000` defines the
 amount of tokens that are self delegated from your validator wallet.
 
 Now, connect to the network of your choice.
@@ -186,12 +131,16 @@ validator to Mocha:
 
 ```bash-vue
 MONIKER="your_moniker"
-VALIDATOR_WALLET="validator"
+VALIDATOR_WALLET="<validator-wallet-name>"
 
 celestia-appd tx staking create-validator \
     --amount=1000000utia \
     --pubkey=$(celestia-appd tendermint show-validator) \
     --moniker=$MONIKER \
+    --identity=<optional_identity_signature> \
+    --website="<optional_validator_website>" \
+    --security-contact="<optional_email_address_for_security_contact>" \
+    --details="A short and optional description of the validator." \
     --chain-id={{constants.mochaChainId}} \
     --commission-rate=0.1 \
     --commission-max-rate=0.2 \
@@ -202,6 +151,25 @@ celestia-appd tx staking create-validator \
     --fees=21000utia \
     --gas=220000
 ```
+
+:::tip NOTE
+The options `--identity`, `--website`, `--security-contact` and `--details` are optional. The `--identity` value is used to verify identity with systems like [Keybase](https://keybase.io/) or UPort. If you need to add or update the values of these descriptive fields when your validator is already created, you can use the following command (remove the options that you don't want to change the values for):
+
+```bash
+celestia-appd tx staking edit-validator \
+    --new-moniker=<new_validator_name> \
+    --identity=<identity_signature> \
+    --website="<validator_website>" \
+    --security-contact="<email_address_for_security_contact>" \
+    --details="New description of the validator." \
+    --chain-id={{constants.mochaChainId}} \
+    --from=$VALIDATOR_WALLET \
+    --keyring-backend=test \
+    --fees=21000utia \
+    --gas=220000
+```
+
+:::
 
 You will be prompted to confirm the transaction:
 
@@ -233,6 +201,60 @@ You should now be able to see your validator from
 
 After starting your node, please submit your node as a seed and peer to the
 [networks repository](https://github.com/celestiaorg/networks).
+
+## Optional: Delegate more stake to a validator
+
+Create an environment variable for the address:
+
+```bash
+VALIDATOR_WALLET=<validator-wallet-name>
+```
+
+If you want to delegate more stake to any validator, including your own you
+will need the `celestiavaloper` address of the validator in question. You can run
+the command below to get the `celestiavaloper` of your local validator wallet in
+case you want to delegate more to it:
+
+```bash
+celestia-appd keys show $VALIDATOR_WALLET --bech val -a
+```
+
+After entering the wallet passphrase you should see a similar output:
+
+```bash
+Enter keyring passphrase:
+celestiavaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u43cv6hd
+```
+
+To delegate tokens to the `celestiavaloper` validator, as an
+example you can run:
+
+```bash-vue
+celestia-appd tx staking delegate \
+<the_valoper_address_starts_with_celestiavaloper1...> 1000000utia \
+--from=$VALIDATOR_WALLET --chain-id={{constants.mochaChainId}} \
+--fees=21000utia
+```
+
+If successful, you should see a similar output as:
+
+```console
+code: 0
+codespace: ""
+data: ""
+gas_used: "0"
+gas_wanted: "0"
+height: "0"
+info: ""
+logs: []
+raw_log: '[]'
+timestamp: ""
+tx: null
+txhash: <tx-hash>
+```
+
+You can check if the TX hash went through using the block explorer by
+inputting the `txhash` ID that was returned.
 
 ## Optional: Transaction indexer configuration options
 

--- a/how-to-guides/validator-node.md
+++ b/how-to-guides/validator-node.md
@@ -202,7 +202,7 @@ You should now be able to see your validator from
 After starting your node, please submit your node as a seed and peer to the
 [networks repository](https://github.com/celestiaorg/networks).
 
-## Optional: Delegate more stake to a validator
+## Optional: Delegate stake to a validator
 
 Create an environment variable for the address:
 


### PR DESCRIPTION
## Overview

This PR contains the following two improvements for the page [Setting up a Celestia validator node](https://docs.celestia.org/how-to-guides/validator-node).

First, the sub-section "Delegate stake to a validator" is moved a bit later after creating a validator. If this is done before creating the validator, the transaction will fail with an error "failed to execute message; message index: 0: validator does not exist" (example [here](https://testnet.celestia.explorers.guru/transaction/CEDAC5D415A774E37CA4F4C5D04E6D0EE4F532A9D66038BC5C64ADEC44559681?height=5857805)).

Second, when creating a validator, users can add extra information such as the logo, website, and a description for the validator. It is also possible to update these fields after creating a validator. This PR adds such explanations to the related section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved the validator node setup guide by reorganizing and clarifying delegation instructions.
  - Clarified usage of the validator wallet variable.
  - Enhanced validator creation steps with optional metadata fields and added guidance on updating validator details after creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->