### PR TITLE
docs: fix non-working link 

### DIFF
--- a/how-to-guides/celestia-app-commands.md
+++ b/how-to-guides/celestia-app-commands.md
@@ -156,7 +156,7 @@ proposals](https://docs.cosmos.network/v0.46/modules/gov/01_concepts.html#propos
 the list of [parameter defaults in the
 specs](https://github.com/celestiaorg/celestia-app/blob/0012451c4dc118767dd59bc8d341878b7a7cacdf/specs/src/specs/params.md),
 and the [x/paramfilter module
-specs](https://github.com/celestiaorg/celestia-app/blob/main/x/minfee/README.md).
+specs](https://github.com/celestiaorg/celestia-app/tree/1570b3d4937ac4418b3ecf77365d47c5f094ad8f/x/paramfilter).
 
 Viewing the available proposals can be done with the query command:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the governance proposals section with a new link to the "x/paramfilter" directory at a specific commit for improved reference accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->