### PR TITLE
Enhance quick-start guide with improved clarity and organization

### DIFF
--- a/how-to-guides/quick-start.md
+++ b/how-to-guides/quick-start.md
@@ -85,7 +85,7 @@ Let's set the trusted hash!
 1. Set the trusted height & hash
     1. Open your `config.toml` at `~/.celestia-light-{{ constants.mochaChainId }}/config.toml`
     1. Set `DASer.SampleFrom` to the trusted height (e.g. `SampleFrom = 123456`)
-    1. Set `Header.TrustedHash` ti the trusted hash (e.g. `TrustedHash = "71BDED03E16EC34A6548388ADBAF3BA679FD5C1AAC3587A7F5F843741856D839"` )
+    1. Set `Header.TrustedHash` ti the trusted hash (e.g. `TrustedHash = "E8BD0C48260C496BB7A4D8D1E7BDBF1F26A2FE3CF5714DECE1741B2FFB3C095C"` )
 
 > If you don't do this, when trying to retrieve data in a few minutes, you'll see a response saying `"result": "header: syncing in progress: localHeadHeight: 94721, requestedHeight: 2983850"`. You'll either need to let the node sync to the `requestedHeight`, or use quick sync with trusted hash to do this.
 Learn more in [the trusted hash quick sync guide](/how-to-guides/celestia-node-trusted-hash.md).

--- a/how-to-guides/quick-start.md
+++ b/how-to-guides/quick-start.md
@@ -258,24 +258,17 @@ celestia light auth admin --p2p.network mocha
 
 Use `celestia light auth --help` to learn more about the available options.
 
-### Key management with cel-key
+### Advanced Key management with `cel-key`
 
-In the first part of this guide, we generated a key when we initialized the light node.
 
-An advanced option for key management is using the `cel-key` utility, which is a separate tool from the `celestia` binary. `cel-key` is a key management tool that allows you to create, import, and manage keys for your Celestia DA node.
+For more advanced key management beyond the built-in capabilities of the light node, use the separate cel-key utility. This dedicated tool allows you to: 
+ - Create, import, and manage keys.
+ - Backup, verify and select the active key used by your node
 
-If you're using the quickstart script above, you will have to build `cel-key` separately from source. You can find the instructions for building `cel-key` in the [celestia-node](/how-to-guides/celestia-node.md) documentation.
+To utilize cel-key, you'll need to build it separately. Follow the instructions provided in the [celestia-node](/how-to-guides/celestia-node.md) documentation.
 
-#### Managing the key returned by `celestia state account-address`
+Detailed instructions for backing up, recovering, and verifying node keys are available in the guide on [Managing the key returned by `celestia state account-address`](/tutorials/celestia-node-key.md#managing-the-key-returned-by-celestia-state-account-address).
 
-When you run the command `celestia state account-address`, it returns the address of the key that your node is currently using. This is the same key that was generated during node initialization or that you've manually created/imported with `cel-key`.
-
-For detailed instructions on how to:
-- Backup and recover this key
-- Verify the relationship between this key and your node
-- Use a specific key with your node
-
-Please refer to our comprehensive guide on [Managing the key returned by celestia state account-address](/tutorials/celestia-node-key.md#managing-the-key-returned-by-celestia-state-account-address).
 
 
 ## Troubleshooting

--- a/how-to-guides/quick-start.md
+++ b/how-to-guides/quick-start.md
@@ -215,6 +215,7 @@ In response, you'll see the data you posted:
   }
 }
 ```
+You can also inspect this example on celenium explorer [here](https://mocha.celenium.io/blob?commitment=cVqyRncskjEExVbcKNXU/PygOYsKJSvNGd1XBUlXVqw=&hash=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAABxdW90ZXM=&height=2990556).
 
 Let's break it down:
 

--- a/how-to-guides/quick-start.md
+++ b/how-to-guides/quick-start.md
@@ -79,12 +79,13 @@ Let's set the trusted hash!
 1. Get trusted height & hash from the P-OPS consensus endpoint:
 
     ```bash
-    export TRUSTED_HEIGHT=$(curl -s "https://rpc-mocha.pops.one/header" | jq -r '.result.header.height') && export TRUSTED_HASH=$(curl -s "https://rpc-mocha.pops.one/header" | jq -r '.result.header.last_block_id.hash') && echo "Height: $TRUSTED_HEIGHT" && echo "Hash: $TRUSTED_HASH"
+    read -r TRUSTED_HEIGHT TRUSTED_HASH <<<"$(curl -s https://rpc-mocha.pops.one/header | jq -r '.result.header | "\(.height) \(.last_block_id.hash)"')" && export TRUSTED_HEIGHT TRUSTED_HASH && echo "Height: $TRUSTED_HEIGHT" && echo "Hash:   $TRUSTED_HASH"
     ```
 
 1. Set the trusted height & hash
-    1. Open your `config.toml` at `.celestia-light-{{ constants.mochaChainId }}/config.toml`
+    1. Open your `config.toml` at `~/.celestia-light-{{ constants.mochaChainId }}/config.toml`
     1. Set `DASer.SampleFrom` to the trusted height (e.g. `SampleFrom = 123456`)
+    1. Set `Header.TrustedHash` ti the trusted hash (e.g. `TrustedHash = "71BDED03E16EC34A6548388ADBAF3BA679FD5C1AAC3587A7F5F843741856D839"` )
 
 > If you don't do this, when trying to retrieve data in a few minutes, you'll see a response saying `"result": "header: syncing in progress: localHeadHeight: 94721, requestedHeight: 2983850"`. You'll either need to let the node sync to the `requestedHeight`, or use quick sync with trusted hash to do this.
 Learn more in [the trusted hash quick sync guide](/how-to-guides/celestia-node-trusted-hash.md).
@@ -96,8 +97,7 @@ Run the following command to start your light node:
 In the same terminal you initialized the node store and set the variable for `TRUSTED_HASH`, start the node with the hash and flag:
 
 ```bash
-celestia light start --headers.trusted-hash $TRUSTED_HASH \
-    --p2p.network mocha --core.ip rpc-mocha.pops.one --core.port 9090
+celestia light start --p2p.network mocha --core.ip rpc-mocha.pops.one --core.port 9090
 ```
 
 The `core.ip` flag is used to specify the consensus RPC endpoints you want to connect to, this is the same one we got the trusted height and hash from. We'll use `rpc-mocha.pops.one` from the P-OPS team for Mocha testnet. The `headers.trusted-hash` flag will set the trusted hash from the previous section.
@@ -116,7 +116,7 @@ network: 	{{ constants.mochaChainId }}
 ```
 
 :::tip
-If you want to see that your node is synced, use the `celestia das sampling-stats` command to check it in another terminal:
+If you want to see that your node is synced, use the `celestia das sampling-stats` command to check it in another terminal. Here is how a fully synced node looks like:
 
 ```bash
 {

--- a/how-to-guides/quick-start.md
+++ b/how-to-guides/quick-start.md
@@ -230,6 +230,23 @@ Congratulations! You've successfully learned how to run a light node to post and
 
 This section covers some more in-depth topics that you may find useful when working with your Celestia light node. For advanced configurations like running with custom keys, using SystemD, or authentication with core endpoints, see the [light node guide](/how-to-guides/light-node.md).
 
+### Node store contents
+
+As described in the [initialize the light node section](#initialize-the-light-node) above, the node store is created in the `~/.celestia-<node-type>-<network>` directory. 
+
+In this guide, the node store for `~/.celestia-light-{{ constants.mochaChainId }}` contains the following directories and file types:
+
+- `config.toml`: Node configuration settings
+- `data/`: Contains database files
+  - `.vlog` files: Value log files storing actual data
+  - `.sst` files: Static sorted tables containing indexed data
+  - System files: `DISCARD`, `KEYREGISTRY`, and `MANIFEST` for database management
+- `keys/`: Stores node identity and account keys
+  - Contains encoded node identifiers
+  - `keyring-test/`: Test keyring directory
+    - `.address` files: Account addresses
+    - `.info` files: Key metadata and information
+
 ### Get your auth token
 
 Your auth token may be useful when you want to interact with your Celestia light node from a client application. You can get your auth token by running:
@@ -259,6 +276,17 @@ For detailed instructions on how to:
 
 Please refer to our comprehensive guide on [Managing the key returned by celestia state account-address](/tutorials/celestia-node-key.md#managing-the-key-returned-by-celestia-state-account-address).
 
+
+## Troubleshooting
+
+If you run into issues, check out the [troubleshooting](/how-to-guides/celestia-node-troubleshooting.md) page for common problems and solutions.
+
+## Next steps
+
+Check out the [rollup stacks page](/how-to-guides/rollup-stacks.md) to get started learning about ways to build whatever with Celestia underneath. 
+
+Also, here are some suggested tutorials for you:
+
 ### Rust client tutorial
 
 If you're interested in writing a Rust program to interact with your Celestia light node, check out the [Rust client tutorial](/tutorials/rust-client-tutorial.md).
@@ -267,29 +295,5 @@ If you're interested in writing a Rust program to interact with your Celestia li
 
 If you're interested in writing a Golang program to interact with your Celestia light node, check out the [Golang client tutorial](/tutorials/golang-client-tutorial.md).
 
-### Node store contents
-
-As described in the [initialize the light node section](#initialize-the-light-node) above, the node store is created in the `~/.celestia-<node-type>-<network>` directory.
-
-In this guide, the node store for `~/.celestia-light-{{ constants.mochaChainId }}` contains the following directories and file types:
-
-- `config.toml`: Node configuration settings
-- `data/`: Contains database files
-  - `.vlog` files: Value log files storing actual data
-  - `.sst` files: Static sorted tables containing indexed data
-  - System files: `DISCARD`, `KEYREGISTRY`, and `MANIFEST` for database management
-- `keys/`: Stores node identity and account keys
-  - Contains encoded node identifiers
-  - `keyring-test/`: Test keyring directory
-    - `.address` files: Account addresses
-    - `.info` files: Key metadata and information
-
-## Troubleshooting
-
-If you run into issues, check out the [troubleshooting](/how-to-guides/celestia-node-troubleshooting.md) page for common problems and solutions.
-
-## Next steps
-
-Check out the [rollup stacks page](/how-to-guides/rollup-stacks.md) to get started learning about ways to build whatever with Celestia underneath.
 
 Head to the next page to learn about different node types for the consensus and DA networks.


### PR DESCRIPTION
## Overview 

This PR improves the quick-start guide with several enhancements:

- Streamlines the trusted hash retrieval command using a more efficient one-liner (avoids possible errors)
- Fixes explicit path for config.toml location with home directory
- Adds TrustedHash configuration step that was previously missing
  - Simplifies the node start command by removing the redundant trusted hash flag
- Makes it explicit that the output is an example of fully synced node output
- Adds link to celenium explorer for the example blobl created
- Reorganizes and improves the "Diving deeper" section
- Rewrites the (`cel-key`) key management section for simplicity and clarity
- Improves overall document organization and flow

These changes make the guide more user-friendly and provide better clarity for new users getting started with Celestia light nodes.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved instructions for setting trusted height and hash with a streamlined shell command.
  - Corrected file path references and added missing configuration steps.
  - Simplified the example command for starting the light node.
  - Expanded syncing status information with sample output.
  - Added a link to inspect example data on the Celenium explorer.
  - Introduced a new section detailing node store directory contents.
  - Updated and clarified the key management section, emphasizing advanced usage and external resources.
  - Reorganized advanced client tutorials under a "Next steps" section.
  - Added a new "Troubleshooting" section with helpful references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->