### PR TITLE
docs: arabica v4 upgrade height

### DIFF
--- a/how-to-guides/network-upgrade-process.md
+++ b/how-to-guides/network-upgrade-process.md
@@ -81,8 +81,8 @@ Like the Ginger upgrade, this upgrade will use the in-protocol signaling mechani
 
 The new delay periods for v4 are based on [celestia-app #4413](https://github.com/celestiaorg/celestia-app/issues/4413):
 
-| Network      | Chain ID   | Date and time | Upgrade height | Delay period
-|-------------|------------|---------------|----------------|-------------
-| Arabica     | arabica-11 | TBD           | TBD            | 1 day
-| Mocha       | mocha-4    | TBD           | TBD            | 2 days
-| Mainnet Beta| celestia   | TBD           | TBD            | 7 days
+| Network      | Chain ID   | Date and time         | Upgrade height | Delay period
+|-------------|------------|------------------------|----------------|-------------
+| Arabica     | arabica-11 | 2025/05/16 07:51:35 UTC| 5975265        | 1 day
+| Mocha       | mocha-4    | TBD                    | TBD            | 2 days
+| Mainnet Beta| celestia   | TBD                    | TBD            | 7 days


### PR DESCRIPTION
Reviewers can confirm by inspecting the raw block on https://arabica.celenium.io/block/5975265 and https://arabica.celenium.io/block/5975266 where the app version was increased to 4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the network upgrade schedule to include the specific date, time, and upgrade height for the Arabica network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->