### PR TITLE
Update block timing in docs

### DIFF
--- a/how-to-guides/submit-data.md
+++ b/how-to-guides/submit-data.md
@@ -184,7 +184,7 @@ specify the nonce manually. If this is not done, the new transactions will not
 be able to be submitted until the first transaction is reaped from the mempool (i.e. included in a block), or dropped due to timing out.
 
 By default, nodes will drop a transaction if it does not get included in 5
-blocks (roughly 1 minute). At this point, the user must resubmit their
+blocks (roughly 30 seconds). At this point, the user must resubmit their
 transaction if they want it to eventually be included.
 
 As of v1.0.0 of the application (celestia-app), users are unable to replace an


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

I noticed the docs refer to the older block timing in this section. Now that blocks are every 6 seconds, 5 blocks is roughly 30 seconds, not a minute.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the estimated time for nodes to drop transactions from the mempool, correcting it from roughly 1 minute to roughly 30 seconds after 5 blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->