### PR TITLE
doc: Add Noders Services DA Archive Node Endpoint

### DIFF
--- a/how-to-guides/mainnet.md
+++ b/how-to-guides/mainnet.md
@@ -212,6 +212,7 @@ pruning any data so all data available data is retrievable. You can
 | -------------------------------- | ----------------------------------------------------------------------------------------- | -------- | ------------ |
 | Grove                            | `celestia-archival.rpc.grove.city/v1/c33eeadb`                                            | -        | -            |
 | Mzonder                          | `celestia-da-full-storage.mzonder.com`                                                    | 27758    | 27759        |
+| Noders Services                  | `celestia-archive-da.noders.services`                                                     | 26658    | 26659        |
 | QuickNode                        | <https://www.quicknode.com/chains/celestia> ([docs](https://quicknode.com/docs/celestia)) | -        | -            |
 | See the Brightly Stake dashboard | <https://celestia-tools.brightlystake.com/>                                               | -        | -            |
 


### PR DESCRIPTION

## Overview
Added new archival data availability RPC endpoint from Noders Services to the Celestia Mainnet Beta guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added "Noders Services" as a new archival data availability RPC endpoint provider, including its RPC and Gateway port details, to the mainnet guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->