### PR TITLE
docs [learn]: replace incorrect link

### DIFF
--- a/learn/how-celestia-works/transaction-lifecycle.md
+++ b/learn/how-celestia-works/transaction-lifecycle.md
@@ -27,7 +27,7 @@ executed by the Celestia state machine once the block is committed.
 
 Next, the block producer adds to the block header a commitment
 of the block data. As
-[described in the "Celestia's data availability layer" page](/how-to-guides/data-availability-layer.md),
+[described in the "Celestia's data availability layer" page](/learn/how-celestia-works/data-availability-layer.md),
 the commitment is the Merkle root of the $4k$ intermediate Merkle roots
 (i.e., one for each row and column of the extended matrix).
 To compute this commitment, the block producer performs the following operations:


### PR DESCRIPTION
## Overview

broken link is on [this page](https://docs.celestia.org/learn/how-celestia-works/transaction-lifecycle) . replaced. now works prorpely 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated a hyperlink to correctly reference the "Celestia's data availability layer" page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->