### PR TITLE
fix link to staking-governance-supply in learn/tia.md

### DIFF
--- a/learn/tia.md
+++ b/learn/tia.md
@@ -56,7 +56,7 @@ governance over key parts of Celestia, such as voting on network parameters
 through governance proposals, and governing the community pool, which receives
 2% of block rewards.
 
-Learn more about [Celestia’s decentralised governance model](/how-to-guides/staking-governance-supply.md#decentralised-governance).
+Learn more about [Celestia’s decentralised governance model](/learn/staking-governance-supply.md#decentralised-governance).
 
 ### Denominations
 


### PR DESCRIPTION
wrong link is [here](https://docs.celestia.org/learn/tia)