### PR TITLE
docs: fix typo in blobstream-proof-queries.md

### DIFF
--- a/how-to-guides/blobstream-proof-queries.md
+++ b/how-to-guides/blobstream-proof-queries.md
@@ -1127,7 +1127,7 @@ If the `dataRoot` or the `tupleRootNonce` is unknown during the verification:
 - `dataRoot`: can be queried using the `/block?height=15` query
   (`15` in this example endpoint), and taking the `data_hash`
   field from the response.
-- `tupleRootNonce`: can be retrieved via querying the
+- `tupleRootNonce`: can be retrieved by querying the
   data commitment stored events from the Blobstream
   contract and looking for the nonce attesting to the
   corresponding data.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

"Retried" means to try again, usually after a failure. In our context, you mean to **fetch** or **get** data, so the correct word is **"retrieved."**
