### PR TITLE
chore: add v4 mainnet vers

### DIFF
--- a/.vitepress/constants/constants.js
+++ b/.vitepress/constants/constants.js
@@ -1,5 +1,5 @@
 const constants = Object.freeze({
-  golangNodeMainnet: "1.23.0",
+  golangNodeMainnet: "1.24.1",
   golangNodeMocha: "1.24.1",
   golangNodeArabica: "1.24.1",
   arabicaChainId: "arabica-11",

--- a/.vitepress/constants/mainnet_versions.js
+++ b/.vitepress/constants/mainnet_versions.js
@@ -1,7 +1,7 @@
 const mainnetVersions = Object.freeze({
-  "app-latest-tag": "v3.10.3",
-  "app-latest-sha": "39292d9f8a64f6849169088e4e8b69016f777524",
-  "node-latest-tag": "v0.22.3",
-  "node-latest-sha": "7e98e6f400baeb49b597fa093353fb68b2e548a6",
+  "app-latest-tag": "v4.0.10",
+  "app-latest-sha": "117b77cc511850eb24ac02472f0b18aec99a76cd",
+  "node-latest-tag": "v0.23.5",
+  "node-latest-sha": "1a02cee72b85ce0afa6d96c8018782bbaab79a3d",
 });
 export default mainnetVersions;


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Updates golang for mainnet to 1.24.1, celestia-node to v0.23.5 https://github.com/celestiaorg/celestia-node/releases/tag/v0.23.5, and celestia-app to v4.0.10 https://github.com/celestiaorg/celestia-app/releases/tag/v4.0.10

Note to reviewer:
1. unfortunately pr previews are failing bc of #2150 
2. same reason this PR is manual like https://github.com/celestiaorg/docs/pull/2149

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
