### PR TITLE
docs: update heights for v5

### DIFF
--- a/how-to-guides/network-upgrade-process.md
+++ b/how-to-guides/network-upgrade-process.md
@@ -33,7 +33,7 @@ The upgrade process can be broken down into a few steps:
 The Lemongrass network upgrade (v2) was the first consensus layer breaking change since Celestia's Mainnet Beta genesis block. The Lemongrass network upgrade included all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-017.md) and implemented CIP-10 for future upgrades.
 
 | Network      | Chain ID   | Date and time          | Upgrade height |
-| ------------ | ---------- | ---------------------- | -------------- |
+|--------------|------------|------------------------|----------------|
 | Arabica      | arabica-11 | 2024/08/19 @ 14:00 UTC | 1751707        |
 | Mocha        | mocha-4    | 2024/08/28 @ 14:00 UTC | 2585031        |
 | Mainnet Beta | celestia   | 2024/09/18 @ 14:00 UTC | 2371495        |
@@ -55,7 +55,7 @@ Unlike the Lemongrass upgrade, there will not be a pre-programmed upgrade height
 Learn more in the [v3.0.0 release notes](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md#v300).
 
 | Network      | Chain ID   | Date and time             | Upgrade height |
-| ------------ | ---------- | ------------------------- | -------------- |
+|--------------|------------|---------------------------|----------------|
 | Arabica      | arabica-11 | 2024/11/05 @ 21:55:13 UTC | 2348907        |
 | Mocha        | mocha-4    | 2024/11/14 @ 18:31:11 UTC | 3140052        |
 | Mainnet Beta | celestia   | 2024/12/12 @ 14:28:52 UTC | 2993219        |
@@ -75,26 +75,26 @@ Like the Ginger upgrade, this upgrade used the in-protocol signaling mechanism. 
 
 The delay periods for v4 were based on [celestia-app #4413](https://github.com/celestiaorg/celestia-app/issues/4413):
 
-| Network      | Chain ID   | Date and time                      | Upgrade height | Delay period |
-| ------------ | ---------- | ---------------------------------- | -------------- | ------------ |
-| Arabica      | arabica-11 | 2025/05/16 07:51:35 UTC            | 5975265        | 1 day        |
-| Mocha        | mocha-4    | 2025/07/01 11:51:58 UTC            | 6915786        | 2 days       |
-| Mainnet Beta | celestia   | (Estimate) 2025/07/28 12:08:30 UTC | 6680339        | 7 days       |
+| Network      | Chain ID   | Date and time           | Upgrade height | Delay period |
+|--------------|------------|-------------------------|----------------|--------------|
+| Arabica      | arabica-11 | 2025/05/16 07:51:35 UTC | 5975265        | 1 day        |
+| Mocha        | mocha-4    | 2025/07/01 11:51:58 UTC | 6915786        | 2 days       |
+| Mainnet Beta | celestia   | 2025/07/28 13:46:27 UTC | 6680339        | 7 days       |
+
+#### v5 network upgrade
+
+The v5 network upgrade included a fix to restore IBC support which was broken in v4.
+
+Like previous upgrades, this upgrade will use the in-protocol signaling mechanism. The upgrade will automatically activate after 5/6 of voting power have signaled for a particular version and a delay period based on the network, in accordance with the table below.
+
+| Network      | Chain ID   | Date and time           | Upgrade height | Delay period |
+|--------------|------------|-------------------------|----------------|--------------|
+| Arabica      | arabica-11 | 2025/07/29 19:59:00 UTC | 7316464        | 1 block      |
+| Mocha        | mocha-4    | 2025/07/30 17:07:29 UTC | 7401191        | 1 block      |
+| Mainnet Beta | celestia   | 2025/08/01 14:30:29 UTC | 6748821        | 1 block      |
 
 ### Upcoming Upgrades
 
 :::warning
 You **do not** need to use a tool like [cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) to upgrade the binary. Please upgrade your binary before signaling support for the new version.
 :::
-
-#### v5 network upgrade
-
-The v5 network upgrade includes a fix to restore IBC support which was broken in v4.
-
-Like previous upgrades, this upgrade will use the in-protocol signaling mechanism. The upgrade will automatically activate after 5/6 of voting power have signaled for a particular version and a delay period based on the network, in accordance with the table below.
-
-| Network      | Chain ID   | Date and time           | Upgrade height | Delay period |
-| ------------ | ---------- | ----------------------- | -------------- | ------------ |
-| Arabica      | arabica-11 | 2025/07/29 19:59:00 UTC | 7316464        | 1 block      |
-| Mocha        | mocha-4    | TBD                     | TBD            | 1 block      |
-| Mainnet Beta | celestia   | TBD                     | TBD            | 1 block      |


### PR DESCRIPTION
Update the heights for v5 activation

## Screenshot

<img width="1480" height="1622" alt="Screenshot 2025-08-06 at 10 14 20 AM" src="https://github.com/user-attachments/assets/b3846bc9-4ea1-46e5-868f-c75f375a6fd7" />
