### PR TITLE
Add link to contribution guidelines in README #2193

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ improving content clarity, or adding new topics, every contribution helps.
 - Push & Create PR: Push your changes to your fork and create a pull request
   to the main branch of this repository.
 
-Please ensure to review the **[detailed Contribution Guidelines](https://github.com/celestiaorg/.github/blob/main/CONTRIBUTING.md#external-contributions)** before
+Please ensure to review the **[full Contribution Guidelines](https://github.com/celestiaorg/.github/blob/main/CONTRIBUTING.md#external-contributions)** before
 making a pull request.
 
 ## Documentation standards


### PR DESCRIPTION
## Summary
This PR adds a link to the external contribution guidelines in the README.md file, as requested in issue #2193. It directs users to the "External Contributions" section for detailed instructions.

## Related Issue
Closes #2193