### PR TITLE
bug: fix missing wallet logos in staking guide

### DIFF
--- a/learn/how-to-stake-tia.md
+++ b/learn/how-to-stake-tia.md
@@ -20,13 +20,13 @@ wallets.
 <!-- markdownlint-disable MD033 -->
 <div style="display: flex">
     <a href="#stake-tia-with-keplr-wallet">
-        <img src="../public/img/keplr.png" alt="Keplr">
+        <img src="/public/img/keplr.png" alt="Keplr">
     </a>
     <a href="#stake-tia-with-leap-wallet">
-        <img src="../public/img/leap.png" alt="Leap">
+        <img src="/public/img/leap.png" alt="Leap">
     </a>
     <a href="#stake-tia-with-gem-wallet">
-        <img src="../public/img/gem.png" alt="Gem Wallet">
+        <img src="/public/img/gem.png" alt="Gem Wallet">
     </a>
 </div>
 

--- a/learn/how-to-stake-tia.md
+++ b/learn/how-to-stake-tia.md
@@ -18,21 +18,15 @@ wallets.
 ## Select your preferred wallet
 
 <!-- markdownlint-disable MD033 -->
-<div style="display: inline-block;">
+<div style="display: flex">
     <a href="#stake-tia-with-keplr-wallet">
-    <img src="../public/img/keplr.png" alt="Keplr">
+        <img src="../public/img/keplr.png" alt="Keplr">
     </a>
-</div>
-
-<div style="display: inline-block;">
     <a href="#stake-tia-with-leap-wallet">
-    <img src="../public/img/leap.png" alt="Leap">
+        <img src="../public/img/leap.png" alt="Leap">
     </a>
-</div>
-
-<div style="display: inline-block;">
     <a href="#stake-tia-with-gem-wallet">
-    <img src="../public/img/gem.png" alt="Gem Wallet">
+        <img src="../public/img/gem.png" alt="Gem Wallet">
     </a>
 </div>
 

--- a/learn/how-to-stake-tia.md
+++ b/learn/how-to-stake-tia.md
@@ -20,19 +20,19 @@ wallets.
 <!-- markdownlint-disable MD033 -->
 <div style="display: inline-block;">
     <a href="#stake-tia-with-keplr-wallet">
-    <img src="/img/keplr.png" alt="Keplr">
+    <img src="../public/img/keplr.png" alt="Keplr">
     </a>
 </div>
 
 <div style="display: inline-block;">
     <a href="#stake-tia-with-leap-wallet">
-    <img src="/img/leap.png" alt="Leap">
+    <img src="../public/img/leap.png" alt="Leap">
     </a>
 </div>
 
 <div style="display: inline-block;">
     <a href="#stake-tia-with-gem-wallet">
-    <img src="/img/gem.png" alt="Gem Wallet">
+    <img src="../public/img/gem.png" alt="Gem Wallet">
     </a>
 </div>
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Fixes issue where wallet selection images (Keplr, Leap, Gem) were not displaying properly in the staking guide.

## Problem
- Wallet logos were not visible to users
- Cards were stacking vertically instead of showing horizontally

## Solution
- Fixed the incorrect path to the wallet icons
- Added horizontal alignment

Fixed #2216