### PR TITLE
delete paragraph about long block times

### DIFF
--- a/tutorials/integrate-celestia.md
+++ b/tutorials/integrate-celestia.md
@@ -67,18 +67,3 @@ other platforms.
 Since we utilize Tendermint and the Cosmos-SDK, syncing the chain can be
 performed by any method that is supported by those libraries. This includes
 fast-sync, state sync, and quick sync.
-
-### Notable exceptions relative to other blockchains
-
-Relative to other Tendermint based chains, Celestia will have significantly
-longer blocktimes of roughly 6\* seconds. The reason behind this block time is to
-optimize the bandwidth used by light clients that are sampling the chain, and
-is not because we have modified Tendermint consensus in any meaningful way.
-Validators will likely download/upload relatively large blocks. It should be
-noted that while these blocks are large, very little typical blockchain state
-execution is actually occurring on Celestia. Meaning that the bandwidth
-requirements will likely be larger than that of a typical Cosmos-SDK based
-blockchain full node, the computing requirements should be similar in
-magnitude.
-
-\*Subject to Change


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
https://github.com/celestiaorg/docs/blob/1ce4b22d9133de0e468b3994942883ef256b476f/tutorials/integrate-celestia.md#L71

Since 5c630b4f42b86b74d1271ec8eecec78291ea037f & #2052 this section makes no sense. The pre-[Ginger](https://blog.celestia.org/ginger/) block time of 12s was very unusual, but 6s is an extremely common block time - e.g. used by Cosmos Hub.
