### PR TITLE
docs: add status pages to participate page that has all networks on it

### DIFF
--- a/how-to-guides/participate.md
+++ b/how-to-guides/participate.md
@@ -20,6 +20,8 @@ the network is stable and continues to receive updates, it remains
 experimental and users may experience occasional instability or
 reduced performance.
 
+See the [official Celestia Mainnet Beta status page](https://status.celestia.dev/status/mainnet).
+
 ### Compatible software versions for Mainnet Beta
 
 <MainnetVersionTags/>
@@ -36,6 +38,8 @@ Arabica will be updated frequently and might be unstable at times given new upda
 Validators won't be able to validate on Arabica as it is not designed for
 validators to participate.
 
+See the [official Celestia Arabica devnet status page](https://status.celestia.dev/status/arabica).
+
 #### Compatible software versions for Arabica devnet
 
 <ArabicaVersionTags/>
@@ -47,6 +51,8 @@ to test out their infrastructure by running nodes connected to the network. Deve
 can also deploy sovereign rollups on Mocha, it just will always be behind Arabica
 as Mocha upgrades are slower given they need to be done via breaking network upgrades
 in coordination with the validator community on Mocha.
+
+See the [official Celestia Mocha testnet status page](https://status.celestia.dev/status/mocha).
 
 ### Compatible software versions for Mocha testnet
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

@sysrex are these status pages actively maintained?

1. [Arabica](https://status.celestia.dev/status/arabica) shows partially degraded service. has that node's IP changed?
<img width="1175" height="360" alt="Screenshot 2025-09-18 at 11 45 34" src="https://github.com/user-attachments/assets/6c06960f-f17a-45a4-a1b0-1415a9747f01" />
2. [mocha](https://status.celestia.dev/status/mocha) shows no consensus nodes
<img width="1150" height="169" alt="Screenshot 2025-09-18 at 11 46 13" src="https://github.com/user-attachments/assets/1a318d1b-43b4-4396-adda-71ae4255093b" />

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
