### PR TITLE
fix: Update docs repository base URL to include the main branch path.

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ const withBasePath = (path: string) => `${basePath}${path}`;
 const THEME_CONFIG = {
   projectLink: "https://github.com/celestiaorg/docs",
   chatLink: "https://discord.gg/celestiacommunity",
-  docsRepositoryBase: "https://github.com/celestiaorg/docs",
+  docsRepositoryBase: "https://github.com/celestiaorg/docs/blob/main",
   footerText: "Celestia Documentation",
   primaryHue: 200,
   primarySaturation: 100,


### PR DESCRIPTION
This pull request makes a minor update to the documentation configuration by changing the base URL for the docs repository to point directly to the `main` branch on GitHub. This ensures that links to the documentation source files reference the latest version.