### PR TITLE
Re Implement per-pull-request preview deployments

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -115,6 +115,8 @@ jobs:
   cleanup-preview:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout docs-preview repository
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying documentation previews. The workflow is now triggered on pull request events instead of branch pushes, generates a unique preview for each PR, automatically posts (and updates) preview links in the PR, and cleans up previews when PRs are closed. These changes improve the preview deployment process, making it more robust, automated, and user-friendly.

**Workflow trigger and structure improvements:**

* The workflow is now triggered on pull request events (opened, reopened, synchronized, closed) instead of on branch pushes, and the job names and concurrency groups have been updated to reflect per-PR deployments.

**Per-PR preview deployment:**

* The build and deployment steps now generate a unique directory for each PR (e.g., `/docs-preview/pr-<PR_NUMBER>/`), ensuring that each PR gets its own isolated preview. [[1]](diffhunk://#diff-22da830e02ef5bed54ecad981722fd9c940aec797740c09927d4a904df0bccd6L35-R41) [[2]](diffhunk://#diff-22da830e02ef5bed54ecad981722fd9c940aec797740c09927d4a904df0bccd6L46-R140)
* The deployment logic was refactored to cleanly remove and recreate the target preview directory before copying new files, ensuring no stale files are left over.

**Automated preview link posting and cleanup:**

* After deploying, the workflow automatically posts (or updates) a comment on the PR with a link to the preview, using the `actions/github-script` action.
* When a PR is closed, a new `cleanup-preview` job runs to remove the corresponding preview directory and commit the removal to the `docs-preview` repository.