### PR TITLE
docs: add latest tags back and improve workflow

### DIFF
--- a/.github/workflows/latest-tags.yaml
+++ b/.github/workflows/latest-tags.yaml
@@ -11,28 +11,42 @@ on:
           - mainnet
           - arabica
           - mocha
+  schedule:
+    - cron: '0 */6 * * *'
 
 permissions:
   contents: read
 
 jobs:
-  logLatestRelease:
+  syncLatestTags:
+    name: Sync latest tags (${{ matrix.network }})
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.network == matrix.network }}
+    strategy:
+      fail-fast: false
+      matrix:
+        network:
+          - mainnet
+          - arabica
+          - mocha
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       OWNER: celestiaorg
-      NETWORK: ${{ inputs.network }}
-    outputs:
-      celestia_app_latest_tag: ${{ steps.latest.outputs.celestia_app_latest_tag }}
-      celestia_app_latest_sha: ${{ steps.latest.outputs.celestia_app_latest_sha }}
-      celestia_node_latest_tag: ${{ steps.latest.outputs.celestia_node_latest_tag }}
-      celestia_node_latest_sha: ${{ steps.latest.outputs.celestia_node_latest_sha }}
+      NETWORK: ${{ matrix.network }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Fetch latest tags and commit SHAs
         id: latest
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const fs = require('node:fs');
+            const path = require('node:path');
+
             const owner = process.env.OWNER;
             const network = process.env.NETWORK;
 
@@ -95,6 +109,7 @@ jobs:
               { repo: 'celestia-node', prefix: 'celestia_node' },
             ];
 
+            const latest = {};
             for (const target of targets) {
               core.info(`Fetching latest release for ${owner}/${target.repo} (network=${network})...`);
               const tag = await getLatestReleaseTag(target.repo);
@@ -102,32 +117,61 @@ jobs:
               core.info(`Resolved ${target.repo}: ${tag} @ ${sha}`);
               core.setOutput(`${target.prefix}_latest_tag`, tag);
               core.setOutput(`${target.prefix}_latest_sha`, sha);
+              latest[`${target.prefix}_latest_tag`] = tag;
+              latest[`${target.prefix}_latest_sha`] = sha;
             }
 
-  createPR:
-    needs: logLatestRelease
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
+            const currentVersionsPath = path.join(
+              process.env.GITHUB_WORKSPACE,
+              'constants',
+              `${network}_versions.json`,
+            );
+
+            let currentVersions = null;
+            try {
+              currentVersions = JSON.parse(fs.readFileSync(currentVersionsPath, 'utf8'));
+            } catch (error) {
+              core.warning(`Failed to read ${currentVersionsPath}: ${error.message}`);
+            }
+
+            const nextVersions = {
+              'app-latest-tag': latest.celestia_app_latest_tag,
+              'app-latest-sha': latest.celestia_app_latest_sha,
+              'node-latest-tag': latest.celestia_node_latest_tag,
+              'node-latest-sha': latest.celestia_node_latest_sha,
+            };
+
+            const shouldUpdate =
+              !currentVersions ||
+              currentVersions['app-latest-tag'] !== nextVersions['app-latest-tag'] ||
+              currentVersions['app-latest-sha'] !== nextVersions['app-latest-sha'] ||
+              currentVersions['node-latest-tag'] !== nextVersions['node-latest-tag'] ||
+              currentVersions['node-latest-sha'] !== nextVersions['node-latest-sha'];
+
+            core.info(
+              shouldUpdate
+                ? `New ${network} release detected; opening PR.`
+                : `No new ${network} release detected; skipping PR.`,
+            );
+            core.setOutput('should_update', shouldUpdate ? 'true' : 'false');
 
       - name: Write latest tags and commit SHAs
+        if: steps.latest.outputs.should_update == 'true'
         run: |
-          cat > "constants/${{ inputs.network }}_versions.json" <<'EOF'
+          cat > "constants/${{ matrix.network }}_versions.json" <<'EOF'
           {
-            "app-latest-tag": "${{ needs.logLatestRelease.outputs.celestia_app_latest_tag }}",
-            "app-latest-sha": "${{ needs.logLatestRelease.outputs.celestia_app_latest_sha }}",
-            "node-latest-tag": "${{ needs.logLatestRelease.outputs.celestia_node_latest_tag }}",
-            "node-latest-sha": "${{ needs.logLatestRelease.outputs.celestia_node_latest_sha }}"
+            "app-latest-tag": "${{ steps.latest.outputs.celestia_app_latest_tag }}",
+            "app-latest-sha": "${{ steps.latest.outputs.celestia_app_latest_sha }}",
+            "node-latest-tag": "${{ steps.latest.outputs.celestia_node_latest_tag }}",
+            "node-latest-sha": "${{ steps.latest.outputs.celestia_node_latest_sha }}"
           }
           EOF
 
       - name: Open PR
+        if: steps.latest.outputs.should_update == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          branch: gh-action/latest-tags-${{ inputs.network }}
-          commit-message: "[automated GH action] update latest release tags & commit sha (${{ inputs.network }})"
-          title: "[GH Action] Update release tags and commit SHAs for ${{ inputs.network }}"
+          branch: gh-action/latest-tags-${{ matrix.network }}
+          commit-message: "[automated GH action] update latest release tags & commit sha (${{ matrix.network }})"
+          title: "[GH Action] Update release tags and commit SHAs for ${{ matrix.network }}"
           token: ${{ secrets.PAT_CREATE_PR }}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Summary

Restores the manual “Latest Tags” workflow and updates it for the new docs constants layout. The workflow fetches the latest `celestia-app` and `celestia-node` release tags (per selected network) and resolves them to commit SHAs, then writes the results to the network JSON file and opens a PR.

## Changes

- Adds `.github/workflows/latest-tags.yaml` (manual workflow_dispatch with `network: mainnet|arabica|mocha`).
- Writes output to `constants/${network}_versions.json` to match the new directory structure and JSON-based constants usage.
- Resolves the tag’s underlying commit SHA (handles annotated tags via ref/tag fallback).

## How to run

Actions → Latest Tags → Run workflow → select network.
Creates/updates a PR from `gh-action/latest-tags-${network}` with the updated `constants/${network}_versions.json`.

## Requirements

 - `PAT_CREATE_PR` secret with permissions to push a branch and open PRs in this repo.
 - Uses `GITHUB_TOKEN` for GitHub API reads.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
