### PR TITLE
Add blobsteam deployed contracts list

### DIFF
--- a/app/build/blobstream/integrate-contracts/page.mdx
+++ b/app/build/blobstream/integrate-contracts/page.mdx
@@ -103,3 +103,21 @@ In the `DAVerifier` library, we find functions that help with data inclusion ver
 
 For an overview of a demo rollup implementation, head to [the next section](/build/blobstream/integrate-offchain).
 
+## Deployed contracts
+
+You can interact with the SP1 Blobstream contracts today. The
+SP1 Blobstream Solidity smart contracts are currently deployed on
+the following chains:
+
+
+| Contract       | EVM network            | Contract address                                                                                                                                 | Attested data on Celestia                        | Link to Celenium                                                                       |
+| -------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| SP1 Blobstream | Ethereum Mainnet       | [`0x7Cf3876F681Dbb6EdA8f6FfC45D66B996Df08fAe`](https://etherscan.io/address/0x7Cf3876F681Dbb6EdA8f6FfC45D66B996Df08fAe#events)                   | [Mainnet Beta](/how-to-guides/mainnet.md)        | [Deployment on Celenium](https://celenium.io/blobstream?network=ethereum&page=1)       |
+| SP1 Blobstream | Arbitrum One           | [`0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794`](https://arbiscan.io/address/0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794#events)                    | [Mainnet Beta](/how-to-guides/mainnet.md)        | [Deployment on Celenium](https://celenium.io/blobstream?network=arbitrum&page=1)       |
+| SP1 Blobstream | Base                   | [`0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794`](https://basescan.org/address/0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794#events)                   | [Mainnet Beta](/how-to-guides/mainnet.md)        | [Deployment on Celenium](https://celenium.io/blobstream?network=base&page=1)           |
+| SP1 Blobstream | Scroll                 | [`0x5008fa5CC3397faEa90fcde71C35945db6822218`](https://scrollscan.com/address/0x5008fa5CC3397faEa90fcde71C35945db6822218)                        | [Mainnet Beta](/how-to-guides/mainnet.md)        | N/A                                                                                    |
+| SP1 Blobstream | Sepolia                | [`0xf0c6429ebab2e7dc6e05dafb61128be21f13cb1e`](https://sepolia.etherscan.io/address/0xf0c6429ebab2e7dc6e05dafb61128be21f13cb1e#events)           | [Mocha testnet](/how-to-guides/mocha-testnet.md) | [Deployment on Celenium](https://mocha.celenium.io/blobstream?network=ethereum&page=1) |
+| SP1 Blobstream | Arbitrum Sepolia       | [`0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2`](https://sepolia.arbiscan.io/address/0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2#events)            | [Mocha testnet](/how-to-guides/mocha-testnet.md) | [Deployment on Celenium](https://mocha.celenium.io/blobstream?network=arbitrum&page=1) |
+| SP1 Blobstream | Base Sepolia           | [`0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2`](https://sepolia.basescan.org/address/0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2#events)           | [Mocha testnet](/how-to-guides/mocha-testnet.md) | [Deployment on Celenium](https://mocha.celenium.io/blobstream?network=base&page=1)     |
+| SP1 Blobstream | Holesky                | [`0x315A044cb95e4d44bBf6253585FbEbcdB6fb41ef`](https://holesky.etherscan.io/address/0x315A044cb95e4d44bBf6253585FbEbcdB6fb41ef)                  | [Mocha testnet](/how-to-guides/mocha-testnet.md) | N/A                                                                                    |
+| SP1 Blobstream | ZKSync Gateway Staging | [`0x3a038D77A9b4eBBc8A7482B438BCff11c3591792`](https://explorer.era-gateway-stage.zksync.dev/address/0x3a038D77A9b4eBBc8A7482B438BCff11c3591792) | [Mocha testnet](/how-to-guides/mocha-testnet.md) | N/A                                                                                    |


### PR DESCRIPTION
This pull request adds a new section documenting the deployment status of the SP1 Blobstream Solidity smart contracts across various EVM-compatible networks. It provides readers with contract addresses, network details, links to attested data, and references to Celenium explorers where available.

**Documentation improvements:**

* Added a "Deployed contracts" section to the integration guide, including a table listing each supported EVM network, the corresponding SP1 Blobstream contract address, links to attested data on Celestia, and Celenium explorer links.