### PR TITLE
fix: update pbs-proxy to pda-proxy to point to correct Docker image in private blockspace quickstart docs

### DIFF
--- a/app/build/private-blockspace/quickstart/page.mdx
+++ b/app/build/private-blockspace/quickstart/page.mdx
@@ -84,26 +84,26 @@ You can verify your signer address in the proxy logs it prints the address when 
 The published image is `amd64` only — run it under emulation:
 
 ```bash
-docker pull --platform=linux/amd64 ghcr.io/celestiaorg/pbs-proxy:latest
+docker pull --platform=linux/amd64 ghcr.io/celestiaorg/pda-proxy:latest
 mkdir -p "$PBS_DB_PATH"
 
-docker run --name pbs-proxy --rm -it   --platform=linux/amd64   --env-file ./.env   -v "$PBS_DB_PATH:$PBS_DB_PATH"   -v "./tls:/app/tls"   -p 26657:26657   ghcr.io/celestiaorg/pbs-proxy:latest
+docker run --name pda-proxy --rm -it   --platform=linux/amd64   --env-file ./.env   -v "$PBS_DB_PATH:$PBS_DB_PATH"   -v "./tls:/app/tls"   -p 26657:26657   ghcr.io/celestiaorg/pda-proxy:latest
 ```
 
 **Intel/AMD Linux or other amd64 hosts**
 
 ```bash
-docker pull ghcr.io/celestiaorg/pbs-proxy:latest
+docker pull ghcr.io/celestiaorg/pda-proxy:latest
 mkdir -p "$PBS_DB_PATH"
 
-docker run --name pbs-proxy --rm -it   --env-file ./.env   -v "$PBS_DB_PATH:$PBS_DB_PATH"   -v "./tls:/app/tls"   -p 26657:26657   ghcr.io/celestiaorg/pbs-proxy:latest
+docker run --name pda-proxy --rm -it   --env-file ./.env   -v "$PBS_DB_PATH:$PBS_DB_PATH"   -v "./tls:/app/tls"   -p 26657:26657   ghcr.io/celestiaorg/pda-proxy:latest
 ```
 
 ### Verify it’s running
 
 Check logs:
 ```bash
-docker logs -f pbs-proxy
+docker logs -f pda-proxy
 ```
 
 Or test status:
@@ -147,7 +147,7 @@ The proxy will:
 
 If the response includes `"result": { "height": "…" }`, you’re set. Jump to **Verify your blob** with that height.
 
-If you see `"[pbs-proxy] Verifiable encryption processing..."`, the proxy queued the job. Two quick options:
+If you see `"[pda-proxy] Verifiable encryption processing..."`, the proxy queued the job. Two quick options:
 
 **Option A — resend once**
 
@@ -157,7 +157,7 @@ Sometimes it finishes fast and you’ll get the height on the next call.
 
 Either tail logs:
 ```bash
-docker logs -f pbs-proxy | egrep -i 'submit|height|commit|error'
+docker logs -f pda-proxy | egrep -i 'submit|height|commit|error'
 ```
 
 Or poll a small window around the tip for your namespace:


### PR DESCRIPTION
## Overview

This PR fixes a typo in the private blockspace quickstart documentation where the Docker image name was incorrectly referenced as `pbs-proxy` instead of the correct `pda-proxy`.

### Changes

- Updated all references of `ghcr.io/celestiaorg/pbs-proxy` → `ghcr.io/celestiaorg/pda-proxy`
- Updated container name from `--name pbs-proxy` → `--name pda-proxy`
- Updated log commands from `docker logs -f pbs-proxy` → `docker logs -f pda-proxy`
- Updated log message reference from `[pbs-proxy]` → `[pda-proxy]`

### Context

The incorrect image name (`pbs-proxy`) caused a `403 Forbidden` error when users attempted to pull the Docker image, as this package doesn't exist. The correct public package is [`pda-proxy`](https://github.com/celestiaorg/private-blockspace-proxy/pkgs/container/pda-proxy).