### PR TITLE
docs: add Hibiscus (v7) upgrade and move Matcha (v6) to past upgrades

### DIFF
--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -149,6 +149,6 @@ Key features include:
 
 | Network      | Chain ID   | Date and time | Upgrade height                                                        | Delay period |
 | ------------ | ---------- | ------------- | --------------------------------------------------------------------- | ------------ |
-| Arabica      | {constants.arabicaChainId} | TBD           | [10133989](https://arabica.celenium.io/block/10133989?tab=transactions) | 1 day        |
+| Arabica      | {constants.arabicaChainId} | 2026/02/14 02:36:26 UTC | [10133989](https://arabica.celenium.io/block/10133989?tab=transactions) | 1 day        |
 | Mocha        | {constants.mochaChainId}    | TBD           | TBD                                                                   | 2 days       |
 | Mainnet Beta | celestia   | TBD           | TBD                                                                   | 7 days       |


### PR DESCRIPTION
## Summary
- Moves the Matcha network upgrade (v6) from "Upcoming Upgrades" to "Past Upgrades"
- Adds the new Hibiscus network upgrade (v7) section under "Upcoming Upgrades" with CIPs from [CIP-47](https://cips.celestia.org/cip-047.html): CIP-44, CIP-45, CIP-46
- Includes Arabica upgrade height [10133989](https://arabica.celenium.io/block/10133989?tab=transactions); Mocha and Mainnet Beta TBD

## Test plan
- [x] Verify the page renders correctly locally
- [x] Confirm all CIP links resolve
- [x] Confirm celenium block link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)