### PR TITLE
docs: add Mocha v7 activation block height

### DIFF
--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -150,5 +150,5 @@ Key features include:
 | Network      | Chain ID                   | Date and time           | Upgrade height                                                          | Delay period |
 | ------------ | -------------------------- | ----------------------- | ----------------------------------------------------------------------- | ------------ |
 | Arabica      | {constants.arabicaChainId} | 2026/02/14 02:36:26 UTC | [10133989](https://arabica.celenium.io/block/10133989?tab=transactions) | 1 day        |
-| Mocha        | {constants.mochaChainId}   | TBD                     | [10209986](https://mocha-4.celenium.io/block/10209986)                  | 2 days       |
+| Mocha        | {constants.mochaChainId}   | 2026/02/23 18:21:52 UTC | [10209986](https://mocha-4.celenium.io/block/10209986)                  | 2 days       |
 | Mainnet Beta | celestia                   | TBD                     | TBD                                                                     | 7 days       |


### PR DESCRIPTION
## Summary
- update the Hibiscus (v7) Mocha upgrade row in network upgrades
- set Mocha activation height to 10209986
- link the height to the mocha-4 celenium block explorer URL

## Context
Mocha v7 activates at block 10209986.