### PR TITLE
docs: align Foundation Delegation Program commission rule with CIP-44

### DIFF
--- a/app/operate/consensus-validators/foundation-delegation-program/page.mdx
+++ b/app/operate/consensus-validators/foundation-delegation-program/page.mdx
@@ -53,7 +53,7 @@ The minimum requirements for participation in the program are as follows:
 - If jailed more than once in the 6 months period before application deadline, then we require a public forum post with detailed post mortem and we consider case by case
 - Not associated with an exchange or custodian
 - Not in the top 10 validators by delegation power, unless it enters the top 10 as a result of the Foundation’s delegation under this program
-- Have 25% or less commission
+- Have commission at or below the protocol maximum (`staking.MaxCommissionRate`): 25% currently, increasing to 60% after [CIP-44](https://cips.celestia.org/cip-044.html) is activated in a major network upgrade
 - Not based within the US, within any country subject to economic sanctions, or within any other prohibited jurisdiction, and successfully complete a compliance screen
 - Dedicated email address so that the Foundation can reach you in the event of emergency upgrades and fixes
 - Not running your infrastructure in Hetzner or OVH


### PR DESCRIPTION
## Summary
- Replace the hardcoded `25% or less commission` requirement in the Foundation Delegation Program docs.
- Align the requirement with protocol `staking.MaxCommissionRate`.
- Note the transition from 25% to 60% after CIP-44 activation.

## Why
CIP-44 proposes increasing validator max commission from 25% to 60%, so the docs should not hardcode a stale cap.