### PR TITLE
fix: update broken Cosmos SDK docs links to new URL structure

### DIFF
--- a/app/learn/TIA/overview/page.mdx
+++ b/app/learn/TIA/overview/page.mdx
@@ -41,7 +41,7 @@ to secure its own consensus. Like in other Cosmos networks, any user can help
 secure the network by delegating their TIA to a Celestia validator for a portion
 of their validator’s staking rewards.
 
-Learn [how proof-of-stake works in Cosmos](https://docs.cosmos.network/main/modules/staking).
+Learn [how proof-of-stake works in Cosmos](https://docs.cosmos.network/sdk/v0.53/build/modules/staking).
 
 ### Decentralised governance
 

--- a/app/learn/TIA/staking-governance-supply/page.mdx
+++ b/app/learn/TIA/staking-governance-supply/page.mdx
@@ -11,7 +11,7 @@ the network. Validators charge a fee to delegators which gives them a percentage
 of staking rewards.
 
 Learn
-[how proof of stake works on Cosmos SDK chains like Celestia](https://docs.cosmos.network/main/modules/staking).
+[how proof of stake works on Cosmos SDK chains like Celestia](https://docs.cosmos.network/sdk/v0.53/build/modules/staking).
 
 | Consensus mechanism  | Proof-of-stake |
 | -------------------- | -------------- |
@@ -52,7 +52,7 @@ Additionally, learn how to
 ### Community pool
 
 Starting at genesis, Celestia’s
-[community pool](https://docs.cosmos.network/main/modules/distribution)
+[community pool](https://docs.cosmos.network/sdk/v0.53/build/modules/distribution)
 receives 2% of all Celestia block rewards. TIA stakers may vote to fund
 ecosystem initiatives as in many other Cosmos SDK chains.
 

--- a/app/learn/celestia-101/data-availability/page.mdx
+++ b/app/learn/celestia-101/data-availability/page.mdx
@@ -151,7 +151,7 @@ For more details on NMTs, refer to the [original paper](https://arxiv.org/abs/19
 The Celestia DA layer consists of a PoS blockchain. Celestia is dubbing this
 blockchain as the [celestia-app](https://github.com/celestiaorg/celestia-app),
 an application that provides transactions to facilitate the DA layer and is built
-using [Cosmos SDK](https://docs.cosmos.network/main). The following figure
+using [Cosmos SDK](https://docs.cosmos.network/sdk/v0.53). The following figure
 shows the main components of celestia-app.
 
 ![Main components of celestia-app](/img/learn/celestia-app.png)

--- a/app/operate/consensus-validators/cli-reference/page.mdx
+++ b/app/operate/consensus-validators/cli-reference/page.mdx
@@ -46,7 +46,7 @@ celestia-appd config keyring-backend test
 
 Options are: `os|file|kwallet|pass|test|memory`.
 
-You can learn more on the [Cosmos documentation](https://docs.cosmos.network/main/user/run-node/keyring)
+You can learn more on the [Cosmos documentation](https://docs.cosmos.network/sdk/v0.53/user/run-node/keyring)
 or [Go Package documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk/crypto/keyring).
 
 ## Key management
@@ -150,7 +150,7 @@ upgrades occur via social consensus, and some params are not modifiable.
 However, one can submit governance proposals to change certain parameters and
 spend community funds. More detailed information on this topic can be found in
 the [cosmos-sdk documentation for submitting
-proposals](https://docs.cosmos.network/v0.46/modules/gov/01_concepts.html#proposal-submission),
+proposals](https://docs.cosmos.network/sdk/v0.53/build/modules/gov),
 the list of [parameter defaults in the
 specs](https://github.com/celestiaorg/celestia-app/blob/0012451c4dc118767dd59bc8d341878b7a7cacdf/specs/src/specs/params.md),
 and the [x/paramfilter module

--- a/app/operate/keys-wallets/celestia-app-wallet/page.mdx
+++ b/app/operate/keys-wallets/celestia-app-wallet/page.mdx
@@ -27,7 +27,7 @@ celestia-appd config keyring-backend test
 
 Options are: `os|file|kwallet|pass|test|memory`.
 
-You can learn more on the [Cosmos documentation](https://docs.cosmos.network/main/user/run-node/keyring)
+You can learn more on the [Cosmos documentation](https://docs.cosmos.network/sdk/v0.53/user/run-node/keyring)
 or [Go Package documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk/crypto/keyring).
 
 ## Create a wallet

--- a/app/operate/keys-wallets/vesting/page.mdx
+++ b/app/operate/keys-wallets/vesting/page.mdx
@@ -393,7 +393,7 @@ broadcast-mode = "sync"
 
 Not all vesting accounts can be created with a message, some need to be
 set at genesis. You can
-[learn more in the Cosmos Network documentation](https://docs.cosmos.network/v0.46/modules/auth/05_vesting.html#note).
+[learn more in the Cosmos Network documentation](https://docs.cosmos.network/sdk/v0.53/build/modules/auth/vesting).
 
 ## Conclusion
 

--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -135,7 +135,7 @@ See [parameters for v6](https://celestiaorg.github.io/celestia-app/parameters_v6
 
 ### Upcoming Upgrades
 
-> **Warning:** You do not need to use a tool like [cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) to upgrade the binary. Please upgrade your binary before signaling support for the new version.
+> **Warning:** You do not need to use a tool like [cosmovisor](https://docs.cosmos.network/sdk/v0.53/build/tooling/cosmovisor) to upgrade the binary. Please upgrade your binary before signaling support for the new version.
 
 #### Hibiscus network upgrade
 

--- a/app/operate/networks/arabica-devnet/page.mdx
+++ b/app/operate/networks/arabica-devnet/page.mdx
@@ -59,7 +59,7 @@ devnet, depending on the type of node you are running. Your best
 approach to participating is to first determine which node you would
 like to run. Each node’s guide will link to the relevant network in
 order to show you how to connect to them. Learn about the different
-endpoint types [in the Cosmos SDK documentation](https://docs.cosmos.network/v0.50/learn/advanced/grpc_rest).
+endpoint types [in the Cosmos SDK documentation](https://docs.cosmos.network/sdk/v0.53/learn/advanced/grpc_rest).
 
 ### Production RPC endpoints
 

--- a/app/operate/networks/mainnet-beta/page.mdx
+++ b/app/operate/networks/mainnet-beta/page.mdx
@@ -99,7 +99,7 @@ depending on the type of node you are running. Your best approach to
 participating is to first [determine which node you would like to run](/operate/getting-started/overview). Each
 node's guide will link to the relevant network in order to show you how
 to connect to them. Learn about the different endpoint types
-[in the Cosmos SDK documentation](https://docs.cosmos.network/v0.50/learn/advanced/grpc_rest).
+[in the Cosmos SDK documentation](https://docs.cosmos.network/sdk/v0.53/learn/advanced/grpc_rest).
 
 ### Production RPC endpoints
 


### PR DESCRIPTION
The Cosmos SDK docs restructured from docs.cosmos.network/{main|v0.xx}/... to docs.cosmos.network/sdk/v0.53/... — updates all 11 broken links across 9 files.

Closes #2436

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
