### PR TITLE
docs: add celestia-app Docker setup guide

### DIFF
--- a/app/operate/consensus-validators/_meta.js
+++ b/app/operate/consensus-validators/_meta.js
@@ -1,5 +1,6 @@
 const meta = {
   "install-celestia-app": "Install celestia-app",
+  docker: "Docker images",
   "consensus-node": "Run a consensus node",
   "validator-node": "Run a validator node",
   "cli-reference": "CLI commands reference",

--- a/app/operate/consensus-validators/docker/page.mdx
+++ b/app/operate/consensus-validators/docker/page.mdx
@@ -1,0 +1,188 @@
+---
+sidebar_label: Docker images
+description: Running celestia-app using Docker images.
+---
+
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# 🐳 Docker setup for celestia-app
+
+This page has instructions to run `celestia-appd` using Docker images.
+
+If you are looking for instructions to run `celestia-node` using Docker, refer
+to the [celestia-node Docker page](/operate/getting-started/docker).
+
+## Prerequisites
+
+- [Docker Desktop for Mac or Windows](https://docs.docker.com/get-docker)
+- [Docker Engine for Linux](https://docs.docker.com/engine/install/)
+- `curl` and `jq`
+
+## Quick start with persistent storage
+
+<Steps>
+
+### Set network and version variables
+
+<Tabs items={['Mainnet Beta', 'Mocha', 'Arabica']}>
+  <Tabs.Tab>
+    ```bash
+    export NETWORK=celestia
+    export CHAIN_ID={{constants['mainnetChainId']}}
+    export APP_VERSION={{mainnetVersions['app-latest-tag']}}
+    export NODE_VERSION={{mainnetVersions['node-latest-tag']}}
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    export NETWORK=mocha
+    export CHAIN_ID={{constants['mochaChainId']}}
+    export APP_VERSION={{mochaVersions['app-latest-tag']}}
+    export NODE_VERSION={{mochaVersions['node-latest-tag']}}
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    export NETWORK=arabica
+    export CHAIN_ID={{constants['arabicaChainId']}}
+    export APP_VERSION={{arabicaVersions['app-latest-tag']}}
+    export NODE_VERSION={{arabicaVersions['node-latest-tag']}}
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+<Callout type="warning">
+If you are block syncing Mainnet Beta from genesis, use
+`export APP_VERSION=v3.0.2` as a temporary workaround for
+[celestia-app issue #4370](https://github.com/celestiaorg/celestia-app/issues/4370).
+After sync completes, upgrade to the latest version.
+</Callout>
+
+### Create the node home directory
+
+```bash
+mkdir -p $HOME/celestia-app-docker
+```
+
+Before mounting this directory, Linux users may need to set permissions:
+
+```bash
+sudo chown 10001:10001 $HOME/celestia-app-docker
+```
+
+### Initialize the node home
+
+```bash
+docker run --rm \
+  -v $HOME/celestia-app-docker:/home/celestia/.celestia-app \
+  ghcr.io/celestiaorg/celestia-app:$APP_VERSION \
+  init "docker-node" --chain-id $CHAIN_ID
+```
+
+### Download the genesis file
+
+```bash
+docker run --rm \
+  -v $HOME/celestia-app-docker:/home/celestia/.celestia-app \
+  ghcr.io/celestiaorg/celestia-app:$APP_VERSION \
+  download-genesis $CHAIN_ID
+```
+
+### Configure persistent peers
+
+<Tabs items={['Mainnet Beta', 'Mocha', 'Arabica']}>
+  <Tabs.Tab>
+    ```bash
+    PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/cosmos/chain-registry/master/{{constants['mainnetChainId']}}/chain.json | jq -r '.peers.persistent_peers[].address' | tr '\n' ',' | sed 's/,$/\n/')
+    sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/celestia-app-docker/config/config.toml
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants['mochaChainId']}}/peers.txt | tr '\n' ',')
+    sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/celestia-app-docker/config/config.toml
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants['arabicaChainId']}}/peers.txt | tr '\n' ',')
+    sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/celestia-app-docker/config/config.toml
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+### Start the container
+
+```bash
+docker run -d \
+  --name celestia-app \
+  --restart unless-stopped \
+  -v $HOME/celestia-app-docker:/home/celestia/.celestia-app \
+  -p 26656:26656 \
+  -p 26657:26657 \
+  -p 9090:9090 \
+  ghcr.io/celestiaorg/celestia-app:$APP_VERSION \
+  start --home /home/celestia/.celestia-app --rpc.laddr tcp://0.0.0.0:26657
+```
+
+### Check node status
+
+```bash
+docker logs -f celestia-app
+curl -s http://localhost:26657/status | jq '.result.sync_info'
+```
+
+</Steps>
+
+## Run celestia-node in Docker against your containerized celestia-app
+
+<Callout type="info">
+If you run a bridge node, make sure your consensus node config follows the
+[bridge requirements](/operate/consensus-validators/consensus-node#optional-connect-a-consensus-node-to-a-bridge-node).
+</Callout>
+
+<Steps>
+
+### Create a shared Docker network
+
+```bash
+docker network create celestia-network
+```
+
+### Recreate celestia-app on the shared network
+
+```bash
+docker stop celestia-app && docker rm celestia-app
+
+docker run -d \
+  --name celestia-app \
+  --restart unless-stopped \
+  --network celestia-network \
+  --network-alias celestia-app \
+  -v $HOME/celestia-app-docker:/home/celestia/.celestia-app \
+  -p 26656:26656 \
+  -p 26657:26657 \
+  -p 9090:9090 \
+  ghcr.io/celestiaorg/celestia-app:$APP_VERSION \
+  start --home /home/celestia/.celestia-app --rpc.laddr tcp://0.0.0.0:26657
+```
+
+### Start celestia-node in the same Docker network
+
+```bash
+docker run --rm -it \
+  --name celestia-node \
+  --network celestia-network \
+  -e NODE_TYPE=light \
+  -e P2P_NETWORK=$NETWORK \
+  ghcr.io/celestiaorg/celestia-node:$NODE_VERSION \
+  celestia light start --core.ip celestia-app --core.port 26657 --p2p.network $NETWORK
+```
+
+</Steps>
+
+## Next steps
+
+- [Consensus node guide](/operate/consensus-validators/consensus-node)
+- [Validator node guide](/operate/consensus-validators/validator-node)
+- [celestia-node Docker guide](/operate/getting-started/docker)

--- a/app/operate/consensus-validators/docker/page.mdx
+++ b/app/operate/consensus-validators/docker/page.mdx
@@ -88,24 +88,69 @@ docker run --rm \
   download-genesis $CHAIN_ID
 ```
 
-### Configure persistent peers
+### Configure seeds
+
+Set seeds in `$HOME/celestia-app-docker/config/config.toml`:
 
 <Tabs items={['Mainnet Beta', 'Mocha', 'Arabica']}>
   <Tabs.Tab>
     ```bash
-    PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/cosmos/chain-registry/master/{{constants['mainnetChainId']}}/chain.json | jq -r '.peers.persistent_peers[].address' | tr '\n' ',' | sed 's/,$/\n/')
+    SEEDS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants['mainnetChainId']}}/seeds.txt | tr '\n' ',' | sed 's/,$//')
+    echo $SEEDS
+    sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/" $HOME/celestia-app-docker/config/config.toml
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    SEEDS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants['mochaChainId']}}/seeds.txt | tr '\n' ',' | sed 's/,$//')
+    echo $SEEDS
+    sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/" $HOME/celestia-app-docker/config/config.toml
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    # For Arabica, you can set seeds manually in the
+    # `$HOME/celestia-app-docker/config/config.toml` file:
+    # Comma separated list of seed nodes to connect to
+    seeds = ""
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+### Optional: Configure persistent peers
+
+<Callout type="warning">
+If you set persistent peers, your node will **always** try to connect to these
+peers. This is useful for a local devnet. In production, setting persistent
+peers is advised only if you are running a
+[sentry node](https://hub.cosmos.network/main/validators/security.html#sentry-nodes-ddos-protection).
+</Callout>
+
+You can get persistent peers from the
+[@cosmos/chain-registry](https://github.com/cosmos/chain-registry) repository
+(for Mainnet Beta) or
+[@celestiaorg/networks](https://github.com/celestiaorg/networks) repository
+(for Mocha and Arabica):
+
+<Tabs items={['Mainnet Beta', 'Mocha', 'Arabica']}>
+  <Tabs.Tab>
+    ```bash
+    PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/cosmos/chain-registry/master/{{constants['mainnetChainId']}}/chain.json | jq -r '.peers.persistent_peers[].address' | tr '\n' ',' | sed 's/,$//')
+    echo $PERSISTENT_PEERS
     sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/celestia-app-docker/config/config.toml
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```bash
-    PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants['mochaChainId']}}/peers.txt | tr '\n' ',')
+    PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants['mochaChainId']}}/peers.txt | tr '\n' ',' | sed 's/,$//')
+    echo $PERSISTENT_PEERS
     sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/celestia-app-docker/config/config.toml
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```bash
-    PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants['arabicaChainId']}}/peers.txt | tr '\n' ',')
+    PERSISTENT_PEERS=$(curl -sL https://raw.githubusercontent.com/celestiaorg/networks/master/{{constants['arabicaChainId']}}/peers.txt | tr '\n' ',' | sed 's/,$//')
+    echo $PERSISTENT_PEERS
     sed -i.bak -e "s/^persistent_peers *=.*/persistent_peers = \"$PERSISTENT_PEERS\"/" $HOME/celestia-app-docker/config/config.toml
     ```
   </Tabs.Tab>
@@ -113,14 +158,20 @@ docker run --rm \
 
 ### Start the container
 
+<Callout type="warning">
+RPC (`26657`) and gRPC (`9090`) are published to localhost only in this
+example. Do not publish these ports on all interfaces on a public host unless
+you intend to expose them. P2P (`26656`) is published for peer connectivity.
+</Callout>
+
 ```bash
 docker run -d \
   --name celestia-app \
   --restart unless-stopped \
   -v $HOME/celestia-app-docker:/home/celestia/.celestia-app \
   -p 26656:26656 \
-  -p 26657:26657 \
-  -p 9090:9090 \
+  -p 127.0.0.1:26657:26657 \
+  -p 127.0.0.1:9090:9090 \
   ghcr.io/celestiaorg/celestia-app:$APP_VERSION \
   start --home /home/celestia/.celestia-app --rpc.laddr tcp://0.0.0.0:26657
 ```
@@ -135,6 +186,9 @@ curl -s http://localhost:26657/status | jq '.result.sync_info'
 </Steps>
 
 ## Run celestia-node in Docker against your containerized celestia-app
+
+celestia-node connects to consensus over gRPC (`--core.port`, default `9090`),
+not Tendermint RPC.
 
 <Callout type="info">
 If you run a bridge node, make sure your consensus node config follows the
@@ -161,8 +215,8 @@ docker run -d \
   --network-alias celestia-app \
   -v $HOME/celestia-app-docker:/home/celestia/.celestia-app \
   -p 26656:26656 \
-  -p 26657:26657 \
-  -p 9090:9090 \
+  -p 127.0.0.1:26657:26657 \
+  -p 127.0.0.1:9090:9090 \
   ghcr.io/celestiaorg/celestia-app:$APP_VERSION \
   start --home /home/celestia/.celestia-app --rpc.laddr tcp://0.0.0.0:26657
 ```
@@ -176,7 +230,7 @@ docker run --rm -it \
   -e NODE_TYPE=light \
   -e P2P_NETWORK=$NETWORK \
   ghcr.io/celestiaorg/celestia-node:$NODE_VERSION \
-  celestia light start --core.ip celestia-app --core.port 26657 --p2p.network $NETWORK
+  celestia light start --core.ip celestia-app --core.port 9090 --p2p.network $NETWORK
 ```
 
 </Steps>

--- a/app/operate/consensus-validators/docker/page.mdx
+++ b/app/operate/consensus-validators/docker/page.mdx
@@ -205,6 +205,10 @@ docker network create celestia-network
 
 ### Recreate celestia-app on the shared network
 
+RPC and gRPC are not published to the host here. `celestia-node` reaches
+`celestia-app` over the Docker network on gRPC port `9090`. Only P2P
+(`26656`) is published for peer connectivity.
+
 ```bash
 docker stop celestia-app && docker rm celestia-app
 
@@ -215,8 +219,6 @@ docker run -d \
   --network-alias celestia-app \
   -v $HOME/celestia-app-docker:/home/celestia/.celestia-app \
   -p 26656:26656 \
-  -p 127.0.0.1:26657:26657 \
-  -p 127.0.0.1:9090:9090 \
   ghcr.io/celestiaorg/celestia-app:$APP_VERSION \
   start --home /home/celestia/.celestia-app --rpc.laddr tcp://0.0.0.0:26657
 ```

--- a/app/operate/consensus-validators/install-celestia-app/page.mdx
+++ b/app/operate/consensus-validators/install-celestia-app/page.mdx
@@ -8,7 +8,9 @@ import { Steps, Tabs } from 'nextra/components'
 
 This tutorial will guide you through installing celestia-app, both
 [from source](#building-binary-from-source) and with
-[a pre-built binary](#installing-a-pre-built-binary)
+[a pre-built binary](#installing-a-pre-built-binary). If you are looking for
+Docker-based setup instructions, refer to the
+[celestia-app Docker page](/operate/consensus-validators/docker).
 
 Celestia-app is the software that enables you to run
 consensus nodes (including validators) and provide RPC endpoints.

--- a/app/operate/getting-started/docker/page.mdx
+++ b/app/operate/getting-started/docker/page.mdx
@@ -10,6 +10,8 @@ import { Steps, Tabs } from 'nextra/components'
 This page has instructions to run celestia-node using Docker. If you are
 looking for instructions to run celestia-node using a binary, please
 refer to the [celestia-node page](/operate/data-availability/install-celestia-node).
+If you are looking for instructions to run celestia-app in Docker, refer to
+the [celestia-app Docker page](/operate/consensus-validators/docker).
 
 Using Docker is the easiest way to run celestia-node for most
 users. Docker is a containerization platform that allows you to run celestia-node


### PR DESCRIPTION
## Summary
- add a dedicated `celestia-app` Docker guide under consensus validators
- document quick start with persistent storage, genesis download, and peer config
- add a Docker network example for running `celestia-node` against containerized `celestia-app`
- add cross-links from existing Docker and install pages

Closes #1100