### PR TITLE
docs: point Docker setup at live consensus gRPC endpoints

### DIFF
--- a/app/operate/consensus-validators/validator-node/page.mdx
+++ b/app/operate/consensus-validators/validator-node/page.mdx
@@ -63,7 +63,7 @@ bridge node to connect successfully.
 
 Using an RPC of your own, or one from
 [Mainnet Beta](/operate/networks/mainnet-beta#integrations),
-[Mocha testnet](/operate/networks/mocha-testnet#rpc-for-da-bridge-full-and-light-nodes) or
+[Mocha testnet](/operate/networks/mocha-testnet#community-consensus-endpoints) or
 [Arabica devnet](/operate/networks/arabica-devnet#integrations),
 initialize your node.
 

--- a/app/operate/getting-started/docker/page.mdx
+++ b/app/operate/getting-started/docker/page.mdx
@@ -89,13 +89,13 @@ celestia-node connects to consensus over gRPC via `--core.ip` and `--core.port`
    using the bare host (without `http://` or `https://`):
 
    ```bash
-   export RPC_URL=this-is-an-rpc-url.com
+   export CORE_IP=consensus.example.com
    ```
 
 Then set the gRPC port for that host (usually `9090`):
 
    ```bash
-   export RPC_PORT=9090
+   export CORE_PORT=9090
    ```
 
 ### Run the container
@@ -105,21 +105,21 @@ Then set the gRPC port for that host (usually `9090`):
        ```bash
        docker run -e NODE_TYPE=$NODE_TYPE -e P2P_NETWORK=$NETWORK \
            ghcr.io/celestiaorg/celestia-node:{{mainnetVersions['node-latest-tag']}} \
-           celestia $NODE_TYPE start --core.ip $RPC_URL --core.port $RPC_PORT --p2p.network $NETWORK
+           celestia $NODE_TYPE start --core.ip $CORE_IP --core.port $CORE_PORT --p2p.network $NETWORK
        ```
      </Tabs.Tab>
      <Tabs.Tab>
        ```bash
        docker run -e NODE_TYPE=$NODE_TYPE -e P2P_NETWORK=$NETWORK \
            ghcr.io/celestiaorg/celestia-node:{{mochaVersions['node-latest-tag']}} \
-           celestia $NODE_TYPE start --core.ip $RPC_URL --core.port $RPC_PORT --p2p.network $NETWORK
+           celestia $NODE_TYPE start --core.ip $CORE_IP --core.port $CORE_PORT --p2p.network $NETWORK
        ```
      </Tabs.Tab>
      <Tabs.Tab>
        ```bash
        docker run -e NODE_TYPE=$NODE_TYPE -e P2P_NETWORK=$NETWORK \
            ghcr.io/celestiaorg/celestia-node:{{arabicaVersions['node-latest-tag']}} \
-           celestia $NODE_TYPE start --core.ip $RPC_URL --core.port $RPC_PORT --p2p.network $NETWORK
+           celestia $NODE_TYPE start --core.ip $CORE_IP --core.port $CORE_PORT --p2p.network $NETWORK
        ```
      </Tabs.Tab>
    </Tabs>
@@ -228,7 +228,7 @@ A full start command will look similar to below.
     docker run -e NODE_TYPE=$NODE_TYPE -e P2P_NETWORK=$NETWORK \
         -v $HOME/my-node-store:/home/celestia \
         ghcr.io/celestiaorg/celestia-node:{{mainnetVersions['node-latest-tag']}} \
-        celestia light start --core.ip $RPC_URL --core.port $RPC_PORT --p2p.network $NETWORK
+        celestia light start --core.ip $CORE_IP --core.port $CORE_PORT --p2p.network $NETWORK
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -236,7 +236,7 @@ A full start command will look similar to below.
     docker run -e NODE_TYPE=$NODE_TYPE -e P2P_NETWORK=$NETWORK \
         -v $HOME/my-node-store:/home/celestia \
         ghcr.io/celestiaorg/celestia-node:{{mochaVersions['node-latest-tag']}} \
-        celestia light start --core.ip $RPC_URL --core.port $RPC_PORT --p2p.network $NETWORK
+        celestia light start --core.ip $CORE_IP --core.port $CORE_PORT --p2p.network $NETWORK
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -244,7 +244,7 @@ A full start command will look similar to below.
     docker run -e NODE_TYPE=$NODE_TYPE -e P2P_NETWORK=$NETWORK \
         -v $HOME/my-node-store:/home/celestia \
         ghcr.io/celestiaorg/celestia-node:{{arabicaVersions['node-latest-tag']}} \
-        celestia light start --core.ip $RPC_URL --core.port $RPC_PORT --p2p.network $NETWORK
+        celestia light start --core.ip $CORE_IP --core.port $CORE_PORT --p2p.network $NETWORK
     ```
   </Tabs.Tab>
 </Tabs>

--- a/app/operate/getting-started/docker/page.mdx
+++ b/app/operate/getting-started/docker/page.mdx
@@ -80,18 +80,19 @@ Choose [the network](/operate/networks/overview) you would like to run your node
      </Tabs.Tab>
    </Tabs>
 
-### Configure the RPC endpoint
+### Configure the consensus endpoint
 
-Set an RPC endpoint for either [Mainnet Beta](/operate/networks/mainnet-beta#integrations),
-   [Mocha](/operate/networks/mocha-testnet#rpc-for-da-bridge-full-and-light-nodes), or
-   [Arabica](/operate/networks/arabica-devnet#integrations)
-   using the bare URL (without http or https):
+celestia-node connects to consensus over gRPC via `--core.ip` and `--core.port`
+(default `9090`). Pick a consensus host from
+   [Mainnet Beta](/operate/networks/mainnet-beta#community-consensus-endpoints)
+   or [Mocha](/operate/networks/mocha-testnet#community-consensus-endpoints)
+   using the bare host (without `http://` or `https://`):
 
    ```bash
    export RPC_URL=this-is-an-rpc-url.com
    ```
 
-Then set the port for the RPC_URL:
+Then set the gRPC port for that host (usually `9090`):
 
    ```bash
    export RPC_PORT=9090

--- a/app/operate/keys-wallets/vesting/page.mdx
+++ b/app/operate/keys-wallets/vesting/page.mdx
@@ -323,7 +323,7 @@ and fund your `origin` address.
 
 To create a vesting account on Mocha, you will need an RPC URL to send
 the transaction to. You can find the
-[RPC endpoints on the Mocha testnet page](/operate/networks/mocha-testnet#rpc-for-da-bridge-full-and-light-nodes).
+[consensus endpoints on the Mocha testnet page](/operate/networks/mocha-testnet#community-consensus-endpoints).
 
 If you are running a production application, use a production endpoint.
 

--- a/app/operate/networks/mocha-testnet/page.mdx
+++ b/app/operate/networks/mocha-testnet/page.mdx
@@ -93,7 +93,17 @@ Several community providers offer comprehensive node setup tools, installation s
 | -------- | -------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------- |
 | ITRocket | [Setup guide](https://itrocket.net/services/testnet/celestia/) | [State sync](https://itrocket.net/services/testnet/celestia/) | [Chain status](https://itrocket.net/services/testnet/celestia/) |
 
-### Community bridge node endpoints
+### Community consensus endpoints
+
+Use these hosts for `--core.ip`. celestia-node connects over gRPC with
+`--core.port` (default `9090`). RPC ports are listed for operators who also
+need Tendermint RPC from the same provider.
+
+| Provider      | Endpoint for `--core.ip`                                          | RPC port | gRPC port |
+| ------------- | ----------------------------------------------------------------- | -------- | --------- |
+| Celestia Labs | `full.consensus.{{constants['mochaChainId']}}.celestia-mocha.com` | 26657    | 9090      |
+| P-OPS         | `rpc-mocha.pops.one`                                              | 443      | 9090      |
+| ITRocket      | `celestia-testnet-consensus.itrocket.net`                         | 443      | 9090      |
 
 You can also find the list of official Celestia bootstrappers in the [celestia-node GitHub repository](https://github.com/celestiaorg/celestia-node/blob/a87a17557223d88231b56d323d22ac9da31871db/nodebuilder/p2p/bootstrap.go#L39).
 
@@ -114,12 +124,7 @@ to their respective DA node.
 
 > **Tip for bridge nodes:** Community RPC endpoints do not guarantee full block downloads. If you are running a bridge node, also run a local [consensus node](/operate/consensus-validators/consensus-node) to download full blocks.
 
-- `full.consensus.{{constants['mochaChainId']}}.celestia-mocha.com`
-- `consensus-full-{{constants['mochaChainId']}}.celestia-mocha.com`
-- `rpc-mocha.pops.one`
-- `celestia-testnet-consensus.itrocket.net`
-  - RPC port: 26657
-  - gRPC port: 9090
+Use one of the `--core.ip` values from the [community consensus endpoints](#community-consensus-endpoints) table above.
 
 ## Community RPC endpoints
 
@@ -154,7 +159,6 @@ broadcast transactions.
 
 - `grpc-mocha.pops.one`
 - `full.consensus.{{constants['mochaChainId']}}.celestia-mocha.com:9090`
-- `consensus-full-{{constants['mochaChainId']}}.celestia-mocha.com:9090`
 - `mocha.grpc.cumulo.me:443`
 - `grpc-1.testnet.celestia.nodes.guru:10790`
 - `grpc-2.testnet.celestia.nodes.guru:10790`


### PR DESCRIPTION
## Overview

Fixes #1625.

Updates Docker setup so Mainnet and Mocha links land on community consensus endpoint sections that list hosts usable with `--core.ip` / `--core.port`.

celestia-node connects to consensus over **gRPC only** (`--core.port`, default `9090`) after [celestia-node#3915](https://github.com/celestiaorg/celestia-node/pull/3915) removed the Tendermint RPC dependency. Arabica is left alone (being removed separately).

## Changes

- Docker: rename step to consensus endpoint; link Mainnet + Mocha `#community-consensus-endpoints`; clarify gRPC port usage
- Mocha: add live `--core.ip` table (Celestia Labs, P-OPS, ITRocket); remove dead `consensus-full-…` host
- Retarget vesting + validator Mocha links to the new anchor

## Validation

- Checked `nodebuilder/core/flags.go` / constructors: `--core.port` is gRPC only (default `9090`)
- Probed Mocha hosts: `full.consensus.mocha-4…` has 26657+9090; `rpc-mocha.pops.one` and `celestia-testnet-consensus.itrocket.net` have gRPC on 9090
- Anchors: `/operate/networks/mainnet-beta#community-consensus-endpoints`, `/operate/networks/mocha-testnet#community-consensus-endpoints`