### PR TITLE
docs: add Celestia app API page under RPC documentation

### DIFF
--- a/app/build/rpc/_meta.js
+++ b/app/build/rpc/_meta.js
@@ -1,5 +1,6 @@
 const meta = {
   "node-api": "Node API",
+  "app-api": "App API",
   "clients": "Clients",
 };
 

--- a/app/build/rpc/_meta.js
+++ b/app/build/rpc/_meta.js
@@ -1,6 +1,9 @@
 const meta = {
   "node-api": "Node API",
-  "app-api": "Celestia-app",
+  "app-api": {
+    title: "Celestia-app",
+    href: "https://celestiaorg.github.io/celestia-app/swagger/",
+  },
   "clients": "Clients",
 };
 

--- a/app/build/rpc/_meta.js
+++ b/app/build/rpc/_meta.js
@@ -1,6 +1,6 @@
 const meta = {
   "node-api": "Node API",
-  "app-api": "App API",
+  "app-api": "Celestia-app",
   "clients": "Clients",
 };
 

--- a/app/build/rpc/app-api/page.mdx
+++ b/app/build/rpc/app-api/page.mdx
@@ -1,10 +1,3 @@
 # App API
 
-The Celestia app exposes a REST API based on the Cosmos SDK gRPC-gateway. The full interactive specification is available via Swagger UI.
-
-<iframe
-  src="https://celestiaorg.github.io/celestia-app/swagger/"
-  width="100%"
-  height="900px"
-  style={{ border: 'none', borderRadius: '8px' }}
-/>
+The Celestia app exposes a REST API based on the Cosmos SDK gRPC-gateway. The full interactive specification is available via [Swagger UI](https://celestiaorg.github.io/celestia-app/swagger/).

--- a/app/build/rpc/app-api/page.mdx
+++ b/app/build/rpc/app-api/page.mdx
@@ -1,0 +1,10 @@
+# App API
+
+The Celestia app exposes a REST API based on the Cosmos SDK gRPC-gateway. The full interactive specification is available via Swagger UI.
+
+<iframe
+  src="https://celestiaorg.github.io/celestia-app/swagger/"
+  width="100%"
+  height="900px"
+  style={{ border: 'none', borderRadius: '8px' }}
+/>

--- a/app/build/rpc/app-api/page.mdx
+++ b/app/build/rpc/app-api/page.mdx
@@ -1,3 +1,0 @@
-# Celestia-app
-
-The Celestia app exposes a REST API based on the Cosmos SDK gRPC-gateway. The full interactive specification is available via [Swagger UI](https://celestiaorg.github.io/celestia-app/swagger/).

--- a/app/build/rpc/app-api/page.mdx
+++ b/app/build/rpc/app-api/page.mdx
@@ -1,3 +1,3 @@
-# App API
+# Celestia-app
 
 The Celestia app exposes a REST API based on the Cosmos SDK gRPC-gateway. The full interactive specification is available via [Swagger UI](https://celestiaorg.github.io/celestia-app/swagger/).


### PR DESCRIPTION
## Summary

- Adds a new **App API** entry to the RPC Documentation sidebar
- Creates `app/build/rpc/app-api/page.mdx` which embeds the Celestia app Swagger UI

Closes #2473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
