### PR TITLE
docs: add v8 network upgrade

### DIFF
--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -161,6 +161,6 @@ Like previous upgrades, v8 uses the in-protocol signaling mechanism. The upgrade
 
 | Network      | Chain ID                   | Date and time           | Upgrade height                                                          | Delay period |
 | ------------ | -------------------------- | ----------------------- | ----------------------------------------------------------------------- | ------------ |
-| Arabica      | {constants.arabicaChainId} | 2026/03/11 12:36:36 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        |
+| Arabica      | {constants.arabicaChainId} | 2026/04/04 17:22:00 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        |
 | Mocha        | {constants.mochaChainId}   | TBD                     | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526)     | 2 days       |
 | Mainnet Beta | celestia                   | TBD                     | TBD                                                                     | 7 days       |

--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -161,6 +161,6 @@ Like previous upgrades, v8 uses the in-protocol signaling mechanism. The upgrade
 
 | Network      | Chain ID                   | Date and time           | Upgrade height                                                          | Delay period |
 | ------------ | -------------------------- | ----------------------- | ----------------------------------------------------------------------- | ------------ |
-| Arabica      | {constants.arabicaChainId} | 2026/04/04 17:22:00 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        |
+| Arabica      | {constants.arabicaChainId} | 2026/04/04 17:22:12 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        |
 | Mocha        | {constants.mochaChainId}   | TBD                     | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526)     | 2 days       |
 | Mainnet Beta | celestia                   | TBD                     | TBD                                                                     | 7 days       |

--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -152,3 +152,15 @@ Key features include:
 | Arabica      | {constants.arabicaChainId} | 2026/02/14 02:36:26 UTC | [10133989](https://arabica.celenium.io/block/10133989?tab=transactions) | 1 day        |
 | Mocha        | {constants.mochaChainId}   | 2026/02/23 18:21:52 UTC | [10209986](https://mocha-4.celenium.io/block/10209986)                  | 2 days       |
 | Mainnet Beta | celestia                   | TBD                     | TBD                                                                     | 7 days       |
+
+#### v8 network upgrade
+
+Due to a bug discovered in v7, the next scheduled upgrade is v8.
+
+Like previous upgrades, v8 uses the in-protocol signaling mechanism. The upgrade activates automatically after 5/6 of voting power have signaled for a particular version and a delay period based on the network.
+
+| Network      | Chain ID                   | Date and time           | Upgrade height                                                          | Delay period |
+| ------------ | -------------------------- | ----------------------- | ----------------------------------------------------------------------- | ------------ |
+| Arabica      | {constants.arabicaChainId} | 2026/03/11 12:36:36 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        |
+| Mocha        | {constants.mochaChainId}   | TBD                     | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526)     | 2 days       |
+| Mainnet Beta | celestia                   | TBD                     | TBD                                                                     | 7 days       |


### PR DESCRIPTION
## Summary
- add a new v8 section to the network upgrades page
- note that v8 supersedes v7 due to a bug in v7
- add Arabica and Mocha activation heights for v8

## Testing
- not run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
