### PR TITLE
chore: pin lodash-es to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8135,9 +8135,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "overrides": {
     "@xmldom/xmldom": "0.9.9",
+    "lodash-es": "4.18.1",
     "@eslint/config-array": { "minimatch": "3.1.5" },
     "@eslint/eslintrc": { "minimatch": "3.1.5" },
     "eslint": { "minimatch": "3.1.5" },
@@ -67,6 +68,7 @@
   },
   "resolutions": {
     "@xmldom/xmldom": "0.9.9",
+    "lodash-es": "4.18.1",
     "minimatch": "3.1.5",
     "@typescript-eslint/typescript-estree/minimatch": "9.0.9",
     "@ts-morph/common/minimatch": "10.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3922,10 +3922,10 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21, lodash-es@4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+lodash-es@4.17.21, lodash-es@4.18.1, lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.merge@^4.6.2:
   version "4.6.2"


### PR DESCRIPTION
## Summary
- add npm and Yarn transitive pins for `lodash-es@4.18.1`
- update `package-lock.json` and `yarn.lock` to resolve `lodash-es` to the patched release
- keep the change scoped to the lodash-es Dependabot findings on `package-lock.json`

## Testing
- npm run lint
- npm audit --json | jq '[.. | objects | select(.name? == "lodash-es")]'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
