### PR TITLE
docs: add v8 Mocha activation timestamp

### DIFF
--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -162,5 +162,5 @@ Like previous upgrades, v8 uses the in-protocol signaling mechanism. The upgrade
 | Network      | Chain ID                   | Date and time           | Upgrade height                                                          | Delay period |
 | ------------ | -------------------------- | ----------------------- | ----------------------------------------------------------------------- | ------------ |
 | Arabica      | {constants.arabicaChainId} | 2026/04/04 17:22:12 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        |
-| Mocha        | {constants.mochaChainId}   | TBD                     | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526)     | 2 days       |
+| Mocha        | {constants.mochaChainId}   | 2026/04/16 14:26:21 UTC | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526)     | 2 days       |
 | Mainnet Beta | celestia                   | TBD                     | TBD                                                                     | 7 days       |


### PR DESCRIPTION
## Summary
- Add the activation timestamp (2026/04/16 14:26:21 UTC) for the v8 network upgrade on Mocha testnet at block [10941526](https://www.mintscan.io/celestia-testnet/block/10941526).

## Test plan
- [x] Verify the v8 table on the Network upgrades page renders the Mocha row with the new timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)