### PR TITLE
docs: consolidate network upgrade tables by network

### DIFF
--- a/app/operate/maintenance/_meta.js
+++ b/app/operate/maintenance/_meta.js
@@ -3,7 +3,7 @@ const meta = {
   "trusted-hash-recovery": "Trusted hash recovery",
   "datastore-structure": "Datastore layout",
   systemd: "Systemd service setup",
-  "network-upgrades": "Network upgrade process",
+  "network-upgrades": "Network upgrades",
   troubleshooting: "Troubleshooting",
 };
 

--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -2,8 +2,6 @@
 description: Overview of the Celestia network upgrade process.
 ---
 
-import { constants } from "@/constants";
-
 # Network upgrades
 
 Blockchain networks often need to upgrade with new features which require coordination work among the community of developers, validators, and node operators prior to activating the upgrades. This process is called a network upgrade, which can be breaking or non-breaking. During planned network upgrades the community will coordinate to prepare for the upcoming upgrade. Breaking network upgrades are not backward-compatible with older versions of the network software, which is why it is important that validators upgrade their software to continue validating on the network. Non-breaking network upgrades are backward-compatible and require less coordination.
@@ -37,130 +35,48 @@ The upgrade process can be broken down into a few steps:
    - Upgrades using pre-programmed height (v2) activate at a predetermined block number.
    - Upgrades using in-protocol signaling (v3+) activate one week after 5/6 of the voting power has signaled for a particular version
 
-### Past Upgrades
+### Network upgrade history
 
-#### Lemongrass network upgrade
+v7 (Hibiscus) was skipped on Mainnet Beta due to a bug discovered after testnet activation; v8 (defined in [CIP-49](https://cips.celestia.org/cip-049.html)) was activated instead.
 
-The Lemongrass network upgrade (v2) was the first consensus layer breaking change since Celestia's Mainnet Beta genesis block. The Lemongrass network upgrade included all of the CIPs listed in [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-017.md) and implemented CIP-10 for future upgrades.
+#### Arabica devnet
 
-| Network      | Chain ID                   | Date and time          | Upgrade height |
-| ------------ | -------------------------- | ---------------------- | -------------- |
-| Arabica      | {constants.arabicaChainId} | 2024/08/19 @ 14:00 UTC | 1751707        |
-| Mocha        | {constants.mochaChainId}   | 2024/08/28 @ 14:00 UTC | 2585031        |
-| Mainnet Beta | {constants.mainnetChainId} | 2024/09/18 @ 14:00 UTC | 2371495        |
+| Version | Name       | Meta-CIP                                                                | Date and time           | Upgrade height                                                          | Delay period | Parameters                                                          |
+| ------- | ---------- | ----------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------- |
+| v2      | Lemongrass | [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-017.md) | 2024/08/19 14:00 UTC    | 1751707                                                                 | —            | [v2](https://celestiaorg.github.io/celestia-app/parameters_v2.html) |
+| v3      | Ginger     | [CIP-25](https://cips.celestia.org/cip-025.html)                        | 2024/11/05 21:55:13 UTC | 2348907                                                                 | —            | [v3](https://celestiaorg.github.io/celestia-app/parameters_v3.html) |
+| v4      | Lotus      | [CIP-33](https://cips.celestia.org/cip-033.html)                        | 2025/05/16 07:51:35 UTC | 5975265                                                                 | 1 day        | [v4](https://celestiaorg.github.io/celestia-app/parameters_v4.html) |
+| v5      | —          | —                                                                       | 2025/07/29 19:59:00 UTC | 7316464                                                                 | 1 block      | [v5](https://celestiaorg.github.io/celestia-app/parameters_v5.html) |
+| v6      | Matcha     | [CIP-42](https://cips.celestia.org/cip-042.html)                        | 2025/09/09 06:08:11 UTC | [8105605](https://arabica.celenium.io/block/8105605)                    | 1 day        | [v6](https://celestiaorg.github.io/celestia-app/parameters_v6.html) |
+| v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | 2026/02/14 02:36:26 UTC | [10133989](https://arabica.celenium.io/block/10133989?tab=transactions) | 1 day        | —                                                                   |
+| v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/04/04 17:22:12 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        | —                                                                   |
 
-See [parameters for v2](https://celestiaorg.github.io/celestia-app/parameters_v2.html).
+#### Mocha testnet
 
-#### Ginger network upgrade
+| Version | Name       | Meta-CIP                                                                | Date and time           | Upgrade height                                                      | Delay period | Parameters                                                          |
+| ------- | ---------- | ----------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------- |
+| v2      | Lemongrass | [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-017.md) | 2024/08/28 14:00 UTC    | 2585031                                                             | —            | [v2](https://celestiaorg.github.io/celestia-app/parameters_v2.html) |
+| v3      | Ginger     | [CIP-25](https://cips.celestia.org/cip-025.html)                        | 2024/11/14 18:31:11 UTC | 3140052                                                             | —            | [v3](https://celestiaorg.github.io/celestia-app/parameters_v3.html) |
+| v4      | Lotus      | [CIP-33](https://cips.celestia.org/cip-033.html)                        | 2025/07/01 11:51:58 UTC | 6915786                                                             | 2 days       | [v4](https://celestiaorg.github.io/celestia-app/parameters_v4.html) |
+| v5      | —          | —                                                                       | 2025/07/30 17:07:29 UTC | 7401191                                                             | 1 block      | [v5](https://celestiaorg.github.io/celestia-app/parameters_v5.html) |
+| v6      | Matcha     | [CIP-42](https://cips.celestia.org/cip-042.html)                        | 2025/10/03 01:25:02 UTC | [8236886](https://www.mintscan.io/celestia-testnet/block/8236886)   | 2 days       | [v6](https://celestiaorg.github.io/celestia-app/parameters_v6.html) |
+| v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | 2026/02/23 18:21:52 UTC | [10209986](https://mocha-4.celenium.io/block/10209986)              | 2 days       | —                                                                   |
+| v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/04/16 14:26:21 UTC | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526) | 2 days       | —                                                                   |
 
-The Ginger network upgrade (v3) was the first to use the in-protocol signaling mechanism defined in [CIP-10](https://cips.celestia.org/cip-010.html). This upgrade included changes defined in [CIP-25](https://cips.celestia.org/cip-025.html):
+#### Mainnet Beta
 
-Key features include:
+| Version | Name       | Meta-CIP                                                                | Date and time           | Upgrade height                                                | Delay period | Parameters                                                          |
+| ------- | ---------- | ----------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------- | ------------ | ------------------------------------------------------------------- |
+| v2      | Lemongrass | [CIP-17](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-017.md) | 2024/09/18 14:00 UTC    | 2371495                                                       | —            | [v2](https://celestiaorg.github.io/celestia-app/parameters_v2.html) |
+| v3      | Ginger     | [CIP-25](https://cips.celestia.org/cip-025.html)                        | 2024/12/12 14:28:52 UTC | 2993219                                                       | —            | [v3](https://celestiaorg.github.io/celestia-app/parameters_v3.html) |
+| v4      | Lotus      | [CIP-33](https://cips.celestia.org/cip-033.html)                        | 2025/07/28 13:46:27 UTC | 6680339                                                       | 7 days       | [v4](https://celestiaorg.github.io/celestia-app/parameters_v4.html) |
+| v5      | —          | —                                                                       | 2025/08/01 14:30:29 UTC | 6748821                                                       | 1 block      | [v5](https://celestiaorg.github.io/celestia-app/parameters_v5.html) |
+| v6      | Matcha     | [CIP-42](https://cips.celestia.org/cip-042.html)                        | 2025/11/24 12:33:12 UTC | [8662012](https://celenium.io/block/8662012?tab=transactions) | 7 days       | [v6](https://celestiaorg.github.io/celestia-app/parameters_v6.html) |
+| v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | N/A (skipped, see v8)   | N/A                                                           | —            | —                                                                   |
+| v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/05/05 16:37:35 UTC | [10960599](https://celestia.explorers.guru/block/10960599)    | 7 days       | —                                                                   |
 
-- [CIP-21](https://cips.celestia.org/cip-021.html): Introduce blob type with verified signer
-- [CIP-24](https://cips.celestia.org/cip-024.html): Versioned Gas Scheduler Variables
-- [CIP-26](https://cips.celestia.org/cip-026.html): Versioned timeouts
-- [CIP-27](https://cips.celestia.org/cip-027.html): Block limits for number of PFBs and non-PFBs
-- [CIP-28](https://cips.celestia.org/cip-028.html): Transaction size limit
-
-Unlike the Lemongrass upgrade, there will not be a pre-programmed upgrade height. Instead, validators will signal their readiness for v3 through in-protocol signaling, and the upgrade will automatically activate one week after 5/6 of voting power have signaled for a particular version.
-
-Learn more in the [v3.0.0 release notes](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md#v300).
-
-| Network      | Chain ID                   | Date and time             | Upgrade height |
-| ------------ | -------------------------- | ------------------------- | -------------- |
-| Arabica      | {constants.arabicaChainId} | 2024/11/05 @ 21:55:13 UTC | 2348907        |
-| Mocha        | {constants.mochaChainId}   | 2024/11/14 @ 18:31:11 UTC | 3140052        |
-| Mainnet Beta | celestia                   | 2024/12/12 @ 14:28:52 UTC | 2993219        |
-
-See [parameters for v3](https://celestiaorg.github.io/celestia-app/parameters_v3.html).
-
-#### Lotus network upgrade
-
-The Lotus network upgrade (v4) included several important changes defined in [CIP-33](https://cips.celestia.org/cip-033.html):
-
-Key features include:
-
-- [CIP-29](https://cips.celestia.org/cip-029.html): Decrease inflation and disinflation
-- [CIP-30](https://cips.celestia.org/cip-030.html): Disable auto-claim of staking rewards
-- [CIP-31](https://cips.celestia.org/cip-031.html): Incorporate staking rewards into vesting account schedules
-- [CIP-32](https://cips.celestia.org/cip-032.html): Add Hyperlane to Celestia
-
-Like the Ginger upgrade, this upgrade used the in-protocol signaling mechanism. The upgrade activated automatically after 5/6 of voting power signaled for a particular version and a delay period based on the network.
-
-The delay periods for v4 were based on [celestia-app #4413](https://github.com/celestiaorg/celestia-app/issues/4413):
-
-| Network      | Chain ID                   | Date and time           | Upgrade height | Delay period |
-| ------------ | -------------------------- | ----------------------- | -------------- | ------------ |
-| Arabica      | {constants.arabicaChainId} | 2025/05/16 07:51:35 UTC | 5975265        | 1 day        |
-| Mocha        | {constants.mochaChainId}   | 2025/07/01 11:51:58 UTC | 6915786        | 2 days       |
-| Mainnet Beta | celestia                   | 2025/07/28 13:46:27 UTC | 6680339        | 7 days       |
-
-See [parameters for v4](https://celestiaorg.github.io/celestia-app/parameters_v4.html).
-
-#### v5 network upgrade
-
-The v5 network upgrade included a fix to restore IBC support which was broken in v4.
-
-Like previous upgrades, this upgrade will use the in-protocol signaling mechanism. The upgrade will automatically activate after 5/6 of voting power have signaled for a particular version and a delay period based on the network, in accordance with the table below.
-
-| Network      | Chain ID                   | Date and time           | Upgrade height | Delay period |
-| ------------ | -------------------------- | ----------------------- | -------------- | ------------ |
-| Arabica      | {constants.arabicaChainId} | 2025/07/29 19:59:00 UTC | 7316464        | 1 block      |
-| Mocha        | {constants.mochaChainId}   | 2025/07/30 17:07:29 UTC | 7401191        | 1 block      |
-| Mainnet Beta | celestia                   | 2025/08/01 14:30:29 UTC | 6748821        | 1 block      |
-
-See [parameters for v5](https://celestiaorg.github.io/celestia-app/parameters_v5.html).
-
-#### Matcha network upgrade
-
-The Matcha network upgrade (v6) includes several important changes defined in [CIP-42](https://cips.celestia.org/cip-042.html).
-
-Key features include:
-
-- [CIP-36](https://cips.celestia.org/cip-036.html): Lowering Trusting Period to 7 Days
-- [CIP-37](https://cips.celestia.org/cip-037.html): Lower unbonding period to ~14 days
-- [CIP-38](https://cips.celestia.org/cip-038.html): Increase maximum block, square and transaction size
-- [CIP-39](https://cips.celestia.org/cip-039.html): Remove token filter for Hyperlane and IBC
-- [CIP-40](https://cips.celestia.org/cip-040.html): Privval Interface Extension for Arbitrary Message Signing
-- [CIP-41](https://cips.celestia.org/cip-041.html): Reduce issuance to 2.5% and increase minimum commission to 10%
-
-| Network      | Chain ID                   | Date and time           | Upgrade height                                                    | Delay period |
-| ------------ | -------------------------- | ----------------------- | ----------------------------------------------------------------- | ------------ |
-| Arabica      | {constants.arabicaChainId} | 2025/09/09 06:08:11 UTC | [8105605](https://arabica.celenium.io/block/8105605)              | 1 day        |
-| Mocha        | {constants.mochaChainId}   | 2025/10/03 01:25:02 UTC | [8236886](https://www.mintscan.io/celestia-testnet/block/8236886) | 2 days       |
-| Mainnet Beta | celestia                   | 2025/11/24 12:33:12 UTC | [8662012](https://celenium.io/block/8662012?tab=transactions)     | 7 days       |
-
-See [parameters for v6](https://celestiaorg.github.io/celestia-app/parameters_v6.html).
-
-### Upcoming Upgrades
+### Upcoming upgrades
 
 > **Warning:** You do not need to use a tool like [cosmovisor](https://docs.cosmos.network/sdk/v0.53/build/tooling/cosmovisor) to upgrade the binary. Please upgrade your binary before signaling support for the new version.
 
-#### Hibiscus network upgrade
-
-The Hibiscus network upgrade (v7) includes several important changes defined in [CIP-47](https://cips.celestia.org/cip-047.html).
-
-Key features include:
-
-- [CIP-44](https://cips.celestia.org/cip-044.html): Adjust Validator Commission Bounds
-- [CIP-45](https://cips.celestia.org/cip-045.html): Forwarding Module
-- [CIP-46](https://cips.celestia.org/cip-046.html): ZK Interchain Security Module
-
-| Network      | Chain ID                   | Date and time              | Upgrade height                                                          | Delay period |
-| ------------ | -------------------------- | -------------------------- | ----------------------------------------------------------------------- | ------------ |
-| Arabica      | {constants.arabicaChainId} | 2026/02/14 02:36:26 UTC    | [10133989](https://arabica.celenium.io/block/10133989?tab=transactions) | 1 day        |
-| Mocha        | {constants.mochaChainId}   | 2026/02/23 18:21:52 UTC    | [10209986](https://mocha-4.celenium.io/block/10209986)                  | 2 days       |
-| Mainnet Beta | celestia                   | [N/A](#v8-network-upgrade) | [N/A](#v8-network-upgrade)                                              | 7 days       |
-
-#### v8 network upgrade
-
-Due to a bug discovered in v7, the next scheduled upgrade is v8, as defined in [CIP-49](https://cips.celestia.org/cip-049.html).
-
-Like previous upgrades, v8 uses the in-protocol signaling mechanism. The upgrade activates automatically after 5/6 of voting power have signaled for a particular version and a delay period based on the network.
-
-| Network      | Chain ID                   | Date and time           | Upgrade height                                                          | Delay period |
-| ------------ | -------------------------- | ----------------------- | ----------------------------------------------------------------------- | ------------ |
-| Arabica      | {constants.arabicaChainId} | 2026/04/04 17:22:12 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        |
-| Mocha        | {constants.mochaChainId}   | 2026/04/16 14:26:21 UTC | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526)     | 2 days       |
-| Mainnet Beta | celestia                   | 2026/05/05 16:37:35 UTC | [10960599](https://celestia.explorers.guru/block/10960599)              | 7 days       |
+No upcoming upgrades are currently announced.

--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -48,8 +48,8 @@ v7 (Hibiscus) was skipped on Mainnet Beta due to a bug discovered after testnet 
 | v4      | Lotus      | [CIP-33](https://cips.celestia.org/cip-033.html)                        | 2025/05/16 07:51:35 UTC | 5975265                                                                 | 1 day        | [v4](https://celestiaorg.github.io/celestia-app/parameters_v4.html) |
 | v5      | —          | —                                                                       | 2025/07/29 19:59:00 UTC | 7316464                                                                 | 1 block      | [v5](https://celestiaorg.github.io/celestia-app/parameters_v5.html) |
 | v6      | Matcha     | [CIP-42](https://cips.celestia.org/cip-042.html)                        | 2025/09/09 06:08:11 UTC | [8105605](https://arabica.celenium.io/block/8105605)                    | 1 day        | [v6](https://celestiaorg.github.io/celestia-app/parameters_v6.html) |
-| v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | 2026/02/14 02:36:26 UTC | [10133989](https://arabica.celenium.io/block/10133989?tab=transactions) | 1 day        | —                                                                   |
-| v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/04/04 17:22:12 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        | —                                                                   |
+| v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | 2026/02/14 02:36:26 UTC | [10133989](https://arabica.celenium.io/block/10133989?tab=transactions) | 1 day        | [v7](https://celestiaorg.github.io/celestia-app/parameters_v7.html) |
+| v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/04/04 17:22:12 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        | [v8](https://celestiaorg.github.io/celestia-app/parameters_v8.html) |
 
 #### Mocha testnet
 
@@ -60,8 +60,8 @@ v7 (Hibiscus) was skipped on Mainnet Beta due to a bug discovered after testnet 
 | v4      | Lotus      | [CIP-33](https://cips.celestia.org/cip-033.html)                        | 2025/07/01 11:51:58 UTC | 6915786                                                             | 2 days       | [v4](https://celestiaorg.github.io/celestia-app/parameters_v4.html) |
 | v5      | —          | —                                                                       | 2025/07/30 17:07:29 UTC | 7401191                                                             | 1 block      | [v5](https://celestiaorg.github.io/celestia-app/parameters_v5.html) |
 | v6      | Matcha     | [CIP-42](https://cips.celestia.org/cip-042.html)                        | 2025/10/03 01:25:02 UTC | [8236886](https://www.mintscan.io/celestia-testnet/block/8236886)   | 2 days       | [v6](https://celestiaorg.github.io/celestia-app/parameters_v6.html) |
-| v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | 2026/02/23 18:21:52 UTC | [10209986](https://mocha-4.celenium.io/block/10209986)              | 2 days       | —                                                                   |
-| v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/04/16 14:26:21 UTC | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526) | 2 days       | —                                                                   |
+| v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | 2026/02/23 18:21:52 UTC | [10209986](https://mocha-4.celenium.io/block/10209986)              | 2 days       | [v7](https://celestiaorg.github.io/celestia-app/parameters_v7.html) |
+| v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/04/16 14:26:21 UTC | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526) | 2 days       | [v8](https://celestiaorg.github.io/celestia-app/parameters_v8.html) |
 
 #### Mainnet Beta
 
@@ -73,7 +73,7 @@ v7 (Hibiscus) was skipped on Mainnet Beta due to a bug discovered after testnet 
 | v5      | —          | —                                                                       | 2025/08/01 14:30:29 UTC | 6748821                                                       | 1 block      | [v5](https://celestiaorg.github.io/celestia-app/parameters_v5.html) |
 | v6      | Matcha     | [CIP-42](https://cips.celestia.org/cip-042.html)                        | 2025/11/24 12:33:12 UTC | [8662012](https://celenium.io/block/8662012?tab=transactions) | 7 days       | [v6](https://celestiaorg.github.io/celestia-app/parameters_v6.html) |
 | v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | N/A (skipped, see v8)   | N/A                                                           | —            | —                                                                   |
-| v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/05/05 16:37:35 UTC | [10960599](https://celestia.explorers.guru/block/10960599)    | 7 days       | —                                                                   |
+| v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/05/05 16:37:35 UTC | [10960599](https://celestia.explorers.guru/block/10960599)    | 7 days       | [v8](https://celestiaorg.github.io/celestia-app/parameters_v8.html) |
 
 ### Upcoming upgrades
 

--- a/app/operate/maintenance/network-upgrades/page.mdx
+++ b/app/operate/maintenance/network-upgrades/page.mdx
@@ -35,11 +35,11 @@ The upgrade process can be broken down into a few steps:
    - Upgrades using pre-programmed height (v2) activate at a predetermined block number.
    - Upgrades using in-protocol signaling (v3+) activate one week after 5/6 of the voting power has signaled for a particular version
 
-### Network upgrade history
+## Network upgrade history
 
 v7 (Hibiscus) was skipped on Mainnet Beta due to a bug discovered after testnet activation; v8 (defined in [CIP-49](https://cips.celestia.org/cip-049.html)) was activated instead.
 
-#### Arabica devnet
+### Arabica devnet
 
 | Version | Name       | Meta-CIP                                                                | Date and time           | Upgrade height                                                          | Delay period | Parameters                                                          |
 | ------- | ---------- | ----------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------- |
@@ -51,7 +51,7 @@ v7 (Hibiscus) was skipped on Mainnet Beta due to a bug discovered after testnet 
 | v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | 2026/02/14 02:36:26 UTC | [10133989](https://arabica.celenium.io/block/10133989?tab=transactions) | 1 day        | [v7](https://celestiaorg.github.io/celestia-app/parameters_v7.html) |
 | v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/04/04 17:22:12 UTC | [10853352](https://arabica.celenium.io/block/10853352?tab=transactions) | 1 day        | [v8](https://celestiaorg.github.io/celestia-app/parameters_v8.html) |
 
-#### Mocha testnet
+### Mocha testnet
 
 | Version | Name       | Meta-CIP                                                                | Date and time           | Upgrade height                                                      | Delay period | Parameters                                                          |
 | ------- | ---------- | ----------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------- |
@@ -63,7 +63,7 @@ v7 (Hibiscus) was skipped on Mainnet Beta due to a bug discovered after testnet 
 | v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | 2026/02/23 18:21:52 UTC | [10209986](https://mocha-4.celenium.io/block/10209986)              | 2 days       | [v7](https://celestiaorg.github.io/celestia-app/parameters_v7.html) |
 | v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/04/16 14:26:21 UTC | [10941526](https://www.mintscan.io/celestia-testnet/block/10941526) | 2 days       | [v8](https://celestiaorg.github.io/celestia-app/parameters_v8.html) |
 
-#### Mainnet Beta
+### Mainnet Beta
 
 | Version | Name       | Meta-CIP                                                                | Date and time           | Upgrade height                                                | Delay period | Parameters                                                          |
 | ------- | ---------- | ----------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------- | ------------ | ------------------------------------------------------------------- |
@@ -75,7 +75,7 @@ v7 (Hibiscus) was skipped on Mainnet Beta due to a bug discovered after testnet 
 | v7      | Hibiscus   | [CIP-47](https://cips.celestia.org/cip-047.html)                        | N/A (skipped, see v8)   | N/A                                                           | —            | —                                                                   |
 | v8      | —          | [CIP-49](https://cips.celestia.org/cip-049.html)                        | 2026/05/05 16:37:35 UTC | [10960599](https://celestia.explorers.guru/block/10960599)    | 7 days       | [v8](https://celestiaorg.github.io/celestia-app/parameters_v8.html) |
 
-### Upcoming upgrades
+## Upcoming upgrades
 
 > **Warning:** You do not need to use a tool like [cosmovisor](https://docs.cosmos.network/sdk/v0.53/build/tooling/cosmovisor) to upgrade the binary. Please upgrade your binary before signaling support for the new version.
 

--- a/app/operate/networks/arabica-devnet/page.mdx
+++ b/app/operate/networks/arabica-devnet/page.mdx
@@ -175,5 +175,5 @@ There are multiple explorers you can use for Arabica:
 Join our [Telegram announcement channel](https://t.me/+smSFIA7XXLU4MjJh)
 for network upgrades.
 
-See the [network upgrade process page](/operate/maintenance/network-upgrades) to learn more
+See the [network upgrades page](/operate/maintenance/network-upgrades) to learn more
 about specific upgrades like the [Ginger network upgrade](/operate/maintenance/network-upgrades#ginger-network-upgrade).

--- a/app/operate/networks/mainnet-beta/page.mdx
+++ b/app/operate/networks/mainnet-beta/page.mdx
@@ -246,5 +246,5 @@ There are a few ways to stay informed about network upgrades on Mainnet Beta:
 - Telegram [announcement channel](https://t.me/+smSFIA7XXLU4MjJh)
 - Discord [Mainnet Beta announcements](https://discord.com/channels/638338779505229824/1169237690114388039)
 
-See the [network upgrade process page](/operate/maintenance/network-upgrades) to learn more
+See the [network upgrades page](/operate/maintenance/network-upgrades) to learn more
 about specific upgrades like the [Ginger network upgrade](/operate/maintenance/network-upgrades#ginger-network-upgrade).

--- a/app/operate/networks/mocha-testnet/page.mdx
+++ b/app/operate/networks/mocha-testnet/page.mdx
@@ -247,5 +247,5 @@ There are a few ways to stay informed about network upgrades on the Mocha testne
 - Telegram [announcement channel](https://t.me/+smSFIA7XXLU4MjJh)
 - Discord [Mocha announcements](https://discord.com/channels/638338779505229824/979037494735691816)
 
-See the [network upgrade process page](/operate/maintenance/network-upgrades) to learn more
+See the [network upgrades page](/operate/maintenance/network-upgrades) to learn more
 about specific upgrades like the [Ginger network upgrade](/operate/maintenance/network-upgrades#ginger-network-upgrade).

--- a/app/operate/networks/overview/page.mdx
+++ b/app/operate/networks/overview/page.mdx
@@ -60,5 +60,5 @@ There are a few ways to stay informed about network upgrades:
 - Discord [Mainnet Beta announcements](https://discord.com/channels/638338779505229824/1169237690114388039)
 - Discord [Mocha announcements](https://discord.com/channels/638338779505229824/979037494735691816)
 
-See the [network upgrade process page](/operate/maintenance/network-upgrades) to learn more
+See the [network upgrades page](/operate/maintenance/network-upgrades) to learn more
 about specific upgrades like the [Ginger network upgrade](/operate/maintenance/network-upgrades#ginger-network-upgrade).


### PR DESCRIPTION
## Summary

- Move v7 (Hibiscus) and v8 from "Upcoming Upgrades" to "Network upgrade history" now that both have activated.
- Consolidate the per-version tables into three per-network tables (Arabica, Mocha, Mainnet Beta), each with one row per version (v2–v8).
- Replace per-version prose and CIP bullet lists with `Meta-CIP` and `Parameters` columns inside each table.
- Link v2–v8 parameters pages in the `Parameters` column for every activated row. v7 Mainnet Beta is left as `—` since the upgrade was skipped.
- v7 on Mainnet Beta is marked as skipped (replaced by v8, per [CIP-49](https://cips.celestia.org/cip-049.html)).
- Rename "Past Upgrades" → "Network upgrade history"; keep the "Upcoming upgrades" heading + cosmovisor warning with a placeholder line.
- Drop the unused `constants` import (chain IDs are no longer in the tables).
- Flatten page structure: promote "Network upgrade history" and "Upcoming upgrades" to H2 so they're peers of "Upgrade process" instead of nested under it. Per-network sub-headings move from H4 to H3.
- Rename the left-sidebar entry for this page from "Network upgrade process" to "Network upgrades".
- Update inline link text on the four pages that reference this page (arabica-devnet, mocha-testnet, mainnet-beta, networks/overview) from "network upgrade process page" to "network upgrades page".

## Test plan

- [x] Preview deploy renders all three tables correctly on desktop and mobile.
- [x] Left sidebar shows "Network upgrades" (not "Network upgrade process").
- [x] Right TOC shows "Network upgrade history" and "Upcoming upgrades" as top-level entries.
- [x] CIP and parameter links resolve (including the new v7/v8 parameter pages).
- [x] Block-explorer links open the right block.
- [x] The four per-network pages link to this page with text "network upgrades page".

🤖 Generated with [Claude Code](https://claude.com/claude-code)