### PR TITLE
docs: remove broken snapshot provider links

### DIFF
--- a/app/operate/maintenance/snapshots/page.mdx
+++ b/app/operate/maintenance/snapshots/page.mdx
@@ -50,7 +50,6 @@ Their services include installation scripts, state sync, snapshots, RPC endpoint
 | ITRocket    | [Pruned](https://itrocket.net/services/mainnet/celestia/) • [Archive](https://itrocket.net/services/mainnet/celestia/)                         | [Archive](https://itrocket.net/services/mainnet/celestia/)                 |
 | Polkachu    | [Pruned](https://polkachu.com/tendermint_snapshots/celestia)                                                                                   | -                                                                          |
 | kjnodes     | [Pruned](https://services.kjnodes.com/mainnet/celestia/snapshot/) • [Archive](https://services.kjnodes.com/mainnet/celestia/snapshot-archive/) | -                                                                          |
-| TTT         | [Pruned](https://services.tienthuattoan.com/mainnet/celestia/snapshot)                                                                         | -                                                                          |
 | Noders      | [Pruned](https://noders.services/mainnet-networks/celestia/snapshot/)                                                                          | -                                                                          |
 | QubeLabs    | [Archive](https://snaps.qubelabs.io/celestia/)                                                                                                 | -                                                                          |
 
@@ -61,7 +60,6 @@ Their services include installation scripts, state sync, snapshots, RPC endpoint
 | ITRocket    | [Pruned](https://itrocket.net/services/testnet/celestia/) • [Archive](https://itrocket.net/services/testnet/celestia/) | [Archive](https://itrocket.net/services/testnet/celestia/)                 |
 | Polkachu    | [Pruned](https://polkachu.com/testnets/celestia/snapshots)                                                             | -                                                                          |
 | kjnodes     | [Pruned](https://services.kjnodes.com/testnet/celestia/snapshot/)                                                      | -                                                                          |
-| Noders      | [Pruned](https://noders.services/testnet-networks/celestia/snapshot)                                                   | -                                                                          |
 | QubeLabs    | [Archive](https://snaps.qubelabs.io/celestia/)                                                                         | -                                                                          |
 
 ## Using celestia-snapshot-finder


### PR DESCRIPTION
## Summary
Removes two 404 links from the snapshot providers tables in [app/operate/maintenance/snapshots/page.mdx](app/operate/maintenance/snapshots/page.mdx):

- **TTT** (mainnet): `https://services.tienthuattoan.com/mainnet/celestia/snapshot` — 404
- **Noders** (testnet): `https://noders.services/testnet-networks/celestia/snapshot` — 404

Noders' mainnet entry and all other providers remain.

## Test plan
- [x] Both URLs confirmed 404 via the broken-link checker
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)