### PR TITLE
Fix stale Operate links and include _page._mdx in link checks

### DIFF
--- a/app/operate/_page._mdx
+++ b/app/operate/_page._mdx
@@ -6,25 +6,28 @@ Learn how to run and maintain Celestia infrastructure. This section covers node 
 
 ## Node types
 
-- [Full DA node](/operate/full-node): Complete blockchain data and validation
-- [Light node](/operate/light-node): Data availability sampling and verification
-- [Bridge node](/operate/bridge-node): Connects rollups to Celestia
-- [Consensus node](/operate/consensus-node): Participates in consensus and optionally validates the chain
+- [Validator node](/operate/consensus-validators/validator-node): Produces and votes on blocks.
+- [Consensus node](/operate/consensus-validators/consensus-node): Syncs Celestia consensus history.
+- [Bridge node](/operate/data-availability/bridge-node): Connects the consensus network to the DA network.
+- [Light node](/operate/data-availability/light-node/quickstart): Performs data availability sampling.
 
 ## Getting started
 
-- [Node installation](/operate/installation)
-- [Configuration](/operate/configuration)
-- [Network participation](/operate/participation)
+- [Node operation overview](/operate/getting-started/overview)
+- [Hardware requirements](/operate/getting-started/hardware-requirements)
+- [Environment setup](/operate/getting-started/environment-setup)
+- [Networks overview](/operate/networks/overview)
 
 ## Maintenance
 
-- [Monitoring](/operate/monitoring)
-- [Updates](/operate/updates)
-- [Troubleshooting](/operate/troubleshooting)
+- [Systemd service setup](/operate/maintenance/systemd)
+- [Network upgrades](/operate/maintenance/network-upgrades)
+- [Snapshots and fast sync](/operate/maintenance/snapshots)
+- [Troubleshooting](/operate/maintenance/troubleshooting)
 
 ## Advanced operations
 
-- [Validator setup of consensus node](/operate/validators)
-- [Network security](/operate/security)
-- [Performance tuning](/operate/performance)
+- [Configuration reference](/operate/data-availability/config-reference)
+- [DA node metrics](/operate/data-availability/metrics)
+- [Consensus node metrics](/operate/consensus-validators/metrics)
+- [Keys and wallets](/operate/keys-wallets/celestia-node-key)

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -620,6 +620,7 @@ async function main() {
   // Find all MDX files
   const mdxFiles = [
     ...glob.sync('app/**/*.mdx', { cwd: rootDir }),
+    ...glob.sync('app/**/_page._mdx', { cwd: rootDir }),
   ].filter(file => !file.includes('node_modules'));
   
   // Find all _meta.js files


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

This fixes stale internal links on the `/operate` overview page and updates the link checker so `_page._mdx` files are included in future internal link checks.

The Operate overview page was still pointing to old routes such as `/operate/full-node`, `/operate/installation`, and `/operate/troubleshooting`. These have been replaced with current documentation routes for node types, getting started, maintenance, and advanced operations.


- Replaced stale `/operate` overview links with existing docs routes
- Updated `scripts/check-links.mjs` to scan `app/**/_page._mdx`
- Keeps future landing/section pages covered by the internal link checker
