### PR TITLE
Replace Validao node maps with ProbeLab

### DIFF
--- a/app/learn/celestia-101/resources/page.mdx
+++ b/app/learn/celestia-101/resources/page.mdx
@@ -16,7 +16,7 @@ A collection of useful tools, dashboards, and analytics platforms for exploring 
 | **Celenium**      | Blockchain explorer and analytics platform for Celestia      | [celenium.io](https://celenium.io/)                                            |
 | **Celestia Data** | Comprehensive analytics and metrics for the Celestia network | [celestiadata.com](https://celestiadata.com/)                                  |
 | **L2 Beat**       | Data availability tracking and metrics by L2BEAT             | [l2beat.com](https://l2beat.com/data-availability/projects/celestia/no-bridge) |
-| **Validao**       | Validator and network visualization tools                    | [validao.xyz](https://validao.xyz/#maps-celestia-da)                           |
+| **ProbeLab**      | Network monitoring and topology analytics for Celestia       | [probelab.io](https://probelab.io/celestia/)                                   |
 
 ## Bridge & node data
 

--- a/app/operate/networks/mainnet-beta/page.mdx
+++ b/app/operate/networks/mainnet-beta/page.mdx
@@ -236,7 +236,7 @@ The following websites provide analytics for Celestia:
 
 The following websites provide visual maps of Celestia DA nodes:
 
-- [https://validao.xyz/#maps-celestia-da](https://validao.xyz/#maps-celestia-da) (community contribution)
+- [https://probelab.io/celestia/](https://probelab.io/celestia/) (community contribution)
 
 ## Network upgrades
 

--- a/app/operate/networks/mocha-testnet/page.mdx
+++ b/app/operate/networks/mocha-testnet/page.mdx
@@ -220,7 +220,7 @@ The following websites provide analytics for Mocha Testnet:
 
 The following websites provide visual maps of Celestia DA nodes:
 
-- [https://validao.xyz/#maps-celestia-testnet-da](https://validao.xyz/#maps-celestia-testnet-da) (community contribution)
+- [https://probelab.io/celestia/](https://probelab.io/celestia/) (community contribution)
 
 ## Explorers
 

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -44,7 +44,6 @@ const DEFAULT_SKIP_PATTERNS = [
   'github.com/celestiaorg/celestia-app/blob/29906a468910184f221b42be0a15898722a2b08f/specs/src/parameters_v6.md',
   'github.com/celestiaorg/celestia-app/blob/main/docs/audit/', // Audit PDFs prone to 429 rate limiting
   // External tools and explorers that block automated checks
-  'validao.xyz', // Community node map visualization
   'celestia.valopers.com', // Community explorer
   'holesky.etherscan.io', // Testnet Etherscan (can be flaky)
   'arbiscan.io', // Cloudflare challenge blocks automated checks


### PR DESCRIPTION
Replace outdated Validao node-map links with ProbeLab across the Celestia resources, Mainnet Beta, and Mocha documentation.

Remove the obsolete Validao link-check exception now that no references remain.

Validation: `npm run lint` passes with one existing warning, and the ProbeLab URL returns HTTP 200.

Note: `npm run check-links` is blocked by the repository’s existing `glob`/`minimatch` resolution mismatch under Node 26.