### PR TITLE
docs: use QuickNode public RPC endpoints

### DIFF
--- a/app/build/post-retrieve-blob/client/go/page.mdx
+++ b/app/build/post-retrieve-blob/client/go/page.mdx
@@ -248,18 +248,18 @@ Choose your connection type:
 <Callout type="info">
 To submit blobs, you need both a DA JSON-RPC endpoint on port `26658` and a consensus gRPC endpoint on port `9090`.
 The public Mocha combination verified for this guide is ITRocket for DA JSON-RPC
-and P-OPS for consensus gRPC:
+and QuickNode for consensus gRPC:
 `http://celestia-testnet-consensus.itrocket.net:26658` and
-`rpc-mocha.pops.one:9090`.
+`public-endpoint.celestia-mocha.quiknode.pro:9090`.
 </Callout>
 
-**Public community endpoints (tested on Mocha):**
+**Public endpoints (tested on Mocha):**
 
 ```bash
 export CELE_DA_URL=http://celestia-testnet-consensus.itrocket.net:26658
 export CELE_DA_TLS=false
-export CELE_CORE_GRPC=rpc-mocha.pops.one:9090
-export CELE_CORE_TLS=false
+export CELE_CORE_GRPC=public-endpoint.celestia-mocha.quiknode.pro:9090
+export CELE_CORE_TLS=true
 ```
 
 **Managed provider (for example QuickNode):**

--- a/app/build/post-retrieve-blob/client/go/page.mdx
+++ b/app/build/post-retrieve-blob/client/go/page.mdx
@@ -11,7 +11,9 @@ The Celestia Go client lets you submit and retrieve data from the Celestia netwo
 
 ## Prerequisites
 
-- Go 1.25.1 or later
+- Go 1.25.x (Go 1.26 is not yet supported by a transitive dependency,
+  `bytedance/sonic`; if your default toolchain is newer, run the tutorial with
+  `GOTOOLCHAIN=go1.25.1 go run main.go`)
 - A Celestia account (created automatically)
 - Testnet tokens from the [Mocha faucet](/operate/networks/mocha-testnet#mocha-testnet-faucet)
 
@@ -246,18 +248,18 @@ go mod tidy
 Choose your connection type:
 
 <Callout type="info">
-To submit blobs, you need both a DA JSON-RPC endpoint on port `26658` and a consensus gRPC endpoint on port `9090`.
-The public Mocha combination verified for this guide is ITRocket for DA JSON-RPC
-and QuickNode for consensus gRPC:
-`http://celestia-testnet-consensus.itrocket.net:26658` and
-`public-endpoint.celestia-mocha.quiknode.pro:9090`.
+To submit blobs, you need both a DA JSON-RPC endpoint and a consensus gRPC endpoint.
+The public QuickNode Mocha endpoint serves both, and the full submit and
+retrieve flow in this guide was verified against it:
+`https://public-endpoint.celestia-mocha.quiknode.pro` for DA JSON-RPC and
+`public-endpoint.celestia-mocha.quiknode.pro:9090` for consensus gRPC.
 </Callout>
 
 **Public endpoints (tested on Mocha):**
 
 ```bash
-export CELE_DA_URL=http://celestia-testnet-consensus.itrocket.net:26658
-export CELE_DA_TLS=false
+export CELE_DA_URL=https://public-endpoint.celestia-mocha.quiknode.pro
+export CELE_DA_TLS=true
 export CELE_CORE_GRPC=public-endpoint.celestia-mocha.quiknode.pro:9090
 export CELE_CORE_TLS=true
 ```
@@ -284,8 +286,8 @@ export CELE_CORE_TLS=false
 **Read-only mode (no blob submission):**
 
 ```bash
-export CELE_DA_URL=http://celestia-testnet-consensus.itrocket.net:26658
-export CELE_DA_TLS=false
+export CELE_DA_URL=https://public-endpoint.celestia-mocha.quiknode.pro
+export CELE_DA_TLS=true
 # Don't set CELE_CORE_GRPC for read-only mode
 ```
 

--- a/app/operate/consensus-validators/cli-reference/page.mdx
+++ b/app/operate/consensus-validators/cli-reference/page.mdx
@@ -119,7 +119,7 @@ Example usage:
 
 ```sh
 celestia-appd q bank balances celestia1czpgn3hdh9sodm06d5qk23xzgpq2uyc8ggdqgw \
-    --node https://rpc-mocha.pops.one:443
+    --node https://public-endpoint.celestia-mocha.quiknode.pro
 ```
 
 Transfer tokens from one wallet to another:
@@ -133,7 +133,8 @@ Example usage:
 
 ```sh
 celestia-appd tx bank send <FROM_ADDRESS> <TO_ADDRESS> \
-    19000000utia --node https://rpc-mocha.pops.one:443 --chain-id mocha
+    19000000utia --node https://public-endpoint.celestia-mocha.quiknode.pro \
+    --chain-id mocha-4
 ```
 
 To see options:

--- a/app/operate/data-availability/bridge-node/page.mdx
+++ b/app/operate/data-availability/bridge-node/page.mdx
@@ -124,7 +124,7 @@ celestia bridge start --core.ip <archival-consensus-endpoint> --core.port 9090 -
 ```
 
 <Callout type="warning">
-Bridge nodes sync headers from genesis and require an archive consensus node. Public RPC endpoints are typically pruned and will not work for initial sync — use your own archive consensus node or an archive endpoint from an infrastructure provider.
+Bridge nodes sync headers from genesis and require an archival consensus node. Public RPC endpoints are typically pruned and will not work for initial sync. Use your own archival consensus node or an archival endpoint from an infrastructure provider.
 </Callout>
 
 <Callout type="info">

--- a/app/operate/data-availability/bridge-node/page.mdx
+++ b/app/operate/data-availability/bridge-node/page.mdx
@@ -120,8 +120,12 @@ celestia bridge start --core.ip <URI> --core.port <port>
 Here is an example of starting the bridge node on Mocha:
 
 ```sh
-celestia bridge start --core.ip rpc-mocha.pops.one --core.port 9090 --p2p.network mocha
+celestia bridge start --core.ip <archive-consensus-endpoint> --core.port 9090 --p2p.network mocha
 ```
+
+<Callout type="warning">
+Bridge nodes sync headers from genesis and require an archive consensus node. Public RPC endpoints are typically pruned and will not work for initial sync — use your own archive consensus node or an archive endpoint from an infrastructure provider.
+</Callout>
 
 <Callout type="info">
 If you're connecting your bridge node to a localhost consensus node (`--core.ip localhost` or `--core.ip 127.0.0.1`), ensure that gRPC is enabled in your consensus node's `app.toml` configuration file. Look for the `[grpc]` section and verify that `enable = true` is set:

--- a/app/operate/data-availability/bridge-node/page.mdx
+++ b/app/operate/data-availability/bridge-node/page.mdx
@@ -120,7 +120,7 @@ celestia bridge start --core.ip <URI> --core.port <port>
 Here is an example of starting the bridge node on Mocha:
 
 ```sh
-celestia bridge start --core.ip <archive-consensus-endpoint> --core.port 9090 --p2p.network mocha
+celestia bridge start --core.ip <archival-consensus-endpoint> --core.port 9090 --p2p.network mocha
 ```
 
 <Callout type="warning">

--- a/app/operate/data-availability/ibc-relayer/page.mdx
+++ b/app/operate/data-availability/ibc-relayer/page.mdx
@@ -126,7 +126,7 @@ derivation = "cosmos"
 [[chains]]
 id = "{{constants['mochaChainId']}}"
 type = "CosmosSdk"
-rpc_addr = "https://rpc-celestia-mocha.architectnodes.com"
+rpc_addr = "https://public-endpoint.celestia-mocha.quiknode.pro"
 grpc_addr = "https://grpc.celestia-mocha.com:443"
 rpc_timeout = "10s"
 trusted_node = false

--- a/app/operate/data-availability/ibc-relayer/page.mdx
+++ b/app/operate/data-availability/ibc-relayer/page.mdx
@@ -148,7 +148,7 @@ sequential_batch_tx = false
 
 [chains.event_source]
 mode = "push"
-url = "ws://rpc-mocha.pops.one:26657/websocket"
+url = "wss://public-endpoint.celestia-mocha.quiknode.pro/websocket"
 batch_delay = "500ms"
 
 [chains.trust_threshold]

--- a/app/operate/data-availability/light-node/advanced/page.mdx
+++ b/app/operate/data-availability/light-node/advanced/page.mdx
@@ -88,10 +88,10 @@ Celestia also supports initializing from a trusted hash via
 
 ### Get a trusted height and hash
 
-This example uses the P-OPS Mocha endpoint:
+This example uses the public QuickNode Mocha endpoint:
 
 ```bash
-read -r TRUSTED_HEIGHT TRUSTED_HASH <<<"$(curl -s https://rpc-mocha.pops.one/header | jq -r '.result.header | "\(.height) \(.last_block_id.hash)"')" && export TRUSTED_HEIGHT TRUSTED_HASH
+read -r TRUSTED_HEIGHT TRUSTED_HASH <<<"$(curl -s https://public-endpoint.celestia-mocha.quiknode.pro/header | jq -r '.result.header | "\(.height) \(.last_block_id.hash)"')" && export TRUSTED_HEIGHT TRUSTED_HASH
 ```
 
 ### Set `SyncFromHeight` and `SyncFromHash`
@@ -108,7 +108,9 @@ Ensure `SyncFromHash` has **no `0x` prefix**.
 ### Start the node
 
 ```bash
-celestia light start --p2p.network mocha --core.ip rpc-mocha.pops.one --core.port 9090
+celestia light start --p2p.network mocha \
+  --core.ip public-endpoint.celestia-mocha.quiknode.pro \
+  --core.port 9090 --core.tls
 ```
 
 </Steps>
@@ -159,7 +161,9 @@ TxWorkerAccounts = 1
 #### Restart your node
 
 ```bash
-celestia light start --p2p.network mocha --core.ip rpc-mocha.pops.one --core.port 9090
+celestia light start --p2p.network mocha \
+  --core.ip public-endpoint.celestia-mocha.quiknode.pro \
+  --core.port 9090 --core.tls
 ```
 
 </Steps>
@@ -198,7 +202,9 @@ TxWorkerAccounts = 8
 #### Restart your node
 
 ```bash
-celestia light start --p2p.network mocha --core.ip rpc-mocha.pops.one --core.port 9090
+celestia light start --p2p.network mocha \
+  --core.ip public-endpoint.celestia-mocha.quiknode.pro \
+  --core.port 9090 --core.tls
 ```
 
 </Steps>

--- a/app/operate/data-availability/light-node/quickstart/page.mdx
+++ b/app/operate/data-availability/light-node/quickstart/page.mdx
@@ -85,14 +85,16 @@ for state access (balances, submitting `PayForBlobs`, etc.).
 <Tabs items={['Mainnet Beta', 'Mocha']}>
   <Tabs.Tab>
     ```bash
-    celestia light start --core.ip rpc.celestia.pops.one \
-      --core.port 9090 --p2p.network celestia
+    celestia light start \
+      --core.ip public-endpoint.celestia-mainnet.quiknode.pro \
+      --core.port 9090 --core.tls --p2p.network celestia
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```bash
-    celestia light start --core.ip rpc-mocha.pops.one \
-      --core.port 9090 --p2p.network mocha
+    celestia light start \
+      --core.ip public-endpoint.celestia-mocha.quiknode.pro \
+      --core.port 9090 --core.tls --p2p.network mocha
     ```
   </Tabs.Tab>
 </Tabs>

--- a/app/operate/keys-wallets/celestia-node-key/page.mdx
+++ b/app/operate/keys-wallets/celestia-node-key/page.mdx
@@ -233,7 +233,9 @@ celestia <node-type> start --p2p.network <network> --keyring.keyname <key-name> 
 For example:
 
 ```bash
-celestia light start --p2p.network mocha --keyring.keyname my_celes_key --core.ip rpc-mocha.pops.one
+celestia light start --p2p.network mocha --keyring.keyname my_celes_key \
+  --core.ip public-endpoint.celestia-mocha.quiknode.pro \
+  --core.port 9090 --core.tls
 ```
 
 This ensures your node uses the specified key for all operations, including those reported by `celestia state account-address`.
@@ -254,7 +256,8 @@ testnet):
 ```bash
 docker run --name celestia-node -e NODE_TYPE=light -e P2P_NETWORK=mocha -p 26659:26659 \
 ghcr.io/celestiaorg/celestia-node:{{mochaVersions['node-latest-tag']}} celestia light start \
---core.ip rpc-mocha.pops.one --core.port 9090 --p2p.network mocha
+--core.ip public-endpoint.celestia-mocha.quiknode.pro --core.port 9090 \
+--core.tls --p2p.network mocha
 ```
 
 <Callout type="info">
@@ -306,7 +309,7 @@ services:
     image: celestia-node
     environment:
       - NODE_TYPE=light
-    command: celestia light start --core.ip rpc-mocha.pops.one --core.port 9090 --p2p.network mocha --keyring.keyname my_celes_key
+    command: celestia light start --core.ip public-endpoint.celestia-mocha.quiknode.pro --core.port 9090 --core.tls --p2p.network mocha --keyring.keyname my_celes_key
     volumes:
       - ${PWD}/keys:/root/.celestia-light-{{constants['mochaChainId']}}/keys
     ports:

--- a/app/operate/keys-wallets/vesting/page.mdx
+++ b/app/operate/keys-wallets/vesting/page.mdx
@@ -330,7 +330,7 @@ If you are running a production application, use a production endpoint.
 Set your RPC URL:
 
 ```bash
-export RPC_URL=https://rpc-mocha.pops.one:443
+export RPC_URL=https://public-endpoint.celestia-mocha.quiknode.pro
 ```
 
 We will use a few flags in our vesting command that are different than the
@@ -384,7 +384,7 @@ keyring-backend = "test"
 # CLI output format (text|json)
 output = "text"
 # <host>:<port> to Tendermint RPC interface for this chain
-node = "tcp://rpc-mocha.pops.one:443"
+node = "https://public-endpoint.celestia-mocha.quiknode.pro"
 # Transaction broadcasting mode (sync|async|block)
 broadcast-mode = "sync"
 ```

--- a/app/operate/maintenance/troubleshooting/page.mdx
+++ b/app/operate/maintenance/troubleshooting/page.mdx
@@ -105,7 +105,7 @@ celestia <node-type> init --node.store /home/user/celestia-<node-type>-location/
 Next, start your node:
 
 ```bash
-celestia bridge start --core.ip <archive-consensus-endpoint> --p2p.network mocha \
+celestia bridge start --core.ip <archival-consensus-endpoint> --p2p.network mocha \
     --node.store /home/user/celestia-bridge-location/ --core.port <port>
 ```
 

--- a/app/operate/maintenance/troubleshooting/page.mdx
+++ b/app/operate/maintenance/troubleshooting/page.mdx
@@ -105,7 +105,7 @@ celestia <node-type> init --node.store /home/user/celestia-<node-type>-location/
 Next, start your node:
 
 ```bash
-celestia bridge start --core.ip rpc-mocha.pops.one --p2p.network mocha \
+celestia bridge start --core.ip <archive-consensus-endpoint> --p2p.network mocha \
     --node.store /home/user/celestia-bridge-location/ --core.port <port>
 ```
 

--- a/app/operate/maintenance/trusted-hash-recovery/page.mdx
+++ b/app/operate/maintenance/trusted-hash-recovery/page.mdx
@@ -74,7 +74,7 @@ celestia light init --p2p.network mocha
 
 ```sh
 # Get both the height and hash values in a single call
-read -r TRUSTED_HEIGHT TRUSTED_HASH <<<"$(curl -s https://rpc-mocha.pops.one/header | jq -r '.result.header | "\(.height) \(.last_block_id.hash)"')" && export TRUSTED_HEIGHT TRUSTED_HASH
+read -r TRUSTED_HEIGHT TRUSTED_HASH <<<"$(curl -s https://public-endpoint.celestia-mocha.quiknode.pro/header | jq -r '.result.header | "\(.height) \(.last_block_id.hash)"')" && export TRUSTED_HEIGHT TRUSTED_HASH
 
 # Use sed to find and replace the SyncFromHeight value in the config file (macOS version)
 sed -i '' "s/SyncFromHeight = .*/SyncFromHeight = $TRUSTED_HEIGHT/" ~/.celestia-light-{{constants['mochaChainId']}}/config.toml
@@ -90,7 +90,9 @@ echo "SyncFromHash updated to: $TRUSTED_HASH"
 ### Start the node
 
 ```sh
-celestia light start --p2p.network mocha --core.ip rpc-mocha.pops.one --core.port 9090
+celestia light start --p2p.network mocha \
+  --core.ip public-endpoint.celestia-mocha.quiknode.pro \
+  --core.port 9090 --core.tls
 ```
 </Steps>
 

--- a/app/operate/networks/mainnet-beta/page.mdx
+++ b/app/operate/networks/mainnet-beta/page.mdx
@@ -131,6 +131,20 @@ If you are using QuickNode or another provider with authenticated endpoints,
 see [the light node guide](/operate/data-availability/light-node/advanced#optional-start-light-node-with-consensus-endpoint-authentication)
 to learn how to use an endpoint with x-token.
 
+### Public RPC endpoint
+
+For development, testing, and documentation examples, use the public QuickNode
+endpoint:
+
+| Interface | Endpoint |
+| --------- | -------- |
+| HTTP RPC and REST | `https://public-endpoint.celestia-mainnet.quiknode.pro` |
+| WebSocket | `wss://public-endpoint.celestia-mainnet.quiknode.pro/websocket` |
+| gRPC over TLS | `public-endpoint.celestia-mainnet.quiknode.pro:9090` |
+
+This shared endpoint does not provide a production SLA. Use a [production
+provider](#production-rpc-endpoints) or your own node for production workloads.
+
 ### Node setup and tools
 
 Several community providers offer comprehensive node setup tools, installation scripts, and monitoring services to help node operators get started quickly:
@@ -173,12 +187,17 @@ celestia <da_type> start --core.ip <consensus_node_url> --core.port <port>
 ```
 </Callout>
 
-You can use any of the RPC endpoints from the [community consensus endpoints](#community-consensus-endpoints) table above. The default port is 9090, where gRPC is used for both block sync and state access.
+You can use the [public endpoint](#public-rpc-endpoint) or any of the RPC
+endpoints from the [community consensus endpoints](#community-consensus-endpoints)
+table above. The default port is 9090, where gRPC is used for both block sync
+and state access.
 
-For example, to connect to the P-OPS endpoint:
+For example, to connect to the public QuickNode endpoint:
 
 ```bash
-celestia light start --core.ip rpc.celestia.pops.one --core.port 9090
+celestia light start \
+  --core.ip public-endpoint.celestia-mainnet.quiknode.pro \
+  --core.port 9090 --core.tls
 ```
 
 ### Bridge node requirements

--- a/app/operate/networks/mainnet-beta/page.mdx
+++ b/app/operate/networks/mainnet-beta/page.mdx
@@ -141,6 +141,7 @@ endpoint:
 | HTTP RPC and REST | `https://public-endpoint.celestia-mainnet.quiknode.pro` |
 | WebSocket | `wss://public-endpoint.celestia-mainnet.quiknode.pro/websocket` |
 | gRPC over TLS | `public-endpoint.celestia-mainnet.quiknode.pro:9090` |
+| DA JSON-RPC | `https://public-endpoint.celestia-mainnet.quiknode.pro` |
 
 This shared endpoint does not provide a production SLA. Use a [production
 provider](#production-rpc-endpoints) or your own node for production workloads.

--- a/app/operate/networks/mocha-testnet/page.mdx
+++ b/app/operate/networks/mocha-testnet/page.mdx
@@ -93,6 +93,7 @@ endpoint:
 | HTTP RPC and REST | `https://public-endpoint.celestia-mocha.quiknode.pro` |
 | WebSocket | `wss://public-endpoint.celestia-mocha.quiknode.pro/websocket` |
 | gRPC over TLS | `public-endpoint.celestia-mocha.quiknode.pro:9090` |
+| DA JSON-RPC | `https://public-endpoint.celestia-mocha.quiknode.pro` |
 
 This shared endpoint is pruned and does not provide a production SLA. Do not
 use it for historical queries or bridge node sync from genesis.

--- a/app/operate/networks/mocha-testnet/page.mdx
+++ b/app/operate/networks/mocha-testnet/page.mdx
@@ -83,6 +83,20 @@ history, such as:
 
 > **Warning:** Do not rely on the free community endpoints listed below for production deployments. Production deployments should rely on [service providers with SLAs](#production-rpc-endpoints) or your own node.
 
+### Public RPC endpoint
+
+For development, testing, and documentation examples, use the public QuickNode
+endpoint:
+
+| Interface | Endpoint |
+| --------- | -------- |
+| HTTP RPC and REST | `https://public-endpoint.celestia-mocha.quiknode.pro` |
+| WebSocket | `wss://public-endpoint.celestia-mocha.quiknode.pro/websocket` |
+| gRPC over TLS | `public-endpoint.celestia-mocha.quiknode.pro:9090` |
+
+This shared endpoint is pruned and does not provide a production SLA. Do not
+use it for historical queries or bridge node sync from genesis.
+
 ### Node setup and tools
 
 Several community providers offer comprehensive node setup tools, installation scripts, and monitoring services to help node operators get started quickly:

--- a/constants/general.json
+++ b/constants/general.json
@@ -3,9 +3,5 @@
   "golangNodeMocha": "1.24.1",
   "mainnetChainId": "celestia",
   "mochaChainId": "mocha-4",
-  "orchrelayVersion": "v1.0.1",
-  "mochaRpcUrl": "https://public-endpoint.celestia-mocha.quiknode.pro/",
-  "mochaRestUrl": "https://public-endpoint.celestia-mocha.quiknode.pro/",
-  "mainnetRpcUrl": "https://public-endpoint.celestia-mainnet.quiknode.pro/",
-  "mainnetRestUrl": "https://public-endpoint.celestia-mainnet.quiknode.pro/"
+  "orchrelayVersion": "v1.0.1"
 }

--- a/constants/general.json
+++ b/constants/general.json
@@ -4,8 +4,8 @@
   "mainnetChainId": "celestia",
   "mochaChainId": "mocha-4",
   "orchrelayVersion": "v1.0.1",
-  "mochaRpcUrl": "https://rpc-mocha.pops.one/",
-  "mochaRestUrl": "https://api-mocha.pops.one/",
-  "mainnetRpcUrl": "https://rpc.lunaroasis.net/",
-  "mainnetRestUrl": "https://api.celestia.pops.one/"
+  "mochaRpcUrl": "https://public-endpoint.celestia-mocha.quiknode.pro/",
+  "mochaRestUrl": "https://public-endpoint.celestia-mocha.quiknode.pro/",
+  "mainnetRpcUrl": "https://public-endpoint.celestia-mainnet.quiknode.pro/",
+  "mainnetRestUrl": "https://public-endpoint.celestia-mainnet.quiknode.pro/"
 }

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -24,8 +24,4 @@ export const constants = constantsJson as {
     mainnetChainId: string;
     mochaChainId: string;
     orchrelayVersion: string;
-    mochaRpcUrl: string;
-    mochaRestUrl: string;
-    mainnetRpcUrl: string;
-    mainnetRestUrl: string;
 };

--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -96,7 +96,7 @@ Why this is the preferred path:
 - Both clients are built for submit + retrieve flows.
 - Both use local keyring/signer handling.
 - Both use the expected endpoint model: DA bridge RPC plus Core gRPC.
-- For public Mocha examples, prefer `CELE_DA_URL=http://celestia-testnet-consensus.itrocket.net:26658` and `CELE_CORE_GRPC=rpc-mocha.pops.one:9090` unless the user specifies a managed provider.
+- For public Mocha examples, prefer `CELE_DA_URL=http://celestia-testnet-consensus.itrocket.net:26658` and `CELE_CORE_GRPC=public-endpoint.celestia-mocha.quiknode.pro:9090` with Core TLS enabled unless the user specifies a managed provider.
 
 Funding flow for agent-led examples:
 

--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -96,7 +96,7 @@ Why this is the preferred path:
 - Both clients are built for submit + retrieve flows.
 - Both use local keyring/signer handling.
 - Both use the expected endpoint model: DA bridge RPC plus Core gRPC.
-- For public Mocha examples, prefer `CELE_DA_URL=http://celestia-testnet-consensus.itrocket.net:26658` and `CELE_CORE_GRPC=public-endpoint.celestia-mocha.quiknode.pro:9090` with Core TLS enabled unless the user specifies a managed provider.
+- For public Mocha examples, prefer `CELE_DA_URL=https://public-endpoint.celestia-mocha.quiknode.pro` and `CELE_CORE_GRPC=public-endpoint.celestia-mocha.quiknode.pro:9090` with DA and Core TLS enabled unless the user specifies a managed provider.
 
 Funding flow for agent-led examples:
 


### PR DESCRIPTION
## Summary

- add the canonical public QuickNode endpoints for Mainnet and Mocha
- update default HTTP, REST, WebSocket, gRPC, node, and trusted-hash examples
- retain community provider listings; bridge start examples now use an `<archival-consensus-endpoint>` placeholder with an archive-node warning, because public endpoints are pruned and cannot serve bridge sync from genesis
- align the Mocha hermes `rpc_addr` with the QuickNode `event_source` websocket so the relayer queries and subscribes to the same node
- remove the unused `mochaRpcUrl`/`mochaRestUrl`/`mainnetRpcUrl`/`mainnetRestUrl` constants (not referenced by any page)
- keep `--chain-id mocha-4` in the cli-reference tx example: the "mocha" alias only exists for celestia-node's `--p2p.network` flag, while celestia-appd signs transactions against the exact chain ID. Note: chain ID references will move to `mocha-5` with the network restart tracked in #2546.
- use QuickNode for both DA JSON-RPC and consensus gRPC in the Go client guide — the public endpoints serve celestia-node DA JSON-RPC on 443, and the full submit + retrieve flow was verified live on Mocha (blob at block 13821340). Both network pages now list the DA JSON-RPC interface.
- note the Go 1.25.x requirement in the Go guide (`bytedance/sonic` does not compile on Go 1.26 yet; `GOTOOLCHAIN=go1.25.1` workaround documented)

## Context

Tracks [DEVX-102](https://linear.app/celestia/issue/DEVX-102/switch-main-public-rpc-to-quicknode-enterprise-endpoint).

The endpoint aliases and Mainnet/Mocha split were confirmed in the [original Slack thread](https://celestia-team.slack.com/archives/C07TJQPUDJP/p1752701226522469?thread_ts=1750066245.925629&cid=C07TJQPUDJP).

## Validation

- live HTTP RPC, REST, authenticated-free CORS, WebSocket new-block subscriptions, and gRPC GetNodeInfo on both endpoints
- Mainnet archive query at height 1; Mocha confirmed pruned
- `npm run test:endpoints`
- `npm run lint` (passes with one unrelated existing warning)
- `npm run build`
