### PR TITLE
docs: stop recommending the test keyring for Mainnet Beta validators

### DIFF
--- a/app/operate/consensus-validators/cli-reference/page.mdx
+++ b/app/operate/consensus-validators/cli-reference/page.mdx
@@ -39,12 +39,17 @@ Available Commands:
 ## Creating a wallet
 
 ```sh
-celestia-appd config keyring-backend test
+celestia-appd config keyring-backend <backend>
 ```
 
 `keyring-backend` configures the keyring's backend, where the keys are stored.
 
 Options are: `os|file|kwallet|pass|test|memory`.
+
+`test` keeps the key unencrypted on disk with no password, so reserve it for
+local development and testnets. See
+[create a wallet with celestia-app](/operate/keys-wallets/celestia-app-wallet)
+for a comparison of the backends.
 
 You can learn more on the [Cosmos documentation](https://docs.cosmos.network/sdk/v0.53/user/run-node/keyring)
 or [Go Package documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk/crypto/keyring).

--- a/app/operate/consensus-validators/validator-node/page.mdx
+++ b/app/operate/consensus-validators/validator-node/page.mdx
@@ -26,6 +26,9 @@ First, follow the instructions on
 ### Wallet
 
 Follow [the tutorial on creating a wallet](/operate/keys-wallets/celestia-app-wallet).
+That page also covers the available keyring backends. Pick one before you
+create the wallet: a Mainnet Beta validator should not use the `test` backend,
+which stores the key unencrypted on disk.
 
 ## Optional: Deploy the celestia-node
 
@@ -115,6 +118,10 @@ In order to create a validator on-chain, follow the steps below.
    # Set VALIDATOR_WALLET to the same you defined previously.
    export VALIDATOR_WALLET="validator"
 
+   # Set KEYRING_BACKEND to the backend you chose when creating the wallet.
+   # Use `test` only on a testnet: it stores the key unencrypted on disk.
+   export KEYRING_BACKEND="file"
+
    # Set VALIDATOR_PUBKEY to the pubkey of your validator wallet.
    export VALIDATOR_PUBKEY=$(celestia-appd tendermint show-validator)
    ```
@@ -138,7 +145,7 @@ In order to create a validator on-chain, follow the steps below.
            --commission-max-change-rate=0.01 \
            --min-self-delegation=1000000 \
            --from=$VALIDATOR_WALLET \
-           --keyring-backend=test \
+           --keyring-backend=$KEYRING_BACKEND \
            --fees=21000utia \
            --gas=220000 \
            --yes
@@ -195,7 +202,7 @@ celestia-appd tx staking edit-validator \
     --security-contact="<email_address_for_security_contact>" \
     --details="New description of the validator." \
     --from=$VALIDATOR_WALLET \
-    --keyring-backend=test \
+    --keyring-backend=$KEYRING_BACKEND \
     --fees=21000utia \
     --gas=220000
 ```

--- a/app/operate/consensus-validators/validator-node/page.mdx
+++ b/app/operate/consensus-validators/validator-node/page.mdx
@@ -119,7 +119,8 @@ In order to create a validator on-chain, follow the steps below.
    export VALIDATOR_WALLET="validator"
 
    # Set KEYRING_BACKEND to the backend you chose when creating the wallet.
-   # Use `test` only on a testnet: it stores the key unencrypted on disk.
+   # `test` stores the key unencrypted on disk: it is a reasonable choice on
+   # Mocha, but do not use it on Mainnet Beta.
    export KEYRING_BACKEND="file"
 
    # Set VALIDATOR_PUBKEY to the pubkey of your validator wallet.
@@ -167,7 +168,7 @@ In order to create a validator on-chain, follow the steps below.
            --commission-max-change-rate=0.01 \
            --min-self-delegation=1000000 \
            --from=$VALIDATOR_WALLET \
-           --keyring-backend=test \
+           --keyring-backend=$KEYRING_BACKEND \
            --fees=21000utia \
            --gas=220000 \
            --yes
@@ -229,7 +230,8 @@ the command below to get the `celestiavaloper` of your local validator wallet in
 case you want to delegate more to it:
 
 ```bash
-celestia-appd keys show $VALIDATOR_WALLET --bech val -a
+celestia-appd keys show $VALIDATOR_WALLET --bech val -a \
+--keyring-backend=$KEYRING_BACKEND
 ```
 
 After entering the wallet passphrase you should see a similar output:
@@ -246,6 +248,7 @@ example you can run:
 celestia-appd tx staking delegate \
 <the_valoper_address_starts_with_celestiavaloper1...> 1000000utia \
 --from=$VALIDATOR_WALLET --chain-id={{constants['mochaChainId']}} \
+--keyring-backend=$KEYRING_BACKEND \
 --fees=21000utia
 ```
 

--- a/app/operate/keys-wallets/celestia-app-wallet/page.mdx
+++ b/app/operate/keys-wallets/celestia-app-wallet/page.mdx
@@ -17,26 +17,49 @@ Note, you do not need to install celestia-node for this tutorial.
 
 ## Keyring backend
 
-First, create an application CLI configuration file:
+`keyring-backend` configures where celestia-appd stores your keys. Choose it
+before you create a wallet, because the backend you pick decides whether the
+private key is encrypted at rest.
 
-```sh
-celestia-appd config keyring-backend test
-```
+| Backend | Where keys are stored | Suitable for |
+| --- | --- | --- |
+| `os` | The operating system keychain: Keychain on macOS, Credentials Management on Windows, libsecret, kwallet or keyctl on Linux | A single-operator machine |
+| `file` | Encrypted inside the app's configuration directory; the password is requested on every access | Servers and containers |
+| `pass` | GPG-encrypted files managed by the `pass` utility | Servers with an existing GPG setup |
+| `kwallet` | KDE Wallet Manager | KDE desktops |
+| `test` | **Unencrypted on disk, with no password** | Local development and testnets |
+| `memory` | Process memory, discarded when the process exits | Throwaway scripts |
 
-`keyring-backend` configures the keyring's backend, where the keys are stored.
+<Callout type="warning">
+The Cosmos SDK describes `test` as "a password-less variation of the file
+backend. Keys are stored unencrypted on disk" and states that it is "not
+recommended for use in production environments". Anyone who can read the
+directory can spend from the account and sign on behalf of the validator.
 
-Options are: `os|file|kwallet|pass|test|memory`.
+Do not use `test` for a wallet that holds real funds or operates a Mainnet Beta
+validator. Use a hardware wallet, or a
+[multisig account](/operate/keys-wallets/multisig) so that no single key can
+move funds on its own.
+</Callout>
 
-You can learn more on the [Cosmos documentation](https://docs.cosmos.network/sdk/v0.53/user/run-node/keyring)
+You can set the backend for a single command with `--keyring-backend`, which is
+what the examples in these docs do. You can learn more on the
+[Cosmos documentation](https://docs.cosmos.network/sdk/v0.53/user/run-node/keyring)
 or [Go Package documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk/crypto/keyring).
 
 ## Create a wallet
 
-You can pick whatever wallet name you want.
-For our example we used "validator" as the wallet name:
+You can pick whatever wallet name you want. The examples below and the
+[validator node guide](/operate/consensus-validators/validator-node) both use
+`$VALIDATOR_WALLET`, so set it to the name you chose:
 
 ```sh
-celestia-appd keys add validator --interactive
+export VALIDATOR_WALLET=validator
+export KEYRING_BACKEND=file # use `test` only on a testnet
+
+celestia-appd keys add $VALIDATOR_WALLET \
+  --keyring-backend=$KEYRING_BACKEND \
+  --interactive
 ```
 
 Save the mnemonic output as this is the only way to

--- a/app/operate/keys-wallets/celestia-app-wallet/page.mdx
+++ b/app/operate/keys-wallets/celestia-app-wallet/page.mdx
@@ -43,7 +43,9 @@ move funds on its own.
 </Callout>
 
 You can set the backend for a single command with `--keyring-backend`, which is
-what the examples in these docs do. You can learn more on the
+what the examples in these docs do. Pass it on every command that touches a key:
+without the flag, `celestia-appd` falls back to the default backend and will not
+find a key that was created in a different one. You can learn more on the
 [Cosmos documentation](https://docs.cosmos.network/sdk/v0.53/user/run-node/keyring)
 or [Go Package documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk/crypto/keyring).
 
@@ -68,23 +70,24 @@ recover your validator wallet in case you lose it!
 To check all your wallets you can run:
 
 ```sh
-celestia-appd keys list
+celestia-appd keys list --keyring-backend=$KEYRING_BACKEND
 ```
 
 ## Key management
 
 ```sh
 # listing keys
-celestia-appd keys list
+celestia-appd keys list --keyring-backend=$KEYRING_BACKEND
 
 # adding keys
-celestia-appd keys add <KEY_NAME>
+celestia-appd keys add <KEY_NAME> --keyring-backend=$KEYRING_BACKEND
 
 # deleting keys
-celestia-appd keys delete <KEY_NAME>
+celestia-appd keys delete <KEY_NAME> --keyring-backend=$KEYRING_BACKEND
 
 # renaming keys
-celestia-appd keys rename <CURRENT_KEY_NAME> <NEW_KEY_NAME>
+celestia-appd keys rename <CURRENT_KEY_NAME> <NEW_KEY_NAME> \
+  --keyring-backend=$KEYRING_BACKEND
 ```
 
 ### Importing and exporting keys
@@ -92,19 +95,19 @@ celestia-appd keys rename <CURRENT_KEY_NAME> <NEW_KEY_NAME>
 Import an encrypted and ASCII-armored private key into the local keybase.
 
 ```sh
-celestia-appd keys import <KEY_NAME> <KEY_FILE>
+celestia-appd keys import <KEY_NAME> <KEY_FILE> --keyring-backend=$KEYRING_BACKEND
 ```
 
 Example usage:
 
 ```sh
-celestia-appd keys import amanda ./keyfile.txt
+celestia-appd keys import amanda ./keyfile.txt --keyring-backend=$KEYRING_BACKEND
 ```
 
 Export a private key from the local keyring in encrypted and ASCII-armored format:
 
 ```sh
-celestia-appd keys export <KEY_NAME>
+celestia-appd keys export <KEY_NAME> --keyring-backend=$KEYRING_BACKEND
 
 # you will then be prompted to set a password for the encrypted private key:
 Enter passphrase to encrypt the exported key:


### PR DESCRIPTION
Closes #1968

The wallet guide opened by writing `keyring-backend test` into the CLI config, which makes every later command use it silently, and the validator guide passed `--keyring-backend=test` in all three of its transaction examples.

The Cosmos SDK [documents that backend](https://docs.cosmos.network/sdk/v0.53/user/run-node/keyring) as "a password-less variation of the file backend. Keys are stored unencrypted on disk" and "not recommended for use in production environments". These are the only docs for running a Celestia validator, so following them as written leaves a Mainnet Beta signing key readable by anyone with access to the directory.

## Changes

- Compare the keyring backends and say where each is appropriate, with a warning that points at hardware wallets and the existing [multisig page](https://docs.celestia.org/operate/keys-wallets/multisig).
- Drop the global `config keyring-backend test` line and pass the backend per command, so a testnet choice cannot silently carry into mainnet work.
- The validator guide already had `Mainnet Beta` and `Mocha` tabs carrying the same backend. Mainnet Beta now reads `$KEYRING_BACKEND`; Mocha keeps `test`, which is what the tabs were there to distinguish.
- Both pages use `$VALIDATOR_WALLET`, so the wallet you create is the wallet the next guide expects. This was the second point in #1968.

## Left out on purpose

I did not add step-by-step `--ledger` instructions. I have not set up a Celestia validator with a hardware wallet, and I would rather not document a flow I have not run. The backend table names `ledger` and the warning recommends it. Happy to add the full flow if a maintainer who has done it wants to review the wording.

## Testing

`npm run lint` passes. `npm run build` fails locally on `/_not-found` and two unrelated pages, but it fails the same way on a clean `main` here, so it looks like a local Node version issue rather than something in this change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->