### PR TITLE
docs: fix dead links to the celestia-app namespace specification

### DIFF
--- a/app/build/blobstream/proof-queries/page.mdx
+++ b/app/build/blobstream/proof-queries/page.mdx
@@ -208,7 +208,7 @@ The `min` and `max` are `Namespace` type which is:
 
 ```solidity
 /// @notice A representation of the Celestia-app namespace ID and its version.
-/// See: https://celestiaorg.github.io/celestia-app/specs/namespace.html
+/// See: https://celestiaorg.github.io/celestia-app/namespace.html
 struct Namespace {
     // The namespace version.
     bytes1 version;
@@ -230,7 +230,7 @@ Which is the namespace used by the rollup when submitting data to Celestia. As d
 
 ```solidity
 /// @notice A representation of the Celestia-app namespace ID and its version.
-/// See: https://celestiaorg.github.io/celestia-app/specs/namespace.html
+/// See: https://celestiaorg.github.io/celestia-app/namespace.html
 struct Namespace {
     // The namespace version.
     bytes1 version;


### PR DESCRIPTION
## Problem

The Blobstream proof-queries page references the celestia-app namespace specification twice, and both links are dead:

```
/// See: https://celestiaorg.github.io/celestia-app/specs/namespace.html
```

The specs mdbook no longer nests pages under `/specs/`, so this returns **404**.

## Change

Dropped the stale `specs/` path segment in both occurrences:

`https://celestiaorg.github.io/celestia-app/namespace.html` → **200**, page title "Namespace — Celestia App Specifications".

Documentation-only; the change is confined to two comment lines inside Solidity snippets on `app/build/blobstream/proof-queries/page.mdx`.

## Verification

Both URLs requested directly: old path `404`, new path `200` serving the namespace spec.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->