### PR TITLE
fix celestia-node Homebrew install path

### DIFF
--- a/app/operate/data-availability/install-celestia-node/page.mdx
+++ b/app/operate/data-availability/install-celestia-node/page.mdx
@@ -99,9 +99,10 @@ commit hash, build date, system version, and Golang version.
 
 Installing a pre-built binary is the fastest way to get started with your Celestia data availability node. Releases after celestia-node v0.13.3 have these binaries available.
 
-The installation script will download a binary file named `celestia`. Depending on your chosen installation option, the `celestia` binary will be available at one of these locations:
+The installation script will download a binary file named `celestia`. Depending on your environment and chosen installation option, the `celestia` binary will be available at one of these locations:
 
-- `$GOPATH/bin/celestia` (if Go is installed)
+- The Homebrew bin directory (usually `/opt/homebrew/bin/celestia` on Apple silicon or `/usr/local/bin/celestia` on Intel Macs) when Go is installed with Homebrew
+- `$GOBIN/celestia`, or `$GOPATH/bin/celestia` when `GOBIN` is unset, for other Go installations
 - `/usr/local/bin/celestia`
 - `$HOME/celestia-node-temp/celestia`
 
@@ -129,7 +130,7 @@ The script will:
 3. Verify the checksum for security
 4. Provide installation location options based on your environment:
    - If Go is installed:
-     - Go bin directory (`$GOPATH/bin`)
+     - Detected Go bin directory (the Homebrew bin directory when Go is installed with Homebrew, otherwise `$GOBIN` or `$GOPATH/bin`)
      - System bin directory (`/usr/local/bin`)
      - Keep in current directory
    - If Go is not installed:

--- a/public/celestia-node.sh
+++ b/public/celestia-node.sh
@@ -158,8 +158,23 @@ echo "Temporary files cleaned up." | tee -a "$LOGFILE"
 
 # Check if Go is installed
 if command -v go >/dev/null 2>&1; then
-    GOPATH=${GOPATH:-$(go env GOPATH)}
-    GOBIN="$GOPATH/bin"
+    GOBIN=$(go env GOBIN)
+    GOBIN_LABEL="Go bin directory"
+
+    # Homebrew leaves GOBIN unset and defaults GOPATH to $HOME/go, which may
+    # not be in PATH. Prefer Homebrew's bin directory when it provides Go.
+    if [ -z "$GOBIN" ] && command -v brew >/dev/null 2>&1; then
+        HOMEBREW_PREFIX=$(brew --prefix 2>/dev/null)
+        if [ -n "$HOMEBREW_PREFIX" ] && [ "$(command -v go)" = "$HOMEBREW_PREFIX/bin/go" ]; then
+            GOBIN="$HOMEBREW_PREFIX/bin"
+            GOBIN_LABEL="Homebrew bin directory"
+        fi
+    fi
+
+    if [ -z "$GOBIN" ]; then
+        GOPATH=${GOPATH:-$(go env GOPATH)}
+        GOBIN="$GOPATH/bin"
+    fi
     HAS_GO=true
 else
     HAS_GO=false
@@ -169,7 +184,7 @@ fi
 echo ""
 if [ "$HAS_GO" = true ]; then
     echo "Where would you like to install the celestia binary?"
-    echo "1) Go bin directory ($GOBIN) [Recommended]"
+    echo "1) $GOBIN_LABEL ($GOBIN) [Recommended]"
     echo "2) System bin directory (/usr/local/bin)"
     echo "3) Keep in current directory ($TEMP_DIR)"
 else

--- a/public/celestia-node.sh
+++ b/public/celestia-node.sh
@@ -161,9 +161,10 @@ if command -v go >/dev/null 2>&1; then
     GOBIN=$(go env GOBIN)
     GOBIN_LABEL="Go bin directory"
 
-    # Homebrew leaves GOBIN unset and defaults GOPATH to $HOME/go, which may
-    # not be in PATH. Prefer Homebrew's bin directory when it provides Go.
-    if [ -z "$GOBIN" ] && command -v brew >/dev/null 2>&1; then
+    # Honor an explicitly configured GOPATH before falling back to Homebrew's
+    # bin directory. Homebrew leaves GOBIN unset and defaults GOPATH to
+    # $HOME/go, which may not be in PATH.
+    if [ -z "$GOBIN" ] && [ -z "$GOPATH" ] && command -v brew >/dev/null 2>&1; then
         HOMEBREW_PREFIX=$(brew --prefix 2>/dev/null)
         if [ -n "$HOMEBREW_PREFIX" ] && [ "$(command -v go)" = "$HOMEBREW_PREFIX/bin/go" ]; then
             GOBIN="$HOMEBREW_PREFIX/bin"


### PR DESCRIPTION
## Summary

- install the pre-built `celestia` binary into Homebrew's bin directory when Homebrew provides Go
- continue to honor an explicit `GOBIN` and fall back to `$GOPATH/bin` for other Go installations
- document the detected install locations

## Root cause

Homebrew leaves `GOBIN` unset, so the installer used Go's default `$HOME/go` GOPATH even though `$HOME/go/bin` was not on `PATH`. The recommended option therefore installed a binary that the shell could not find.

## Validation

- `bash -n public/celestia-node.sh`
- verified the detection logic resolves this Homebrew Go installation to `/opt/homebrew/bin`
- `yarn lint` (passes with one pre-existing warning in `app/build/rpc/components/NodeAPIContent.tsx`)
- `yarn build`

Fixes #2561
