### PR TITLE
fix(docs): repair genesis and peers links in network details tables

### DIFF
--- a/app/operate/networks/mainnet-beta/page.mdx
+++ b/app/operate/networks/mainnet-beta/page.mdx
@@ -28,8 +28,8 @@ functional, users may encounter occasional instability or reduced performance.
 | ------------- | -------------------------------------------------------------------------------------------------- |
 | Chain ID      | `{{constants['mainnetChainId']}}`                                                                       |
 | Genesis hash  | `6BE39EFD10BA412A9DB5288488303F5DD32CF386707A5BEF33617F4C43301872`                                 |
-| Genesis file  | https://github.com/celestiaorg/networks/blob/master/{constants.mainnetChainId}/genesis.json        |
-| Peers file    | https://github.com/celestiaorg/networks/blob/master/{constants.mainnetChainId}/peers.txt           |
+| Genesis file  | <a href={`https://github.com/celestiaorg/networks/blob/main/${constants.mainnetChainId}/genesis.json`}>genesis.json</a> |
+| Peers file    | <a href={`https://github.com/celestiaorg/networks/blob/main/${constants.mainnetChainId}/peers.txt`}>peers.txt</a>       |
 | Validators    | 100                                                                                                |
 | Block time    | [Approximately 3 seconds](https://cips.celestia.org/cip-048.html)                                      |
 

--- a/app/operate/networks/mocha-testnet/page.mdx
+++ b/app/operate/networks/mocha-testnet/page.mdx
@@ -142,8 +142,8 @@ to the correct instructions on this page on how to connect to Mocha.
 | ------------- | -------------------------------------------------------------------------------------------------- |
 | Chain ID      | `{{constants['mochaChainId']}}`                                                                                     |
 | Genesis hash  | `82DB3AC5AB8485E4784054BD10457533A64563F055C0D234A3134603A9C85D33`                                 |
-| Genesis file  | https://github.com/celestiaorg/networks/blob/main/{constants.mochaChainId}/genesis.json                      |
-| Peers file    | https://github.com/celestiaorg/networks/blob/main/{constants.mochaChainId}/peers.txt                         |
+| Genesis file  | <a href={`https://github.com/celestiaorg/networks/blob/main/${constants.mochaChainId}/genesis.json`}>genesis.json</a> |
+| Peers file    | <a href={`https://github.com/celestiaorg/networks/blob/main/${constants.mochaChainId}/peers.txt`}>peers.txt</a>       |
 | Validators    | 100 (max)                                                                                                |
 
 ## Software version numbers


### PR DESCRIPTION
The **Genesis file** and **Peers file** rows in the Network details tables were rendering the literal placeholder `{constants.mochaChainId}` / `{constants.mainnetChainId}` and linking to a 404. This fixes all four links.

Spotted while updating the Keplr chain registry for `mocha-5`.

### Cause

Both rows were bare URLs containing a single-brace expression:

```
| Genesis file  | https://github.com/celestiaorg/networks/blob/main/{constants.mochaChainId}/genesis.json |
```

remark-gfm autolinks a bare URL during parse, so the braces never become an MDX expression. The visible text kept the placeholder and the href was emitted with the braces percent-encoded (`.../blob/main/%7Bconstants.mochaChainId%7D/genesis.json`), which 404s.

This is specific to autolinked URLs. The other `{constants.*}` occurrences on these pages — plain text, list items, table cells — do interpolate correctly and are left alone.

### Fix

MDX does not evaluate expressions inside markdown link destinations either, so `[label](https://.../{constants.x}/...)` fails the same way. I confirmed this by compiling all three forms with `@mdx-js/mdx` + `remark-gfm`:

| Form | href emitted |
| --- | --- |
| bare autolinked URL | `https://x.dev/%7Bconstants.mochaChainId%7D/...` |
| markdown link | `https://x.dev/%7Bconstants.mochaChainId%7D/...` |
| JSX anchor with template literal | `` href={`https://x.dev/${constants.mochaChainId}/...`} `` |

So these rows now use a JSX anchor, which interpolates in both the href and the label.

Also: the Mainnet Beta URLs pointed at the `master` branch of celestiaorg/networks, which now 302s to `main`. They reference `main` directly.

### Verification

Against a local dev server (`yarn dev`), all four rows render working links:

- `https://github.com/celestiaorg/networks/blob/main/mocha-5/genesis.json`
- `https://github.com/celestiaorg/networks/blob/main/mocha-5/peers.txt`
- `https://github.com/celestiaorg/networks/blob/main/celestia/genesis.json`
- `https://github.com/celestiaorg/networks/blob/main/celestia/peers.txt`

All four return HTTP 200. `yarn lint` passes (one pre-existing unrelated warning in `NodeAPIContent.tsx`).

One thing I could not run: `yarn check-links` fails on this checkout before it reaches any link, with `SyntaxError: The requested module 'minimatch' does not provide an export named 'GLOBSTAR'` from `node_modules/glob/dist/esm/pattern.js`. That looks like a pre-existing dependency resolution problem rather than anything to do with this change, but flagging it since it means the repo's own link checker is currently not runnable — and it is exactly the tool that would have caught these four 404s.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->