### PR TITLE
fix(deps): stop the blanket minimatch pin from breaking glob under yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   "resolutions": {
     "@xmldom/xmldom": "0.9.10",
     "lodash-es": "4.18.1",
-    "minimatch": "3.1.5",
     "@typescript-eslint/typescript-estree/minimatch": "9.0.9",
     "@ts-morph/common/minimatch": "10.2.4",
     "glob/minimatch": "10.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,7 +2006,7 @@ brace-expansion@^2.0.2:
   dependencies:
     balanced-match "^1.0.0"
 
-brace-expansion@^5.0.2:
+brace-expansion@^5.0.2, brace-expansion@^5.0.8:
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
   integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
@@ -5162,26 +5162,40 @@ mimic-fn@^4.0.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
-minimatch@10.2.4:
+minimatch@10.2.4, minimatch@^10.1.1:
   version "10.2.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz"
   integrity sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==
   dependencies:
     brace-expansion "^5.0.2"
 
-minimatch@3.1.2, minimatch@3.1.5, minimatch@^10.0.1, minimatch@^10.1.1, minimatch@^3.1.2, minimatch@^9.0.4:
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
-  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
+minimatch@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@9.0.9:
+minimatch@9.0.9, minimatch@^9.0.4:
   version "9.0.9"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz"
   integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
     brace-expansion "^2.0.2"
+
+minimatch@^10.0.1:
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.6.tgz#fd956bbe0b77241e9f15ac5dccb1c638060968ef"
+  integrity sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==
+  dependencies:
+    brace-expansion "^5.0.8"
+
+minimatch@^3.1.2:
+  version "3.1.5"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"


### PR DESCRIPTION
`yarn check-links` fails on a clean checkout before it tests a single link:

```
SyntaxError: The requested module 'minimatch' does not provide an export named 'GLOBSTAR'
  at node_modules/glob/dist/esm/pattern.js
```

Found while fixing #2566.

### Cause

`resolutions` carried a blanket `"minimatch": "3.1.5"` alongside the more specific `"glob/minimatch": "10.2.4"`. Yarn Classic applies the blanket entry and ignores the scoped one, so `glob@11` — which requires `minimatch@^10.1.1` — resolved to `minimatch@3.1.5`. That version predates the ESM rewrite and exports no `GLOBSTAR`, so any `import` of glob throws at module load. The lockfile made this visible as one entry claiming to satisfy semver-incompatible ranges at once:

```
minimatch@3.1.2, minimatch@3.1.5, minimatch@^10.0.1, minimatch@^10.1.1, minimatch@^3.1.2, minimatch@^9.0.4:
  version "3.1.5"
```

I also tried `"**/glob/minimatch": "10.2.4"` while keeping the blanket entry; Yarn Classic still applies the blanket. Removing it is the only form that works.

### Why CI didn't catch it

The `link-check` job in `lint.yaml` installs with `npm install --no-package-lock --legacy-peer-deps`, so it reads `overrides` — which are correctly scoped per consumer — and never consults `yarn.lock`. The jobs that install with yarn (`deploy.yml`, `preview.yaml`) don't run the link checker. So the yarn tree has been broken for local development while CI stayed green.

### Why removing the blanket pin is safe

The pin traces back to remediating the brace-expansion advisory, and that remediation does not depend on minimatch's patch version. Every installed copy of brace-expansion is still patched after this change — 1.1.18, 2.1.4 and 5.0.9 — and the `minimatch@3.x` consumers continue to resolve `brace-expansion@^1.1.7` to 1.1.18. The scoped resolutions for `@typescript-eslint/typescript-estree`, `@ts-morph/common` and `glob` are untouched, and `overrides` is unchanged.

### Verification

- `glob` now resolves `minimatch@10.2.4`
- `yarn check-links` runs to completion: 607 links checked, 0 broken
- `yarn lint` passes (one pre-existing unrelated warning in `NodeAPIContent.tsx`)
- `yarn build` succeeds

### Separate finding worth its own issue

With the checker runnable, it reports **0 broken links on this branch even though the four `genesis.json` / `peers.txt` links fixed in #2566 are still broken here.** The checker cannot see them, for two reasons:

1. `scripts/check-links.mjs` parses with `remark-parse` + `remark-math` + `remark-mdx` but **not `remark-gfm`**, so GFM autolink literals never become `link` nodes. Bare URLs written without `[]()` are invisible to it.
2. `replaceVariablesInUrl` resolves only bracket-and-quote placeholders (`{{obj['key']}}` and `{obj['key']}`), not dot access (`{constants.mochaChainId}`), and an unresolved placeholder is passed through silently rather than flagged.

Minor, related: the script calls `processor.parse(content)`, which runs the parser but not transformers, so the `remarkReplaceVariables` plugin registered on that processor never executes.

Happy to follow up with a PR that adds `remark-gfm` and fails on unresolved placeholders — that combination is what would have caught the #2566 links.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->