### PR TITLE
docs: update hardware sizing assumptions

### DIFF
--- a/app/operate/getting-started/hardware-requirements/page.mdx
+++ b/app/operate/getting-started/hardware-requirements/page.mdx
@@ -13,8 +13,9 @@ description: Recommended hardware profiles for Celestia node types.
 | Light node  | 500 MB RAM | Single core | 20 GB SSD   | 56 Kbps   |
 | Bridge node | 64 GB RAM  | 32 cores    | 25 TiB NVME | 1 Gbps    |
 
-Non-archival disk recommendations use a 7-day planning window. The current
-maximum block capacity is 32 MiB with approximately 3-second blocks. These are
+Non-archival disk recommendations use a 7-day planning window sized for the
+128MB/6s maximum-throughput envelope, which provides headroom above the current
+maximum block capacity of 32 MiB at approximately 3-second blocks. These are
 conservative recommendations; operators may provision less by pruning more
 aggressively **at their own risk**.
 
@@ -25,8 +26,9 @@ aggressively **at their own risk**.
 | Light node (unpruned headers) | 500 MB RAM | Single core | 7 TiB NVME\*   | 56 Kbps   |
 | Bridge node                   | 64 GB RAM  | 32 cores    | 637 TiB NVME\* | 1 Gbps    |
 
-\*Archival disk recommendations use a 1-year planning window at the current
-maximum 32 MiB block capacity and approximately 3-second block time. Actual
+\*Archival disk recommendations use a 1-year planning window sized for the
+128MB/6s maximum-throughput envelope, which provides headroom above the current
+maximum block capacity of 32 MiB at approximately 3-second blocks. Actual
 usage can be much lower. Regularly check disk usage and maintain at least 1
 month of maximum-throughput capacity as additional free space.
 
@@ -39,8 +41,9 @@ month of maximum-throughput capacity as additional free space.
 | Validator      | 32 GB RAM | 32 cores | 12 TiB NVME | 1 Gbps    |
 | Consensus node | 32 GB RAM | 32 cores | 12 TiB NVME | 1 Gbps    |
 
-Non-archival disk recommendations use a 7-day planning window. The current
-maximum block capacity is 32 MiB with approximately 3-second blocks. These are
+Non-archival disk recommendations use a 7-day planning window sized for the
+128MB/6s maximum-throughput envelope, which provides headroom above the current
+maximum block capacity of 32 MiB at approximately 3-second blocks. These are
 conservative recommendations; operators may provision less by pruning more
 aggressively **at their own risk**.
 
@@ -50,8 +53,9 @@ aggressively **at their own risk**.
 | -------------- | --------- | -------- | -------------- | --------- |
 | Consensus node | 64 GB RAM | 32 cores | 624 TiB NVME\* | 1 Gbps    |
 
-\*Archival disk recommendations use a 1-year planning window at the current
-maximum 32 MiB block capacity and approximately 3-second block time. Actual
+\*Archival disk recommendations use a 1-year planning window sized for the
+128MB/6s maximum-throughput envelope, which provides headroom above the current
+maximum block capacity of 32 MiB at approximately 3-second blocks. Actual
 usage can be much lower. Regularly check disk usage and maintain at least 1
 month of maximum-throughput capacity as additional free space.
 

--- a/app/operate/getting-started/hardware-requirements/page.mdx
+++ b/app/operate/getting-started/hardware-requirements/page.mdx
@@ -13,7 +13,10 @@ description: Recommended hardware profiles for Celestia node types.
 | Light node  | 500 MB RAM | Single core | 20 GB SSD   | 56 Kbps   |
 | Bridge node | 64 GB RAM  | 32 cores    | 25 TiB NVME | 1 Gbps    |
 
-Non-archival node requirements are based on the maximum possible throughput at 128MB/6s for 7 days. Operators may provision less by pruning more aggressively **at their own risk**.
+Non-archival disk recommendations use a 7-day planning window. The current
+maximum block capacity is 32 MiB with approximately 3-second blocks. These are
+conservative recommendations; operators may provision less by pruning more
+aggressively **at their own risk**.
 
 ### Archival data availability nodes
 
@@ -22,7 +25,10 @@ Non-archival node requirements are based on the maximum possible throughput at 1
 | Light node (unpruned headers) | 500 MB RAM | Single core | 7 TiB NVME\*   | 56 Kbps   |
 | Bridge node                   | 64 GB RAM  | 32 cores    | 637 TiB NVME\* | 1 Gbps    |
 
-\*Archival disk requirement is based on the current v6 128MB/6s throughput at maximum capacity for one year. In reality the requirement can be much lower and we advise regularly checking disk usage and having at least 1 month worth of max throughput of extra disk space.
+\*Archival disk recommendations use a 1-year planning window at the current
+maximum 32 MiB block capacity and approximately 3-second block time. Actual
+usage can be much lower. Regularly check disk usage and maintain at least 1
+month of maximum-throughput capacity as additional free space.
 
 ## Consensus nodes
 
@@ -33,7 +39,10 @@ Non-archival node requirements are based on the maximum possible throughput at 1
 | Validator      | 32 GB RAM | 32 cores | 12 TiB NVME | 1 Gbps    |
 | Consensus node | 32 GB RAM | 32 cores | 12 TiB NVME | 1 Gbps    |
 
-Non-archival node requirements are based on the maximum possible throughput at 128MB/6s for 7 days. Operators may provision less by pruning more aggressively **at their own risk**.
+Non-archival disk recommendations use a 7-day planning window. The current
+maximum block capacity is 32 MiB with approximately 3-second blocks. These are
+conservative recommendations; operators may provision less by pruning more
+aggressively **at their own risk**.
 
 #### Archival consensus nodes
 
@@ -41,11 +50,14 @@ Non-archival node requirements are based on the maximum possible throughput at 1
 | -------------- | --------- | -------- | -------------- | --------- |
 | Consensus node | 64 GB RAM | 32 cores | 624 TiB NVME\* | 1 Gbps    |
 
-\*Archival disk requirement is based on the current v6 128MB/6s throughput at maximum capacity for one year. In reality the requirement can be much lower and we advise regularly checking disk usage and having at least 1 month worth of max throughput of extra disk space.
+\*Archival disk recommendations use a 1-year planning window at the current
+maximum 32 MiB block capacity and approximately 3-second block time. Actual
+usage can be much lower. Regularly check disk usage and maintain at least 1
+month of maximum-throughput capacity as additional free space.
 
-When upgrading to 128MB/6s, validators must use hardware that passes the [CPU benchmark](https://github.com/celestiaorg/celestia-app/blob/main/tools/cpu_requirements/README.md). If your server does not pass, upgrade to a more powerful machine.
+Validators must use hardware that passes the [CPU benchmark](https://github.com/celestiaorg/celestia-app/blob/main/tools/cpu_requirements/README.md). If your server does not pass, upgrade to a more powerful machine.
 
-For a list of CPUs tested for 128MB/6s, see the [release notes](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md#v6---128mb6s). Other CPUs are acceptable if they pass the benchmark. Recommended CPU specs:
+For a list of CPUs tested against the v6 128MB/6s workload, see the [release notes](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md#v6---128mb6s). Other CPUs are acceptable if they pass the benchmark. Recommended CPU specs:
 
 - 32 or more cores
 - GFNI (Galois Field New Instructions) support


### PR DESCRIPTION
## Overview

Updates the hardware requirements page to reflect the current v9 network parameters: a 32 MiB maximum block capacity and approximately 3-second blocks.

## Changes

- Replace stale v6 `128MB/6s` disk-sizing assumptions.
- Clarify the 7-day and 1-year planning windows while retaining the existing conservative hardware recommendations.
- Remove obsolete validator upgrade wording while preserving the CPU benchmark and historical tested-CPU reference.

The hardware table values are intentionally unchanged pending operator confirmation of storage overhead and safety margins.

## Validation

- `npm run lint` (passes with one pre-existing warning in `NodeAPIContent.tsx`)
- `npm run build`
- `git diff --check`

## Related

- PR #2402 also touches this page and will need this wording retained when it is refreshed.