### PR TITLE
docs: document celestia-node v0.31.3 breaking changes

### DIFF
--- a/app/build/rpc/node-api/page.mdx
+++ b/app/build/rpc/node-api/page.mdx
@@ -24,7 +24,21 @@ Celestia node RPC reference for blob, blobstream, da, das, header, node, p2p, sh
 
 </div>
 
-> **Warning:** Starting with celestia-node v0.31.3, RPC request bodies are limited to 16 MiB. Requests larger than this limit are rejected.
+## celestia-node v0.31.3 breaking changes
+
+Starting with celestia-node v0.31.3:
+
+- The `fraud` RPC namespace was removed. Calls to `fraud.Get` and
+  `fraud.Subscribe` are no longer supported.
+- The `type` field returned by `node.Info` is a string such as `"Bridge"` or
+  `"Light"` instead of an integer.
+- RPC request bodies are limited to 16 MiB. Larger requests are rejected.
+- In the Go API, `blob.Commitment.String()` returns a hexadecimal string
+  instead of raw bytes. This does not change the JSON encoding of commitment
+  fields returned by RPC methods.
+
+See the [celestia-node v0.31.3 release notes](https://github.com/celestiaorg/celestia-node/releases/tag/v0.31.3)
+for the complete list of changes.
 
 <NodeAPIContent />
 <DynamicRPCTOC />

--- a/app/operate/data-availability/config-reference/page.mdx
+++ b/app/operate/data-availability/config-reference/page.mdx
@@ -33,6 +33,43 @@ By default, `Remote = false`. Still for devnet, we are going
 to use the remote consensus node option and this can also be set
 by the command line flag `--core.remote`.
 
+### RPC
+
+Starting with celestia-node v0.31.3, the RPC server supports optional per-IP
+rate limiting. If you upgraded an existing node from an earlier version, add
+the new fields while preserving your custom configuration by running:
+
+```bash
+celestia <node-type> config-update --p2p.network <network>
+```
+
+The default rate-limit configuration is:
+
+```toml
+[RPC.RateLimit]
+  Enabled = false
+  RequestsPerSec = 100
+  Burst = 200
+  CacheSize = 8192
+```
+
+- `Enabled` turns per-IP rate limiting on or off.
+- `RequestsPerSec` sets the sustained request rate allowed for each IP address.
+- `Burst` allows short request spikes before the sustained rate is enforced.
+- `CacheSize` limits the number of per-IP rate-limit buckets held in memory.
+
+When the limit is exceeded, the RPC server responds with HTTP status `429 Too
+Many Requests`. Leave this rate limiter disabled when the node is behind a
+reverse proxy because all requests may appear to come from the proxy's IP
+address. Apply rate limiting at the proxy instead.
+
+RPC request bodies are limited to 16 MiB, and the server accepts up to 500
+concurrent connections. These limits are enforced by the server and are not
+configurable in `config.toml`.
+
+See the [celestia-node v0.31.3 release notes](https://github.com/celestiaorg/celestia-node/releases/tag/v0.31.3)
+for the complete upgrade instructions.
+
 ### P2P
 
 #### Bootstrap

--- a/app/operate/data-availability/config-reference/page.mdx
+++ b/app/operate/data-availability/config-reference/page.mdx
@@ -40,7 +40,7 @@ rate limiting. If you upgraded an existing node from an earlier version, add
 the new fields while preserving your custom configuration by running:
 
 ```bash
-celestia <node-type> config-update --p2p.network <network>
+celestia <node_type> config-update --p2p.network <network>
 ```
 
 The default rate-limit configuration is:


### PR DESCRIPTION
## Summary

- document the v0.31.3 RPC rate-limit configuration and defaults
- clarify fixed RPC request-size and connection limits
- add Node API migration notes for the removed fraud namespace, `node.Info`, and `blob.Commitment.String()`

## Validation

- `git diff --check`
- `npm run lint` (passes with one pre-existing warning)
- `npm run build`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->