### PR TITLE
docs: document celestia-app v9 operator changes

### DIFF
--- a/app/operate/consensus-validators/cli-reference/page.mdx
+++ b/app/operate/consensus-validators/cli-reference/page.mdx
@@ -2,6 +2,8 @@
 description: Some of the most helpful celestia-app CLI commands.
 ---
 
+import { Callout } from 'nextra/components'
+
 # Helpful CLI commands
 
 View all options:
@@ -35,6 +37,18 @@ Available Commands:
   location or at the location passed as an arg
   version             Print the application binary version information
 ```
+
+## Updating node configuration
+
+<Callout type="warning">
+The `celestia-appd update-config` command is deprecated as of v9. Required
+configuration values are now enforced by the binary at startup, so do not add
+this command to new node initialisation or upgrade procedures. It currently
+prints a deprecation warning and will be removed in a future release.
+</Callout>
+
+See the [celestia-app v9 release notes](https://github.com/celestiaorg/celestia-app/blob/v9.0.4/docs/release-notes/release-notes.md#update-config-command-deprecated)
+for details.
 
 ## Creating a wallet
 

--- a/app/operate/consensus-validators/consensus-node/page.mdx
+++ b/app/operate/consensus-validators/consensus-node/page.mdx
@@ -162,10 +162,10 @@ min-retain-blocks = 0
 ```
 
 <Callout type="warning">
-Fresh celestia-app v9 nodes default to `min-retain-blocks = 3000`. Any non-zero
-value enables block pruning, so archival operators must explicitly set the
-value to `0`. Changing the value from `0` to a non-zero value starts pruning the
-existing backlog when the node restarts and can temporarily increase sync time.
+`min-retain-blocks` defaults to `0`. Any non-zero value enables block pruning,
+so archival operators must keep the value at `0`. Changing the value from `0`
+to a non-zero value starts pruning the existing backlog when the node restarts
+and can temporarily increase sync time.
 </Callout>
 
 ### Save on storage requirements

--- a/app/operate/consensus-validators/consensus-node/page.mdx
+++ b/app/operate/consensus-validators/consensus-node/page.mdx
@@ -18,7 +18,7 @@ See [hardware requirements](/operate/getting-started/hardware-requirements).
 
 ## Set up a consensus node
 
-The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64
+The following tutorial is done on an Ubuntu Linux 24.04 (LTS) x64
 instance machine.
 
 <Steps>
@@ -151,13 +151,22 @@ indexer = "kv"
 
 If you want to query the historical state — for example, you might want
 to know the balance of a Celestia wallet at a given height in the past —
-you should run an archive node with `pruning = "nothing"` in your `app.toml`.
-Note that this configuration is resource-intensive and will require
+you should run an archive node. In your `app.toml`, set `pruning = "nothing"`
+to retain application state and `min-retain-blocks = 0` to retain all block
+data. Note that this configuration is resource-intensive and will require
 significant storage:
 
 ```toml
 pruning = "nothing"
+min-retain-blocks = 0
 ```
+
+<Callout type="warning">
+Fresh celestia-app v9 nodes default to `min-retain-blocks = 3000`. Any non-zero
+value enables block pruning, so archival operators must explicitly set the
+value to `0`. Changing the value from `0` to a non-zero value starts pruning the
+existing backlog when the node restarts and can temporarily increase sync time.
+</Callout>
 
 ### Save on storage requirements
 
@@ -199,7 +208,19 @@ By default, a consensus node will sync using block sync; which will request, val
 and execute every block up to the head of the blockchain. This is the most secure
 mechanism yet the slowest (taking up to weeks depending on the height of the blockchain).
 
-There is an [issue](https://github.com/celestiaorg/celestia-app/issues/4370) that prevents recent celestia-app binaries from block syncing Mainnet Beta. As a temporary workaround, you can use celestia-app [v3.0.2](https://github.com/celestiaorg/celestia-app/releases/tag/v3.0.2) to block sync Mainnet Beta until that issue is resolved. After block syncing, please upgrade to the latest version of celestia-app to pick up recent security fixes.
+Starting with celestia-app v9, `verify_data` defaults to `false` in the
+`[blocksync]` section of `config.toml`. This skips re-running `ProcessProposal`
+on historical blocks to improve block sync speed. Blocks are still verified by
+their validator signatures, and normal validation resumes after the node enters
+consensus mode. To restore the pre-v9 behaviour, set:
+
+```toml
+[blocksync]
+verify_data = true
+```
+
+See the [celestia-app v9 release notes](https://github.com/celestiaorg/celestia-app/blob/v9.0.4/docs/release-notes/release-notes.md#block-sync-verify_data-default-changed-to-false)
+for details.
 
 There are two alternatives for quicker syncing.
 

--- a/app/operate/consensus-validators/install-celestia-app/page.mdx
+++ b/app/operate/consensus-validators/install-celestia-app/page.mdx
@@ -2,7 +2,7 @@
 description: Learn how you can build celestia-app.
 ---
 
-import { Steps, Tabs } from 'nextra/components'
+import { Callout, Steps, Tabs } from 'nextra/components'
 
 # Install celestia-app
 
@@ -23,6 +23,23 @@ Celestia-app officially supports the following architectures:
 - darwin/arm64 (macOS Apple Silicon)
 
 Only these four architectures are officially tested and supported.
+
+## Linux requirements
+
+<Callout type="warning">
+celestia-app v9 multiplexer binaries require glibc 2.38 or later. Use Ubuntu
+24.04 LTS or an equivalent Linux distribution. Ubuntu 22.04 and older are not
+supported and the binary will fail to start with a glibc version mismatch.
+</Callout>
+
+Check the installed glibc version before installing or upgrading:
+
+```bash
+ldd --version
+```
+
+See the [celestia-app v9 release notes](https://github.com/celestiaorg/celestia-app/blob/v9.0.4/docs/release-notes/release-notes.md#supported-operating-systems)
+for the supported operating system details.
 
 ## Building binary from source
 

--- a/app/operate/consensus-validators/validator-node/page.mdx
+++ b/app/operate/consensus-validators/validator-node/page.mdx
@@ -17,7 +17,7 @@ See [hardware requirements](/operate/getting-started/hardware-requirements).
 
 ## Setting up a validator node
 
-The following tutorial is done on an Ubuntu Linux 20.04 (LTS) x64
+The following tutorial is done on an Ubuntu Linux 24.04 (LTS) x64
 instance machine.
 
 First, follow the instructions on


### PR DESCRIPTION
## Summary

- document the glibc 2.38 and Ubuntu 24.04 requirement for celestia-app v9 multiplexer binaries
- note the `update-config` deprecation and the `verify_data = false` block-sync default
- require `min-retain-blocks = 0` alongside state pruning settings for archival nodes
- update validator setup examples and remove the resolved v3 block-sync workaround

## Testing

- `yarn lint` (0 errors; one existing unrelated warning)
- `yarn build`
- `yarn check-links -- --all` (0 broken internal links; seven unrelated existing audit PDF 404s)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->