### PR TITLE
docs: document PebbleDB migration

### DIFF
--- a/app/operate/consensus-validators/consensus-node/page.mdx
+++ b/app/operate/consensus-validators/consensus-node/page.mdx
@@ -114,9 +114,10 @@ You can get the persistent peers from the [@cosmos/chain-registry](https://githu
 
 ### Database backend
 
-Celestia-app v9 and later support only PebbleDB. New nodes use PebbleDB by
-default. If an existing node is configured with `db_backend = "goleveldb"`,
-stop the node and use the
+Celestia-app v9 and later support only PebbleDB and will not start with any
+other database backend. New nodes use PebbleDB by default. If an existing
+node is configured with a different backend, such as
+`db_backend = "goleveldb"`, stop the node and use the
 [`migrate-db` tool](https://github.com/celestiaorg/celestia-app/tree/v9.x/tools/migrate-db)
 before upgrading to v9 or later.
 

--- a/app/operate/consensus-validators/consensus-node/page.mdx
+++ b/app/operate/consensus-validators/consensus-node/page.mdx
@@ -114,12 +114,11 @@ You can get the persistent peers from the [@cosmos/chain-registry](https://githu
 
 ### Database backend
 
-Celestia-app v9 and later support only PebbleDB and will not start with any
-other database backend. New nodes use PebbleDB by default. If an existing
-node is configured with a different backend, such as
-`db_backend = "goleveldb"`, stop the node and use the
+celestia-app v9 and later use PebbleDB by default for new nodes. Before
+changing an existing node's `db_backend` from `"goleveldb"` to `"pebbledb"`,
+stop the node and use the
 [`migrate-db` tool](https://github.com/celestiaorg/celestia-app/tree/v9.x/tools/migrate-db)
-before upgrading to v9 or later.
+to migrate its databases.
 
 ### Optional: Connect a consensus node to a bridge node
 

--- a/app/operate/consensus-validators/consensus-node/page.mdx
+++ b/app/operate/consensus-validators/consensus-node/page.mdx
@@ -112,6 +112,14 @@ You can get the persistent peers from the [@cosmos/chain-registry](https://githu
 
 ## Storage and pruning configurations
 
+### Database backend
+
+Celestia-app v9 and later support only PebbleDB. New nodes use PebbleDB by
+default. If an existing node is configured with `db_backend = "goleveldb"`,
+stop the node and use the
+[`migrate-db` tool](https://github.com/celestiaorg/celestia-app/tree/v9.x/tools/migrate-db)
+before upgrading to v9 or later.
+
 ### Optional: Connect a consensus node to a bridge node
 
 If your consensus node is being connected to a celestia-node bridge node,
@@ -454,7 +462,7 @@ The available options are:
    transaction status. If you don't need to query transaction data,
    you can choose this option to save space.
 2. `kv`: This is the simplest indexer, backed by
-   key-value storage (defaults to levelDB; see DBBackend).
+   PebbleDB key-value storage.
    When `kv` is chosen, `tx.height` and `tx.hash` will always be
    indexed. This option is suitable for basic queries on transactions.
 3. `psql`: This indexer is backed by PostgreSQL. When psql is chosen,


### PR DESCRIPTION
## Summary

- document PebbleDB as the only supported database backend in celestia-app v9 and later
- point existing LevelDB operators to the maintained migration tool
- correct the transaction indexer backend description

This is a v9/Core v0.40 transition, not a v10 change. CAT was already enforced by celestia-app and no conflicting CAT configuration guidance exists in this docs repo.

## Testing

- `npm run build`
- `npm run check-links`
- pre-push `eslint` (passes with one pre-existing warning in `NodeAPIContent.tsx`)
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->