### PR TITLE
docs: mark Mocha-5 DA network live

### DIFF
--- a/app/operate/networks/mocha-testnet/page.mdx
+++ b/app/operate/networks/mocha-testnet/page.mdx
@@ -165,12 +165,11 @@ For the current Mocha testnet network constants, see
 [mocha.celenium.io/constants](https://mocha.celenium.io/constants).
 
 <Callout type="warning">
-Community infrastructure is still migrating from `mocha-4` to `mocha-5`.
-The community endpoints listed below have been verified to serve
-`mocha-5`; endpoints still serving `mocha-4` have been removed and will
-be re-added as providers migrate. Explorers, faucets, indexers, and
-analytics services may also still show `mocha-4` data. Endpoints below
-were last verified on August 21, 2026.
+Some community infrastructure is still migrating from `mocha-4` to
+`mocha-5`. The endpoints listed below were verified to serve `mocha-5`
+on September 1, 2026. Services still serving `mocha-4` are omitted until
+they migrate. Explorers, faucets, indexers, and analytics services may
+also still show `mocha-4` data.
 </Callout>
 
 ## RPC for DA bridge, full, and light nodes
@@ -195,11 +194,6 @@ history, such as:
 
 For development, testing, and documentation examples, use the public QuickNode
 endpoint:
-
-<Callout type="warning">
-This endpoint currently still serves `mocha-4`. It will migrate to
-`mocha-5` before the `mocha-4` shutdown on September 1, 2026.
-</Callout>
 
 | Interface | Endpoint |
 | --------- | -------- |
@@ -280,9 +274,8 @@ broadcast transactions.
 
 ## Community bridge node endpoints
 
-The `mocha-5` DA network has not started yet; it is planned to launch
-during the week of August 24, 2026. Bridge node endpoints will be added
-here once the DA network is live.
+The `mocha-5` DA network is live. Community bridge node endpoints will
+be added here as providers make them available.
 
 ## Mocha testnet faucet
 


### PR DESCRIPTION
## Summary

- mark the Mocha-5 DA network live and remove the outdated launch estimate
- remove the obsolete warning that the public QuickNode endpoint still serves mocha-4
- refresh the endpoint verification date while keeping unavailable or unmigrated services omitted
- leave the v0.31.6-mocha version update to the automated release PR

## Evidence

Verified on September 1, 2026 that the listed RPC, REST, and gRPC endpoints report mocha-5. The public QuickNode endpoint reports mocha-5 through consensus status, Core gRPC, and DA header.NetworkHead.

## Validation

- npx --yes yarn@1.22.22 lint — passes with one pre-existing warning in NodeAPIContent.tsx
- npx --yes yarn@1.22.22 build — passes, including static export and LLM-ready Markdown generation
- git diff --check — passes

Refs #2568.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/docs/pull/2583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->